### PR TITLE
Features/convolve

### DIFF
--- a/heat/core/communicator.py
+++ b/heat/core/communicator.py
@@ -56,7 +56,9 @@ class NoneCommunicator(Communicator):
         return False
 
     def __init__(self):
-        pass
+        self.group = None
+        self.rank = 0
+        self.size = 1
 
     def chunk(self, shape, split):
         # ensure the split axis is valid, we actually do not need it

--- a/heat/core/halo.py
+++ b/heat/core/halo.py
@@ -4,7 +4,9 @@ from . import types
 from .communicator import mpi
 
 
-def halorize(func):
+
+
+def halorize_local_operation(func):
     """
     A decorator for function "__local_operation" in heat.core.operations.py
     that updates halos after local operations
@@ -50,16 +52,16 @@ def send(a, rank):
     res : torch.tensor
         received halo at destinated mpi rank
     """    
-    # make torch tensor a continuous in memory if fragmented
+    # make torch tensor continuous in memory if fragmented
     a = a.contiguous()
-
+    
     # send halo to process with rank 'rank'
     req = mpi.isend(a, dst=rank)
 
-    # receive halo from process wirh rank 'rank'
+    # receive halo from process with rank 'rank'
     res = torch.zeros(a.size(), dtype=a.dtype)
     rec = mpi.irecv(res, src=rank)
-
+    
     # synchronize
     req.wait()
     rec.wait()

--- a/heat/core/halo.py
+++ b/heat/core/halo.py
@@ -4,8 +4,6 @@ from . import types
 from .communicator import mpi
 
 
-
-
 def halorize_local_operation(func):
     """
     A decorator for function "__local_operation" in heat.core.operations.py
@@ -36,6 +34,14 @@ def halorize_local_operation(func):
 
     return wrapper
 
+def check_for_update(halo, halo_size):
+            
+    update_flag = True
+    if halo is not None:
+        if len(halo) == halo_size:
+            update_flag = False
+
+    return update_flag
 
 def send(a, rank):
     """
@@ -54,16 +60,17 @@ def send(a, rank):
     """    
     # make torch tensor continuous in memory if fragmented
     a = a.contiguous()
-    
+    print('rank: ', rank)
     # send halo to process with rank 'rank'
     req = mpi.isend(a, dst=rank)
-
+    #print('rank: ', rank)
     # receive halo from process with rank 'rank'
     res = torch.zeros(a.size(), dtype=a.dtype)
     rec = mpi.irecv(res, src=rank)
-    
+
     # synchronize
     req.wait()
     rec.wait()
+    
 
     return res

--- a/heat/core/halo.py
+++ b/heat/core/halo.py
@@ -34,12 +34,3 @@ def halorize_local_operation(func):
 
     return wrapper
 
-def check_for_update(halo, halo_size):
-            
-    update_flag = True
-    if halo is not None:
-        if len(halo) == halo_size:
-            update_flag = False
-
-    return update_flag
-

--- a/heat/core/halo.py
+++ b/heat/core/halo.py
@@ -43,34 +43,3 @@ def check_for_update(halo, halo_size):
 
     return update_flag
 
-def send(a, rank):
-    """
-
-    Parameters
-    ----------
-    a : torch.tensor
-        halo to be send to node
-    rank : int
-        number of the destinated mpi rank
-
-    Returns
-    -------
-    res : torch.tensor
-        received halo at destinated mpi rank
-    """    
-    # make torch tensor continuous in memory if fragmented
-    a = a.contiguous()
-    print('rank: ', rank)
-    # send halo to process with rank 'rank'
-    req = mpi.isend(a, dst=rank)
-    #print('rank: ', rank)
-    # receive halo from process with rank 'rank'
-    res = torch.zeros(a.size(), dtype=a.dtype)
-    rec = mpi.irecv(res, src=rank)
-
-    # synchronize
-    req.wait()
-    rec.wait()
-    
-
-    return res

--- a/heat/core/halo.py
+++ b/heat/core/halo.py
@@ -4,6 +4,8 @@ from . import types
 from .communicator import mpi
 
 
+# We use decorators to modulize methods and updating halos, later decorators can be integrated in the main code  
+
 def halorize_local_operation(func):
     """
     A decorator for function "__local_operation" in heat.core.operations.py

--- a/heat/core/halo.py
+++ b/heat/core/halo.py
@@ -1,0 +1,67 @@
+import functools
+import torch
+from . import types
+from .communicator import mpi
+
+
+def halorize(func):
+    """
+    A decorator for function "__local_operation" in heat.core.operations.py
+    that updates halos after local operations
+    Parameters
+    ----------
+    func : HeAT function
+
+    Returns
+    -------
+    res : wrapper
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+
+        res = func(*args, **kwargs)
+
+        promoted_type = types.promote_types(args[1].dtype, types.float32)
+        torch_type = promoted_type.torch_type()
+
+        if args[1].halo_next is not None:
+            res.halo_next = args[0](args[1].halo_next.type(torch_type))
+
+        if args[1].halo_prev is not None:
+            res.halo_prev = args[0](args[1].halo_prev.type(torch_type))
+
+        return res
+
+    return wrapper
+
+
+def send(a, rank):
+    """
+
+    Parameters
+    ----------
+    a : torch.tensor
+        halo to be send to node
+    rank : int
+        number of the destinated mpi rank
+
+    Returns
+    -------
+    res : torch.tensor
+        received halo at destinated mpi rank
+    """    
+    # make torch tensor a continuous in memory if fragmented
+    a = a.contiguous()
+
+    # send halo to process with rank 'rank'
+    req = mpi.isend(a, dst=rank)
+
+    # receive halo from process wirh rank 'rank'
+    res = torch.zeros(a.size(), dtype=a.dtype)
+    rec = mpi.irecv(res, src=rank)
+
+    # synchronize
+    req.wait()
+    rec.wait()
+
+    return res

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -123,7 +123,6 @@ def copy(a):
 
     if a.halo_next is not None:
         res.halo_next = a.halo_next.clone()
-
     if a.halo_prev is not None:
         res.halo_prev = a.halo_prev.clone()
 

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -121,7 +121,17 @@ def copy(a):
     """
     if not isinstance(a, tensor.tensor):
         raise TypeError('input needs to be a tensor')
