### PR TITLE
Implementation of transpose

### DIFF
--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -16,7 +16,8 @@ __all__ = [
     'max',
     'min',
     'sin',
-    'sqrt'
+    'sqrt',
+    'transpose'
 ]
 
 
@@ -348,6 +349,30 @@ def sqrt(x, out=None):
     return __local_operation(torch.sqrt, x, out)
 
 
+def transpose(a, axes=None):
+    """
+    Permute the dimensions of an array.
+
+    Parameters
+    ----------
+    a : array_like
+        Input array.
+    axes : None or list of ints, optional
+        By default, reverse the dimensions, otherwise permute the axes according to the values given.
+
+    Returns
+    -------
+    p : ht.tensor
+        a with its axes permuted.
+    """
+    if not isinstance(a, tensor.tensor):
+        raise TypeError('a must be of type ht.tensor, but was {}'.format(type(a)))
+
+    # sanitize the axis
+    if axes is not None:
+        axes = [stride_tricks.sanitize_axis(a.shape, int(axis)) for axis in axes]
+
+    
 def __local_operation(operation, x, out):
     """
     Generic wrapper for local operations, which do not require communication. Accepts the actual operation function as

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -55,7 +55,9 @@ def sanitize_axis(shape, axis):
     Raises
     -------
     ValueError
-        If the axis cannot be sanitized, i.e. out of bounds.
+        if the axis cannot be sanitized, i.e. out of bounds.
+    TypeError
+        if the the axis is not integral.
     """
     #TODO: test me
     
@@ -63,7 +65,7 @@ def sanitize_axis(shape, axis):
         if isinstance(axis, tuple):
             raise NotImplementedError('Not implemented for axis: tuple of ints')
         if not isinstance(axis, int):
-            raise TypeError('split axis must be None or int, but was {}'.format(type(axis)))
+            raise TypeError('axis must be None or int, but was {}'.format(type(axis)))
 
     if axis is None or 0 <= axis < len(shape):
         return axis

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -471,6 +471,26 @@ class tensor:
         -------
         p : ht.tensor
             a with its axes permuted.
+
+        Examples
+        --------
+        >>> a = ht.array([[1, 2], [3, 4]])
+        >>> a
+        tensor([[1, 2],
+                [3, 4]])
+        >>> a.transpose()
+        tensor([[1, 3],
+                [2, 4]])
+        >>> a.transpose((1, 0))
+        tensor([[1, 3],
+                [2, 4]])
+        >>> a.transpose(1, 0)
+        tensor([[1, 3],
+                [2, 4]])
+                
+        >>> x = ht.ones((1, 2, 3))
+        >>> ht.transpose(x, (1, 0, 2)).shape
+        (2, 1, 3)
         """
         return operations.transpose(self, axes)
 

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -44,6 +44,10 @@ class tensor:
     def split(self):
         return self.__split
 
+    @property
+    def T(self, axes=None):
+        return operations.transpose(self, axes)
+
     def abs(self, out=None, dtype=None):
         """
         Calculate the absolute value element-wise.
