### PR TITLE
Added CUDA-aware MPI checks

### DIFF
--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -1,8 +1,16 @@
 from mpi4py import MPI
 import abc
+import subprocess
 import torch
 
 from .stride_tricks import sanitize_axis
+
+# check whether OpenMPI support CUDA-aware MPI
+try:
+    buffer = subprocess.check_output(['ompi_info', '--parsable', '--all'])
+    CUDA_AWARE_MPI = b'mpi_built_with_cuda_support:value:true' in buffer
+except FileNotFoundError:
+    CUDA_AWARE_MPI = False
 
 
 class Communication(metaclass=abc.ABCMeta):
@@ -93,11 +101,12 @@ class MPICommunication(Communication):
     def as_buffer(obj):
         if isinstance(obj, tensor.tensor):
             obj = obj._tensor__array
-
         if not isinstance(obj, torch.Tensor):
             return obj
 
-        return MPI.memory.fromaddress(obj.cpu().data_ptr(), obj.element_size() * torch.numel(obj))
+        pointer = obj.data_ptr() if CUDA_AWARE_MPI else obj.cpu().data_ptr()
+
+        return MPI.memory.fromaddress(pointer, obj.element_size() * torch.numel(obj))
 
     def convert_tensors(self, a_callable):
         def wrapped(*args, **kwargs):

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -54,3 +54,6 @@ class TestCommunicator(unittest.TestCase):
 
         self.assertIsInstance(chunks, tuple)
         self.assertEqual(len(chunks), len(self.data.shape))
+
+    def test_cuda_aware_mpi(self):
+        self.assertTrue(hasattr(ht.communication, 'CUDA_AWARE_MPI'))


### PR DESCRIPTION
Implemented checks for CUDA-aware MPI. Currently, only OpenMPI supports it in sufficiently. May need to be extended later for other MPI implementation.

Resolves issue #82 