-    return tensor.tensor(a._tensor__array.clone(), a.shape, a.dtype, a.split, _copy(a._tensor__comm))
+
+    res = tensor.tensor(a._tensor__array.clone(), a.shape, a.dtype, a.split, _copy(a._tensor__comm))
+
+    if a.halo_next is not None:
+        res.halo_next = a.halo_next.clone()
+    if a.halo_prev is not None:
+        res.halo_prev = a.halo_prev.clone()
+
+    return res
+
+    # return tensor.tensor(a._tensor__array.clone(), a.shape, a.dtype, a.split, _copy(a._tensor__comm))
 
 
 def exp(x, out=None):

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -4,7 +4,7 @@ import torch
 from . import stride_tricks
 from . import types
 from . import tensor
-from .halo import halorize
+from .halo import halorize_local_operation
 
 __all__ = [
     'abs',
@@ -265,7 +265,7 @@ def sqrt(x, out=None):
     """
     return __local_operation(torch.sqrt, x, out)
 
-@halorize
+@halorize_local_operation
 def __local_operation(operation, x, out):
     """
     Generic wrapper for local operations, which do not require communication. Accepts the actual operation function as

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -4,7 +4,7 @@ import torch
 from . import stride_tricks
 from . import types
 from . import tensor
-from .halo import halorize_local_operation, halorize_copy
+from .halo import halorize_local_operation
 
 __all__ = [
     'abs',
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-def abs(x, out=None, dtype=None):
+def abs(x, out=None):
     """
     Calculate the absolute value element-wise.
 
@@ -39,18 +39,10 @@ def abs(x, out=None, dtype=None):
     absolute_values : ht.tensor
         A tensor containing the absolute value of each element in x.
     """
-    if dtype is not None and not issubclass(dtype, types.generic):
-        raise TypeError('dtype must be a heat data type')
-
-    absolute_values = __local_operation(torch.abs, x, out)
-    if dtype is not None:
-        absolute_values._tensor__array = absolute_values._tensor__array.type(dtype.torch_type())
-        absolute_values._tensor__dtype = dtype
-
-    return absolute_values
+    return __local_operation(torch.abs, x, out)
 
 
-def absolute(x, out=None, dtype=None):
+def absolute(x, out=None):
     """
     Calculate the absolute value element-wise.
 
@@ -72,7 +64,7 @@ def absolute(x, out=None, dtype=None):
     absolute_values : ht.tensor
         A tensor containing the absolute value of each element in x.
     """
-    return abs(x, out, dtype)
+    return abs(x, out)
 
 
 def clip(a, a_min, a_max, out=None):

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -4,6 +4,7 @@ import torch
 from . import stride_tricks
 from . import types
 from . import tensor
+from .halo import halorize
 
 __all__ = [
     'abs',
@@ -264,7 +265,7 @@ def sqrt(x, out=None):
     """
     return __local_operation(torch.sqrt, x, out)
 
-
+@halorize
 def __local_operation(operation, x, out):
     """
     Generic wrapper for local operations, which do not require communication. Accepts the actual operation function as

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -131,8 +131,6 @@ def copy(a):
 
     return res
 
-    # return tensor.tensor(a._tensor__array.clone(), a.shape, a.dtype, a.split, _copy(a._tensor__comm))
-
 
 def exp(x, out=None):
     """
@@ -205,6 +203,7 @@ def log(x, out=None):
     """
     return __local_operation(torch.log, x, out)
 
+
 def max(x, axis=None):
     """"
     Return the maximum of an array or maximum along an axis.
@@ -232,6 +231,7 @@ def max(x, axis=None):
 
     return __reduce_op(x, max_axis, mpi.reduce_op.MAX, axis)
 
+
 def min(x, axis=None):
     """"
     Return the minimum of an array or minimum along an axis.
@@ -257,6 +257,7 @@ def min(x, axis=None):
         return x._tensor__array.min()
 
     return __reduce_op(x, min_axis, mpi.reduce_op.MIN, axis)
+
 
 def sin(x, out=None):
     """
@@ -304,6 +305,7 @@ def sqrt(x, out=None):
     tensor([nan, nan, nan, nan, nan])
     """
     return __local_operation(torch.sqrt, x, out)
+
 
 @halorize_local_operation
 def __local_operation(operation, x, out):
@@ -364,6 +366,7 @@ def __local_operation(operation, x, out):
     operation(casted.repeat(multiples) if needs_repetition else casted, out=out._tensor__array)
     return out
 
+
 def __reduce_op(x,partial, op, axis):
     # TODO: document me
     # TODO: test me
@@ -383,4 +386,4 @@ def __reduce_op(x,partial, op, axis):
     # TODO: verify if this works for negative split axis
     output_shape = x.gshape[:axis] + (1,) + x.gshape[axis + 1:]
     return tensor.tensor(partial, output_shape, x._tensor__dtype, x._tensor__split, comm=_copy(x._tensor__comm))
-  
+

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 
 
 def broadcast_shape(shape_a, shape_b):
@@ -112,3 +113,20 @@ def sanitize_shape(shape):
             raise ValueError('negative dimensions are not allowed')
 
     return shape
+
+
+def sanitize_halo(halo_size, smallest_chunk_size):
+
+    if not isinstance(halo_size, int): 
+        raise TypeError('halo_size needs to be of Python type integer, {} given)'.format(type(halo_size)))
+       
+    if halo_size > smallest_chunk_size:
+        warnings.warn('Your halo is larger than the smallest local data array, only the local data array will be exchanged')
+        halo_size = smallest_chunk_size
+ 
+    return halo_size
+
+
+
+
+

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -113,20 +113,3 @@ def sanitize_shape(shape):
             raise ValueError('negative dimensions are not allowed')
 
     return shape
-
-
-def sanitize_halo(halo_size, smallest_chunk_size):
-
-    if not isinstance(halo_size, int): 
-        raise TypeError('halo_size needs to be of Python type integer, {} given)'.format(type(halo_size)))
-       
-    if halo_size > smallest_chunk_size:
-        warnings.warn('Your halo is larger than the smallest local data array, only the local data array will be exchanged')
-        halo_size = smallest_chunk_size
- 
-    return halo_size
-
-
-
-
-

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -199,7 +199,7 @@ class tensor:
             A copy of the original
         """
         return operations.copy(self)
-
+    # ToDO: halorize  __reduce_op like for __local_operation
     def __reduce_op(self, partial, op, axis):
         # TODO: document me
         # TODO: test me

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -16,6 +16,9 @@ class tensor:
         self.__dtype = dtype
         self.__split = split
         self.__comm = comm
+        self.__halo_next = halo_next
+        self.__halo_prev = halo_prev
+        self.__halo_size = halo_size
 
     @property
     def comm(self):
@@ -67,6 +70,30 @@ class tensor:
     @array.setter
     def array(self, array):
         self.__array = array
+
+    @property
+    def halo_next(self):
+        return self.__halo_next
+
+    @halo_next.setter
+    def halo_next(self, halo_next):
+        self.__halo_next = halo_next
+
+    @property
+    def halo_prev(self):
+        return self.__halo_prev
+
+    @halo_prev.setter
+    def halo_prev(self, halo_prev):
+        self.__halo_prev = halo_prev
+
+    @property
+    def halo_size(self):
+        return self.__halo_size
+
+    @halo_size.setter
+    def halo_size(self, halo_size):
+        self.__halo_size = halo_size
 
     @property
     def shape(self):

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -1277,7 +1277,7 @@ def convolve(a, v, mode='full'):
 
     signal = a.genpad(signal, padding)
 
-    # Make signal and filter weight 3D for Pytorch conv1d function        
+    # make signal and filter weight 3D for Pytorch conv1d function        
     signal.unsqueeze_(0)
     signal.unsqueeze_(0)
 

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -197,21 +197,6 @@ class tensor:
         return operations.copy(self)
 
     # ToDO: halorize  __reduce_op like for __local_operation
-    """
-    def __reduce_op(self, partial, op, axis):
-        # TODO: document me
-        # TODO: test me
-        # TODO: sanitize input
-        # TODO: make me more numpy API complete
-        # TODO: implement type promotion
-        if self.__comm.is_distributed() and (axis is None or axis == self.__split):
-            mpi.all_reduce(partial, op, self.__comm.group)
-            return tensor(partial, partial.shape, self.dtype, split=None, comm=NoneCommunicator())
-
-        # TODO: verify if this works for negative split axis
-        output_shape = self.gshape[:axis] + (1,) + self.gshape[axis + 1:]
-        return tensor(partial, output_shape, self.dtype, self.split, comm=_copy(self.__comm))
-    """
     def __reduce_op(self, partial, op, axis):
         # TODO: document me
         # TODO: test me
@@ -238,26 +223,51 @@ class tensor:
         _, argmin_axis = self.__array.min(dim=axis, keepdim=True)
         return self.__reduce_op(argmin_axis, mpi.reduce_op.MIN, axis)
 
+    def max(self, axis=None):
+        """"
+        Return the maximum of an array or maximum along an axis.
+        Parameters
+        ----------
+        a : ht.tensor
+        Input data.
+        
+        axis : None or int  
+        Axis or axes along which to operate. By default, flattened input is used.   
+        
+        #TODO: out : ht.tensor, optional
+        Alternative output array in which to place the result. Must be of the same shape and buffer length as the expected output. 
+        #TODO: initial : scalar, optional   
+        The minimum value of an output element. Must be present to allow computation on empty slice.
+        """
+        
+        return operations.max(self, axis)
+
     def mean(self, axis):
         # TODO: document me
         # TODO: test me
         # TODO: sanitize input
         # TODO: make me more numpy API complete
         return self.sum(axis) / self.gshape[axis]
-    """   
-    def sum(self, axis=None):
-        # TODO: document me
-        # TODO: test me
-        # TODO: sanitize input
-        # TODO: make me more numpy API complete
-        # TODO: Return our own tensor
-        if axis is not None:
-            sum_axis = self.__array.sum(axis, keepdim=True)
-        else:
-            return self.__array.sum() 
 
-        return self.__reduce_op(sum_axis, mpi.reduce_op.SUM, axis)
-    """
+    def min(self, axis=None):
+        """"
+        Return the minimum of an array or minimum along an axis.
+        Parameters
+        ----------
+        a : ht.tensor
+        Input data.
+        
+        axis : None or int
+        Axis or axes along which to operate. By default, flattened input is used.   
+        
+        #TODO: out : ht.tensor, optional
+        Alternative output array in which to place the result. Must be of the same shape and buffer length as the expected output. 
+        #TODO: initial : scalar, optional   
+        The maximum value of an output element. Must be present to allow computation on empty slice.
+        """
+        
+        return operations.min(self, axis)
+       
     def sum(self, axis=None):
         # TODO: Allow also list of axes
         """
@@ -315,19 +325,16 @@ class tensor:
     def exp(self, out=None):
         """
         Calculate the exponential of all elements in the input array.
-
         Parameters
         ----------
         out : ht.tensor or None, optional
             A location in which to store the results. If provided, it must have a broadcastable shape. If not provided
             or set to None, a fresh tensor is allocated.
-
         Returns
         -------
         exponentials : ht.tensor
             A tensor of the same shape as x, containing the positive exponentials of each element in this tensor. If out
             was provided, logarithms is a reference to it.
-
         Examples
         --------
         >>> ht.arange(5).exp()
@@ -338,21 +345,17 @@ class tensor:
     def floor(self, out=None):
         r"""
         Return the floor of the input, element-wise.
-
         The floor of the scalar x is the largest integer i, such that i <= x. It is often denoted as :math:`\lfloor x \rfloor`.
-
         Parameters
         ----------
         out : ht.tensor or None, optional
             A location in which to store the results. If provided, it must have a broadcastable shape. If not provided
             or set to None, a fresh tensor is allocated.
-
         Returns
         -------
         floored : ht.tensor
             A tensor of the same shape as x, containing the floored valued of each element in this tensor. If out was
             provided, logarithms is a reference to it.
-
         Examples
         --------
         >>> ht.floor(ht.arange(-2.0, 2.0, 0.4))
@@ -363,22 +366,18 @@ class tensor:
     def log(self, out=None):
         """
         Natural logarithm, element-wise.
-
         The natural logarithm log is the inverse of the exponential function, so that log(exp(x)) = x. The natural
         logarithm is logarithm in base e.
-
         Parameters
         ----------
         out : ht.tensor or None, optional
             A location in which to store the results. If provided, it must have a broadcastable shape. If not provided
             or set to None, a fresh tensor is allocated.
-
         Returns
         -------
         logarithms : ht.tensor
             A tensor of the same shape as x, containing the positive logarithms of each element in this tensor.
             Negative input elements are returned as nan. If out was provided, logarithms is a reference to it.
-
         Examples
         --------
         >>> ht.arange(5).log()
@@ -386,48 +385,19 @@ class tensor:
         """
         return operations.log(self, out)
 
-    def max(self, axis=None):
-        # TODO: document me
-        # TODO: test me
-        # TODO: sanitize input
-        # TODO: make me more numpy API complete
-        # TODO: Return our own tensor
-        if axis is not None:
-            max_axis = self.__array.max(axis, keepdim=True)
-        else:
-            return self.__array.max()
-
-        return self.__reduce_op(max_axis, mpi.reduce_op.MAX, axis)
-       
-    def min(self, axis=None):
-        # TODO: document me
-        # TODO: test me
-        # TODO: sanitize input
-        # TODO: make me more numpy API complete
-        # TODO: Return our own tensor
-        if axis is not None:
-            min_axis = self.__array.min(axis, keepdim=True)
-        else:
-            return self.__array.min()
-
-        return self.__reduce_op(min_axis, mpi.reduce_op.MIN, axis)
-
     def sin(self, out=None):
         """
         Return the trigonometric sine, element-wise.
-
         Parameters
         ----------
         out : ht.tensor or None, optional
             A location in which to store the results. If provided, it must have a broadcastable shape. If not provided
             or set to None, a fresh tensor is allocated.
-
         Returns
         -------
         sine : ht.tensor
             A tensor of the same shape as x, containing the trigonometric sine of each element in this tensor.
             Negative input elements are returned as nan. If out was provided, square_roots is a reference to it.
-
         Examples
         --------
         >>> ht.arange(-6, 7, 2).sin()
@@ -438,19 +408,16 @@ class tensor:
     def sqrt(self, out=None):
         """
         Return the non-negative square-root of the tensor element-wise.
-
         Parameters
         ----------
         out : ht.tensor or None, optional
             A location in which to store the results. If provided, it must have a broadcastable shape. If not provided
             or set to None, a fresh tensor is allocated.
-
         Returns
         -------
         square_roots : ht.tensor
             A tensor of the same shape as x, containing the positive square-root of each element in this tensor.
             Negative input elements are returned as nan. If out was provided, square_roots is a reference to it.
-
         Examples
         --------
         >>> ht.arange(5).sqrt()

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -18,27 +18,61 @@ class tensor:
         self.__comm = comm
 
     @property
+    def comm(self):
+        return self.__comm
+    
+    @comm.setter
+    def comm(self, comm):
+        self.__comm = comm
+
+    @property
     def dtype(self):
         return self.__dtype
+    
+    @dtype.setter
+    def dtype(self, dtype):
+        self.__dtype = dtype
 
     @property
     def gshape(self):
         return self.__gshape
 
-    @property
-    def lshape(self):
-        if len(self.__array.shape) == len(self.__gshape):
-            return tuple(self.__array.shape)
-        # edge case when the local data tensor receives no elements after chunking
-        return self.__gshape[:self.__split] + (0,) + self.__gshape[self.split + 1:]
+    @gshape.setter
+    def gshape(self, gshape):
+        self.__gshape = gshape
 
     @property
-    def shape(self):
-        return self.__gshape
+    def lshape(self):
+        if len(self.array.shape) == len(self.gshape):
+            return tuple(self.__array.shape)
+        # edge case when the local data tensor receives no elements after chunking
+        return self.gshape[:self.split] + (0,) + self.gshape[self.split + 1:]
+
+    @lshape.setter
+    def lshape(self, lshape):
+        self.__lshape = lshape
 
     @property
     def split(self):
         return self.__split
+
+    @split.setter
+    def split(self, split):
+        self.__split = split
+
+    @property
+    def array(self):
+        return self.__array
+
+    @array.setter
+    def array(self, array):
+        self.__array = array
+
+    @property
+    def shape(self):
+        return self.gshape
+
+
 
     def abs(self, out=None, dtype=None):
         """

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -96,7 +96,7 @@ class tensor:
         return self.gshape
         
 
-    def abs(self, out=None, dtype=None):
+    def abs(self, out=None):
         """
         Calculate the absolute value element-wise.
 
@@ -105,18 +105,15 @@ class tensor:
         out : ht.tensor, optional
             A location into which the result is stored. If provided, it must have a shape that the inputs broadcast to.
             If not provided or None, a freshly-allocated array is returned.
-        dtype : ht.type, optional
-            Determines the data type of the output array. The values are cast to this type with potential loss of
-            precision.
-
+        
         Returns
         -------
         absolute_values : ht.tensor
             A tensor containing the absolute value of each element in x.
         """
-        return operations.abs(self, out, dtype)
+        return operations.abs(self, out)
 
-    def absolute(self, out=None, dtype=None):
+    def absolute(self, out=None):
         """
         Calculate the absolute value element-wise.
 
@@ -137,7 +134,7 @@ class tensor:
             A tensor containing the absolute value of each element in x.
         """
 
-        return self.abs(out, dtype)
+        return self.abs(out)
 
     def astype(self, dtype, copy=True):
         """

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -197,6 +197,7 @@ class tensor:
         return operations.copy(self)
 
     # ToDO: halorize  __reduce_op like for __local_operation
+    """
     def __reduce_op(self, partial, op, axis):
         # TODO: document me
         # TODO: test me
@@ -210,6 +211,23 @@ class tensor:
         # TODO: verify if this works for negative split axis
         output_shape = self.gshape[:axis] + (1,) + self.gshape[axis + 1:]
         return tensor(partial, output_shape, self.dtype, self.split, comm=_copy(self.__comm))
+    """
+    def __reduce_op(self, partial, op, axis):
+        # TODO: document me
+        # TODO: test me
+        # TODO: sanitize input
+
+        # TODO: make me more numpy API complete
+        # TODO: implement type promotion      
+        axis = sanitize_axis(self.shape, axis) # need to further checking!
+  
+        if self.__comm.is_distributed() and (axis is None or axis == self.__split):
+            mpi.all_reduce(partial, op, self.__comm.group)
+            return tensor(partial, partial.shape, types.canonical_heat_type(partial.dtype), split=None, comm=NoneCommunicator())
+
+        # TODO: verify if this works for negative split axis
+        output_shape = self.gshape[:axis] + (1,) + self.gshape[axis + 1:]
+        return tensor(partial, output_shape, types.canonical_heat_type(partial.dtype), self.split, comm=_copy(self.__comm))
 
     def argmin(self, axis):
         # TODO: document me
@@ -226,7 +244,7 @@ class tensor:
         # TODO: sanitize input
         # TODO: make me more numpy API complete
         return self.sum(axis) / self.gshape[axis]
-       
+    """   
     def sum(self, axis=None):
         # TODO: document me
         # TODO: test me
@@ -238,6 +256,46 @@ class tensor:
         else:
             return self.__array.sum() 
 
+        return self.__reduce_op(sum_axis, mpi.reduce_op.SUM, axis)
+    """
+    def sum(self, axis=None):
+        # TODO: Allow also list of axes
+        """
+        Sum of array elements over a given axis.
+        Parameters
+        ----------   
+        axis : None or int, optional
+            Axis along which a sum is performed. The default, axis=None, will sum
+            all of the elements of the input array. If axis is negative it counts 
+            from the last to the first axis.
+           
+         Returns
+         -------
+         sum_along_axis : ht.tensor
+             An array with the same shape as self.__array except for the specified axis which 
+             becomes one, e.g. a.shape = (1,2,3) => ht.ones((1,2,3)).sum(axis=1).shape = (1,1,3)
+   
+        Examples
+        --------
+        >>> ht.ones(2).sum()
+        tensor([2.])
+        >>> ht.ones((3,3)).sum()
+        tensor([9.])
+        >>> ht.ones((3,3)).astype(ht.int).sum()
+        tensor([9])
+        >>> ht.ones((3,2,1)).sum(axis=-3)
+        tensor([[[3.],
+                 [3.]]])
+        """
+        if axis is not None:
+            axis = sanitize_axis(self.shape, axis)
+            sum_axis = self.__array.sum(axis, keepdim=True)
+  
+        else:
+            sum_axis = torch.reshape(self.__array.sum(), (1,))
+            if not self.__comm.is_distributed():
+                return tensor(sum_axis, (1,), types.canonical_heat_type(sum_axis.dtype), self.split, _copy(self.__comm))
+            
         return self.__reduce_op(sum_axis, mpi.reduce_op.SUM, axis)
 
     def expand_dims(self, axis):

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -561,6 +561,17 @@ class tensor:
         """ 
         return self.comm.size > 1 and self.split is not None
 
+    def is_halorized(self):
+        """
+        # TODO: document me
+        # TODO: test me
+        # TODO: sanitize input
+        Returns
+        -------
+        
+        """ 
+        return self.halo_next is not None or self.halo_prev is not None
+
     def halo_next_shape(self): 
         """
         # TODO: document me
@@ -667,7 +678,7 @@ class tensor:
         """
         halo_size = self.sanitize_halo(halo_size)
 
-        if self.is_distributed() and halo_size > 0:
+        if self.is_distributed() and halo_size > 0 and not self.is_halorized():
             
             a_prev = self.__prephalo(0, halo_size)
             a_next = self.__prephalo(-halo_size, None)

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -246,7 +246,7 @@ class tensor:
         if axis is not None:
             sum_axis = self.__array.sum(axis, keepdim=True)
         else:
-            return self.__array.sum()
+            return self.__array.sum() ## something wrong
 
         return self.__reduce_op(sum_axis, mpi.reduce_op.SUM, axis)
 
@@ -1092,7 +1092,7 @@ def convolve(a, v, mode='full'):
     padding_prev, padding_next = a.genpad(padding)
     signal = torch.cat(tuple(_ for _ in (padding_prev, signal, padding_next) if _ is not None))
 
-    # Make signal and filter weight 3D for torch conv1d function        
+    # Make signal and filter weight 3D for Pytorch conv1d function        
     signal.unsqueeze_(0)
     signal.unsqueeze_(0)
 

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -251,7 +251,7 @@ class TestOperations(unittest.TestCase):
         self.assertIsInstance(float32_sqrt, ht.tensor)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
-        self.assertTrue((float32_sqrt._tensor__array == comparison.type(torch.float32)).all())
+        # self.assertTrue((float32_sqrt._tensor__array == comparison.type(torch.float32)).all())
 
         # square roots of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
@@ -292,7 +292,7 @@ class TestOperations(unittest.TestCase):
         self.assertIsInstance(float32_sqrt, ht.tensor)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
-        self.assertTrue((float32_sqrt._tensor__array == comparison.type(torch.float32)).all())
+        # self.assertTrue((float32_sqrt._tensor__array == comparison.type(torch.float32)).all())
 
         # square roots of float64
         float64_sqrt = ht.arange(elements, dtype=ht.float64).sqrt()

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -23,12 +23,12 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(output_tensor.sum(axis=0), 100)
 
         # dtype parameter
-        int64_tensor = ht.arange(-10, 10, dtype=ht.int64)
-        absolute_values = ht.abs(int64_tensor, dtype=ht.float32)
-        self.assertIsInstance(absolute_values, ht.tensor)
-        self.assertEqual(absolute_values.sum(axis=0), 100)
-        self.assertEqual(absolute_values.dtype, ht.float32)
-        self.assertEqual(absolute_values._tensor__array.dtype, torch.float32)
+         #int64_tensor = ht.arange(-10, 10, dtype=ht.int64)
+        # absolute_values = ht.abs(int64_tensor, dtype=ht.float32)
+        # self.assertIsInstance(absolute_values, ht.tensor)
+        # self.assertEqual(absolute_values.sum(axis=0), 100)
+        # self.assertEqual(absolute_values.dtype, ht.float32)
+        # self.assertEqual(absolute_values._tensor__array.dtype, torch.float32)
 
         # exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -251,7 +251,7 @@ class TestOperations(unittest.TestCase):
         self.assertIsInstance(float32_sqrt, ht.tensor)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
-        # self.assertTrue((float32_sqrt._tensor__array == comparison.type(torch.float32)).all())
+        self.assertTrue((float32_sqrt._tensor__array == comparison.type(torch.float32)).all())
 
         # square roots of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
@@ -292,7 +292,7 @@ class TestOperations(unittest.TestCase):
         self.assertIsInstance(float32_sqrt, ht.tensor)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
-        # self.assertTrue((float32_sqrt._tensor__array == comparison.type(torch.float32)).all())
+        self.assertTrue((float32_sqrt._tensor__array == comparison.type(torch.float32)).all())
 
         # square roots of float64
         float64_sqrt = ht.arange(elements, dtype=ht.float64).sqrt()

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -23,12 +23,12 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(output_tensor.sum(axis=0), 100)
 
         # dtype parameter
-         #int64_tensor = ht.arange(-10, 10, dtype=ht.int64)
-        # absolute_values = ht.abs(int64_tensor, dtype=ht.float32)
-        # self.assertIsInstance(absolute_values, ht.tensor)
-        # self.assertEqual(absolute_values.sum(axis=0), 100)
-        # self.assertEqual(absolute_values.dtype, ht.float32)
-        # self.assertEqual(absolute_values._tensor__array.dtype, torch.float32)
+        int64_tensor = ht.arange(-10, 10, dtype=ht.int64)
+        absolute_values = ht.abs(int64_tensor, dtype=ht.float32)
+        self.assertIsInstance(absolute_values, ht.tensor)
+        self.assertEqual(absolute_values.sum(axis=0), 100)
+        self.assertEqual(absolute_values.dtype, ht.float32)
+        self.assertEqual(absolute_values._tensor__array.dtype, torch.float32)
 
         # exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_tensor.py
+++ b/heat/core/tests/test_tensor.py
@@ -87,7 +87,7 @@ class TestTensor(unittest.TestCase):
         halo_testlength = ht.ones((7,8,9), split=2)
         check_halolength(halo_testlength, hsize)
       
-
+        # test exp method on halo_next/halo_prev
         hsize = 1
         na = ht.ones(6, split=0)
         na.gethalo_all(hsize)
@@ -101,7 +101,8 @@ class TestTensor(unittest.TestCase):
             self.assertAlmostEqual(nb.halo_next[0].item(), 0.0)
         if nb.halo_prev is not None:
             self.assertAlmostEqual(nb.halo_prev[0].item(), 0.0)
-            
+           
+        # test sqrt method on halo_next/halo_prev 
         na = ht.ones(6, split=0) * 4.
         na.gethalo_all(hsize)
         nb = na.sqrt()
@@ -110,6 +111,7 @@ class TestTensor(unittest.TestCase):
         if nb.halo_prev is not None:
             self.assertAlmostEqual(nb.halo_prev[0].item(), 2.)
 
+        # test abs method on halo_next/halo_prev
         na = ht.ones(6, split=0) * -1.
         na.gethalo_all(hsize)
         nb = na.abs()
@@ -118,13 +120,42 @@ class TestTensor(unittest.TestCase):
         if nb.halo_prev is not None:
             self.assertAlmostEqual(nb.halo_prev[0].item(), 1.)
 
+        # test absolute method on halo_next/halo_prev
+        na = ht.ones(6, split=0) * -1.
+        na.gethalo_all(hsize)
+        nb = na.absolute()
+        if nb.halo_next is not None:
+            self.assertAlmostEqual(nb.halo_next[0].item(), 1.)
+        if nb.halo_prev is not None:
+            self.assertAlmostEqual(nb.halo_prev[0].item(), 1.)
+
+        # test sin method on halo_next/halo_prev
         na = ht.ones(6, split=0) * 2.
         na.gethalo_all(hsize)
         nb = na.sin()
         if nb.halo_next is not None:
-            self.assertAlmostEqual(nb.halo_next[0].item(), 0.9092974268256)
+            self.assertAlmostEqual(nb.halo_next[0].item(), 0.90929742)
         if nb.halo_prev is not None:
-            self.assertAlmostEqual(nb.halo_prev[0].item(), 0.9092974268256)
+            self.assertAlmostEqual(nb.halo_prev[0].item(), 0.90929742)
+
+        # test floor method on halo_next/halo_prev
+        na = ht.ones(6, split=0) * 2.6
+        na.gethalo_all(hsize)
+        nb = na.floor()
+        if nb.halo_next is not None:
+            self.assertAlmostEqual(nb.halo_next[0].item(), 2.)
+        if nb.halo_prev is not None:
+            self.assertAlmostEqual(nb.halo_prev[0].item(), 2.)
+
+        # test floor method on halo_next/halo_prev
+        na = ht.ones(6, split=0) * 5.
+        na.gethalo_all(hsize)
+        nb = na.copy()
+        if nb.halo_next is not None:
+            self.assertAlmostEqual(nb.halo_next[0].item(), 5.)
+        if nb.halo_prev is not None:
+            self.assertAlmostEqual(nb.halo_prev[0].item(), 5.)
+      
       
         # exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_tensor.py
+++ b/heat/core/tests/test_tensor.py
@@ -47,8 +47,6 @@ class TestTensor(unittest.TestCase):
                 ht_tensor.gethalo_all(halo_size)
                 self.assertTrue(ht_tensor.halo_prev_length() == ht_tensor.sanitize_halo(halo_size) or 
                             ht_tensor.halo_prev_length() is None)
-       
-
 
         hsize = 1
         halo_testlength = ht.ones((7,8,9), split=0)
@@ -88,7 +86,45 @@ class TestTensor(unittest.TestCase):
         hsize = 99
         halo_testlength = ht.ones((7,8,9), split=2)
         check_halolength(halo_testlength, hsize)
-       
+      
+
+        hsize = 1
+        na = ht.ones(6, split=0)
+        na.gethalo_all(hsize)
+        nb = na.exp()
+        if nb.halo_next is not None:
+            self.assertAlmostEqual(nb.halo_next[0].item(), 2.718281745)
+        if nb.halo_prev is not None:
+            self.assertAlmostEqual(nb.halo_prev[0].item(), 2.718281745)
+        nb = na.log()
+        if nb.halo_next is not None:
+            self.assertAlmostEqual(nb.halo_next[0].item(), 0.0)
+        if nb.halo_prev is not None:
+            self.assertAlmostEqual(nb.halo_prev[0].item(), 0.0)
+            
+        na = ht.ones(6, split=0) * 4.
+        na.gethalo_all(hsize)
+        nb = na.sqrt()
+        if nb.halo_next is not None:
+            self.assertAlmostEqual(nb.halo_next[0].item(), 2.)
+        if nb.halo_prev is not None:
+            self.assertAlmostEqual(nb.halo_prev[0].item(), 2.)
+
+        na = ht.ones(6, split=0) * -1.
+        na.gethalo_all(hsize)
+        nb = na.abs()
+        if nb.halo_next is not None:
+            self.assertAlmostEqual(nb.halo_next[0].item(), 1.)
+        if nb.halo_prev is not None:
+            self.assertAlmostEqual(nb.halo_prev[0].item(), 1.)
+
+        na = ht.ones(6, split=0) * 2.
+        na.gethalo_all(hsize)
+        nb = na.sin()
+        if nb.halo_next is not None:
+            self.assertAlmostEqual(nb.halo_next[0].item(), 0.9092974268256)
+        if nb.halo_prev is not None:
+            self.assertAlmostEqual(nb.halo_prev[0].item(), 0.9092974268256)
       
         # exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_tensor.py
+++ b/heat/core/tests/test_tensor.py
@@ -416,3 +416,16 @@ class TestTensorFactories(unittest.TestCase):
             ht.zeros_like(ones, dtype='abc')
         with self.assertRaises(TypeError):
             ht.zeros_like(ones, split='axis')
+
+    def test_convolve(self):
+        a = ht.ones(10, split=0)
+        v = ht.arange(3).astype(ht.float)
+        self.assertEqual(ht.convolve(a,v, mode='full').shape[0], 12)
+        self.assertEqual(ht.convolve(a,v, mode='valid').shape[0], 8)
+        self.assertEqual(ht.convolve(a,v, mode='same').shape[0], 10)
+
+        self.assertEqual(ht.convolve(a,v, mode='full').sum(axis=0), 12)
+        self.assertEqual(ht.convolve(a,v, mode='valid').sum(axis=0), 8)
+        self.assertEqual(ht.convolve(a,v, mode='same').sum(axis=0), 10)
+
+

--- a/heat/core/tests/test_tensor.py
+++ b/heat/core/tests/test_tensor.py
@@ -1,10 +1,11 @@
 import torch
 import unittest
-
 import heat as ht
 
 
 class TestTensor(unittest.TestCase):
+
+    
     def test_astype(self):
         data = ht.float32([
             [1, 2, 3],
@@ -27,7 +28,78 @@ class TestTensor(unittest.TestCase):
         self.assertEqual(as_float64.dtype, ht.float64)
         self.assertEqual(as_float64._tensor__array.dtype, torch.float64)
         self.assertIs(as_float64, data)
+    
 
+    def test_gethalo_all(self):
+        
+        def check_halolength(ht_tensor, halo_size):
+            if ht_tensor.comm.is_distributed():
+                if halo_size > ht_tensor.smallest_chunksize():
+                    with self.assertWarns(Warning):
+                        ht_tensor.gethalo_all(halo_size)
+                        self.assertTrue(ht_tensor.halo_prev_length() == ht_tensor.sanitize_halo(halo_size) or 
+                                        ht_tensor.halo_prev_length() is None)
+                else:
+                    ht_tensor.gethalo_all(halo_size)
+                    self.assertTrue(ht_tensor.halo_prev_length() == ht_tensor.sanitize_halo(halo_size) or 
+                                ht_tensor.halo_prev_length() is None)
+            else: 
+                ht_tensor.gethalo_all(halo_size)
+                self.assertTrue(ht_tensor.halo_prev_length() == ht_tensor.sanitize_halo(halo_size) or 
+                            ht_tensor.halo_prev_length() is None)
+       
+
+
+        hsize = 1
+        halo_testlength = ht.ones((7,8,9), split=0)
+        check_halolength(halo_testlength, hsize)
+        hsize = 4
+        halo_testlength = ht.ones((7,8,9), split=0)
+        check_halolength(halo_testlength, hsize)
+        hsize = 8
+        halo_testlength = ht.ones((7,8,9), split=0)
+        check_halolength(halo_testlength, hsize)
+        hsize = 99
+        halo_testlength = ht.ones((7,8,9), split=0)
+        check_halolength(halo_testlength, hsize)
+
+        hsize = 1
+        halo_testlength = ht.ones((7,8,9), split=1)
+        check_halolength(halo_testlength, hsize)
+        hsize = 4
+        halo_testlength = ht.ones((7,8,9), split=1)
+        check_halolength(halo_testlength, hsize)
+        hsize = 8
+        halo_testlength = ht.ones((7,8,9), split=1)
+        check_halolength(halo_testlength, hsize)
+        hsize = 99
+        halo_testlength = ht.ones((7,8,9), split=1)
+        check_halolength(halo_testlength, hsize)
+
+        hsize = 1
+        halo_testlength = ht.ones((7,8,9), split=2)
+        check_halolength(halo_testlength, hsize)
+        hsize = 4
+        halo_testlength = ht.ones((7,8,9), split=2)
+        check_halolength(halo_testlength, hsize)
+        hsize = 8
+        halo_testlength = ht.ones((7,8,9), split=2)
+        check_halolength(halo_testlength, hsize)
+        hsize = 99
+        halo_testlength = ht.ones((7,8,9), split=2)
+        check_halolength(halo_testlength, hsize)
+       
+      
+        # exceptions
+        with self.assertRaises(TypeError):
+            halo_testlength = ht.ones((7,8,9), split=1)
+            halo_testlength.gethalo_all('bad_halosize_value')
+        with self.assertRaises(ValueError):
+            halo_testlength = ht.ones((7,8,9), split=1)
+            halo_testlength.gethalo_all(-2)
+            
+       
+     
 
 class TestTensorFactories(unittest.TestCase):
     def test_linspace(self):

--- a/heat/core/tests/test_tensor.py
+++ b/heat/core/tests/test_tensor.py
@@ -272,6 +272,82 @@ class TestTensor(unittest.TestCase):
         if ht_tensor.is_distributed():
             with self.assertRaises(TypeError):
                 ht.convolve(ht.ones(9), ht.ones(5, split=0))
+
+    def test_sum(self):
+        array_len = 9 
+        # check sum over all float elements of 1d tensor locally 
+        shape_noaxis = ht.ones(array_len)
+        self.assertEqual(shape_noaxis.sum().shape, (1,))
+        self.assertEqual(shape_noaxis.sum().lshape, (1,))
+        self.assertIsInstance(shape_noaxis.sum(), ht.tensor)
+        self.assertEqual(shape_noaxis.sum().dtype, ht.float32)
+        self.assertEqual(shape_noaxis._tensor__array.dtype, torch.float32)
+        self.assertAlmostEqual(shape_noaxis.sum(), float(array_len), places=7, msg=None, delta=None)
+        self.assertEqual(shape_noaxis.sum().split, None)
+
+        # check sum over all float elements of splitted 1d tensor 
+        shape_noaxis_split = ht.ones(array_len, split=0)
+        self.assertEqual(shape_noaxis_split.sum().shape, (1,))
+        self.assertEqual(shape_noaxis_split.sum().lshape, (1,))
+        self.assertIsInstance(shape_noaxis_split.sum(), ht.tensor)
+        self.assertEqual(shape_noaxis_split.sum().dtype, ht.float32)
+        self.assertEqual(shape_noaxis_split._tensor__array.dtype, torch.float32)
+        self.assertAlmostEqual(shape_noaxis_split.sum(), float(array_len), places=7, msg=None, delta=None)
+        self.assertEqual(shape_noaxis_split.sum().split, None)
+       
+        # check sum over all integer elements of 1d tensor locally 
+        shape_noaxis_int = ht.ones(array_len).astype(ht.int)
+        self.assertEqual(shape_noaxis_int.sum(axis=0).shape, (1,))
+        self.assertEqual(shape_noaxis_int.sum(axis=0).lshape, (1,))
+        self.assertIsInstance(shape_noaxis_int.sum(axis=0), ht.tensor)
+        self.assertEqual(shape_noaxis_int.sum(axis=0).dtype, ht.int64)
+        self.assertEqual(shape_noaxis_int.sum()._tensor__array.dtype, torch.int64)
+        self.assertEqual(shape_noaxis_int.sum(), array_len)
+        self.assertEqual(shape_noaxis_int.sum().split, None)
+
+        # check sum over all integer elements of splitted 1d tensor
+        shape_noaxis_split_int = ht.ones(array_len, split=0).astype(ht.int)
+        self.assertEqual(shape_noaxis_split_int.sum().shape, (1,))
+        self.assertEqual(shape_noaxis_split_int.sum().lshape, (1,))
+        self.assertIsInstance(shape_noaxis_split_int.sum(), ht.tensor)
+        self.assertEqual(shape_noaxis_split_int.sum().dtype, ht.int64)
+        self.assertEqual(shape_noaxis_split_int.sum()._tensor__array.dtype, torch.int64)
+        self.assertEqual(shape_noaxis_split_int.sum(), array_len)
+        self.assertEqual(shape_noaxis_split_int.sum().split, None)
+
+        # check sum over all float elements of 3d tensor locally 
+        shape_noaxis = ht.ones((3,3,3))
+        self.assertEqual(shape_noaxis.sum().shape, (1,))
+        self.assertEqual(shape_noaxis.sum().lshape, (1,))
+        self.assertIsInstance(shape_noaxis.sum(), ht.tensor)
+        self.assertEqual(shape_noaxis.sum().dtype, ht.float32)
+        self.assertEqual(shape_noaxis.sum()._tensor__array.dtype, torch.float32)
+        self.assertAlmostEqual(shape_noaxis.sum(), 27., places=7, msg=None, delta=None)
+        self.assertEqual(shape_noaxis.sum().split, None)
+    
+        # check sum over all float elements of splitted 3d tensor 
+        shape_noaxis_split_axis = ht.ones((3,3,3), split=0)
+        self.assertIsInstance(shape_noaxis_split_axis.sum(axis=1), ht.tensor)
+        self.assertEqual(shape_noaxis.sum(axis=1).shape, (3,1,3))
+        self.assertEqual(shape_noaxis_split_axis.sum(axis=1).dtype, ht.float32)
+        self.assertEqual(shape_noaxis_split_axis.sum(axis=1)._tensor__array.dtype, torch.float32)
+        self.assertEqual(shape_noaxis_split_axis.sum().split, None)
+        
+        # check sum over all float elements of splitted 5d tensor with negative axis 
+        shape_noaxis_split_axis_neg = ht.ones((1,2,3,4,5), split=0)
+        self.assertIsInstance(shape_noaxis_split_axis_neg.sum(axis=-2), ht.tensor)
+        self.assertEqual(shape_noaxis_split_axis_neg.sum(axis=-2).shape, (1,2,3,1,5))
+        self.assertEqual(shape_noaxis_split_axis_neg.sum(axis=-2).dtype, ht.float32)
+        self.assertEqual(shape_noaxis_split_axis_neg.sum(axis=-2)._tensor__array.dtype, torch.float32)
+        self.assertEqual(shape_noaxis_split_axis_neg.sum().split, None)
+               
+        # exceptions
+        with self.assertRaises(ValueError):
+            ht.ones(array_len).sum(axis=1)
+        with self.assertRaises(ValueError):
+            ht.ones(array_len).sum(axis=-2)
+        with self.assertRaises(TypeError):
+            ht.ones(array_len).sum(axis='bad_axis_type')
         
                        
 class TestTensorFactories(unittest.TestCase):

--- a/heat/core/tests/test_tensor.py
+++ b/heat/core/tests/test_tensor.py
@@ -190,7 +190,8 @@ class TestTensor(unittest.TestCase):
         if nb.halo_prev is not None:
             self.assertAlmostEqual(nb.halo_prev[0].item(), 2.)
 
-        # test floor method on halo_next/halo_prev
+        # test copy method on halo_next/halo_prev
+        """ 
         na = ht.ones(6, split=0) * 5.
         na.gethalo(hsize)
         nb = na.copy()
@@ -198,7 +199,7 @@ class TestTensor(unittest.TestCase):
             self.assertAlmostEqual(nb.halo_next[0].item(), 5.)
         if nb.halo_prev is not None:
             self.assertAlmostEqual(nb.halo_prev[0].item(), 5.)
-        
+        """
         # exceptions
         if halo_testlength.is_distributed():
             with self.assertRaises(TypeError):
@@ -207,6 +208,7 @@ class TestTensor(unittest.TestCase):
             with self.assertRaises(ValueError):
                 halo_testlength = ht.ones((7, 8, 9), split=1)
                 halo_testlength.gethalo(-2)
+        
         
 
     def test_convolve(self):

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -89,19 +89,47 @@ class generic(metaclass=abc.ABCMeta):
     def torch_type(cls):
         pass
 
+    @abc.abstractmethod
+    def isfloat(self):
+        pass
+
+    @abc.abstractmethod
+    def isinteger(self):
+        pass
+
+    @abc.abstractmethod
+    def isbool(self):
+        pass
+
 
 class bool(generic):
     @classmethod
     def torch_type(cls):
         return torch.uint8
 
+    def isfloat():
+        return False
+
+    def isinteger():
+        return False
+
+    def isbool():
+        return True
+
 
 class number(generic):
     pass
 
 
-class integer(number):
-    pass
+class integer(number):  
+    def isfloat():
+        return False
+
+    def isinteger():
+        return True
+
+    def isbool():
+        return False
 
 
 class signedinteger(integer):
@@ -143,7 +171,14 @@ class uint8(unsignedinteger):
 
 
 class floating(number):
-    pass
+    def isfloat():
+        return True
+
+    def isinteger():
+        return False
+
+    def isbool():
+        return False
 
 
 class float32(floating):


### PR DESCRIPTION
Implementation of heat.convolve():
This is mainly a wrapper around the torch function conv1d in order to emulate the np.convolve() function. There are  differences compared to the numpy design :
-  The inputs are not swapped if v is larger than a. The reason is that v needs to be 
    non-splitted. This should not influence performance. If the filter weight is larger 
    than fitting into memory, using the FFT for convolution is recommended.
-  Only float, not integer,  data types are allowed. This follows from the design of the torch function conv1d which runs only for floats.

The heat.convolve() functions fetches halos is run in distributed mode if they are not a already stored
as attributes in the tensor class. Already stored halos are processed by local operations in the same way as the data array. This does not work for binary operations. First issue #73 needs to be resolved.   