@@ -453,6 +457,22 @@ class tensor:
                  [3.]]])
         """
         return operations.sum(self, axis)
+
+    def transpose(self, axes=None):
+        """
+        Permute the dimensions of an array.
+
+        Parameters
+        ----------
+        axes : None or list of ints, optional
+            By default, reverse the dimensions, otherwise permute the axes according to the values given.
+
+        Returns
+        -------
+        p : ht.tensor
+            a with its axes permuted.
+        """
+        return operations.transpose(self, axes)
 
     def __binop(self, op, other):
         # TODO: document me

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -405,6 +405,79 @@ class TestOperations(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.sqrt(number_range, 'hello world')
 
+    def test_transpose(self):
+        # vector transpose, not distributed
+        vector = ht.arange(10)
+        vector_t = vector.T
+        self.assertIsInstance(vector_t, ht.tensor)
+        self.assertEqual(vector_t.dtype, ht.int32)
+        self.assertEqual(vector_t.split, None)
+        self.assertEqual(vector_t.shape, (10,))
+
+        # simple matrix transpose, not distributed
+        simple_matrix = ht.zeros((2, 4))
+        simple_matrix_t = simple_matrix.transpose()
+        self.assertIsInstance(simple_matrix_t, ht.tensor)
+        self.assertEqual(simple_matrix_t.dtype, ht.float32)
+        self.assertEqual(simple_matrix_t.split, None)
+        self.assertEqual(simple_matrix_t.shape, (4, 2,))
+        self.assertEqual(simple_matrix_t._tensor__array.shape, (4, 2,))
+
+        # 4D array, not distributed, with given axis
+        array_4d = ht.zeros((2, 3, 4, 5))
+        array_4d_t = ht.transpose(array_4d, axes=(-1, 0, 2, 1))
+        self.assertIsInstance(array_4d_t, ht.tensor)
+        self.assertEqual(array_4d_t.dtype, ht.float32)
+        self.assertEqual(array_4d_t.split, None)
+        self.assertEqual(array_4d_t.shape, (5, 2, 4, 3,))
+        self.assertEqual(array_4d_t._tensor__array.shape, (5, 2, 4, 3,))
+
+        # vector transpose, distributed
+        vector_split = ht.arange(10, split=0)
+        vector_split_t = vector_split.T
+        self.assertIsInstance(vector_split_t, ht.tensor)
+        self.assertEqual(vector_split_t.dtype, ht.int32)
+        self.assertEqual(vector_split_t.split, 0)
+        self.assertEqual(vector_split_t.shape, (10,))
+        self.assertLessEqual(vector_split_t.lshape[0], 10)
+
+        # matrix transpose, distributed
+        matrix_split = ht.ones((10, 20,), split=1)
+        matrix_split_t = matrix_split.transpose()
+        self.assertIsInstance(matrix_split_t, ht.tensor)
+        self.assertEqual(matrix_split_t.dtype, ht.float32)
+        self.assertEqual(matrix_split_t.split, 0)
+        self.assertEqual(matrix_split_t.shape, (20, 10,))
+        self.assertLessEqual(matrix_split_t.lshape[0], 20)
+        self.assertEqual(matrix_split_t.lshape[1], 10)
+
+        # 4D array, distributed
+        array_4d_split = ht.ones((3, 4, 5, 6,), split=3)
+        array_4d_split_t = ht.transpose(array_4d_split, axes=(1, 0, 3, 2,))
+        self.assertIsInstance(array_4d_t, ht.tensor)
+        self.assertEqual(array_4d_split_t.dtype, ht.float32)
+        self.assertEqual(array_4d_split_t.split, 2)
+        self.assertEqual(array_4d_split_t.shape, (4, 3, 6, 5,))
+
+        self.assertEqual(array_4d_split_t.lshape[0], 4)
+        self.assertEqual(array_4d_split_t.lshape[1], 3)
+        self.assertLessEqual(array_4d_split_t.lshape[2], 6)
+        self.assertEqual(array_4d_split_t.lshape[3], 5)
+
+        # exceptions
+        with self.assertRaises(TypeError):
+            ht.transpose(1)
+        with self.assertRaises(ValueError):
+            ht.transpose(ht.zeros((2, 3,)), axes=1.0)
+        with self.assertRaises(ValueError):
+            ht.transpose(ht.zeros((2, 3,)), axes=(-1,))
+        with self.assertRaises(TypeError):
+            ht.zeros((2, 3,)).transpose(axes='01')
+        with self.assertRaises(TypeError):
+            ht.zeros((2, 3,)).transpose(axes=(0, 1.0))
+        with self.assertRaises(ValueError):
+            ht.zeros((2, 3,)).transpose(axes=(0, 3))
+
     def test_tril(self):
         local_ones = ht.ones((5,))
 


### PR DESCRIPTION
Resolves issue #28 

As of now the tensor is correctly transposed, respectively its axes are permuted, and the split axes of the tensor shifts along with the permutation.

A subsequent resplit of the tensor has NOT been implemented for two reasons:
1. It might not be what the programmer wants and what would be efficient for subsequent operations
2. Resplitting the tensor is a separate operation that is part of issue #9 

It might be desirable to introduce an additional parameter called e.g. resplit to the transpose signature as soon as #9 has been implemented.