### PR TITLE
Issue #58: Make ht.randn check for sane input

### DIFF
--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -787,10 +787,10 @@ def randn(*args, dtype = torch.float32, split = None):
     num_of_param = len(args)
 
     # check if all positional arguments are integers and greater than zero
-    all_ints = all([isinstance(_, int) for _ in args])
+    all_ints = all(isinstance(_, int) for _ in args)
     if not all_ints:
         raise TypeError("Only integer-valued dimensions as arguments possible")
-    all_positive = all([_ > 0 for _ in args])
+    all_positive = all(_ > 0 for _ in args)
     if not all_positive:
         raise ValueError("Not all tensor dimensions are positive")
 

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -786,8 +786,13 @@ def randn(*args, dtype = torch.float32, split = None):
     """
     num_of_param = len(args)
 
-    # check if all positional arguments are integers
+    # check if all positional arguments are integers and greater than zero
     all_ints = all([isinstance(_, int) for _ in args])
+    if not all_ints:
+        raise TypeError("Only integer-valued dimensions as arguments possible")
+    all_positive = all([_ > 0 for _ in args])
+    if not all_positive:
+        raise ValueError("Not all tensor dimensions are positive")
 
     # define shape of tensor according to args
     gshape = (args)


### PR DESCRIPTION
So far ht.randn leaves the input checking mostly to pytorch.
This patch modifies ht.randn to at least check some of the
argument properties itself.

Fixes #58