### PR TITLE
150 Implement allclose()

### DIFF
--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -10,6 +10,7 @@ from . import tensor
 
 __all__ = [
     'all',
+    'allclose',
     'argmin',
     'clip',
     'copy',
@@ -80,6 +81,55 @@ def all(x, axis=None, out=None):
     # TODO: make me more numpy API complete. Issue #101
     return __reduce_op(x, lambda t, *args, **kwargs: t.byte().all(*args, **kwargs), MPI.LAND, axis, out=out)
 
+
+def allclose(x, y, rtol = 1e-05, atol = 1e-08, equal_nan = False):
+    """
+    Test whether two tensors are element-wise equal within a tolerance. Returns True if |x - y| <= atol + rtol * |y| for all elements of x and y, False otherwise
+
+    Parameters:
+    -----------
+
+    x : ht.tensor
+        First tensor to compare
+
+    y : ht.tensor
+        Second tensor to compare
+
+    atol: float, optional
+        Absolute tolerance. Default is 1e-08
+
+    rtol: float, optional
+        Relative tolerance (with respect to y). Default is 1e-05
+
+    equal_nan: bool, optional
+        Whether to compare NaN’s as equal. If True, NaN’s in a will be considered equal to NaN’s in b in the output array.
+
+    Returns:
+    --------
+    allclose : bool
+    True if the two tensors are equal within the given tolerance; False otherwise.
+
+    Examples:
+    ---------
+    >>> a = ht.float32([[2, 2], [2, 2]])
+    >>> ht.allclose(a,a)
+    True
+
+    >>> b = ht.float32([[2.00005,2.00005],[2.00005,2.00005]])
+    >>> ht.allclose(a,b)
+    False
+    >>> ht.allclose(a,b, atol=1e-04)
+    True
+
+    """
+
+    if not isinstance(x, tensor.tensor):
+        raise TypeError('Expected x to be a ht.tensor, but was {}'.format(type(x)))
+
+    if not isinstance(y, tensor.tensor):
+        raise TypeError('Expected y to be a ht.tensor, but was {}'.format(type(y)))
+
+    return torch.allclose(x._tensor__array, y._tensor__array, rtol, atol, equal_nan)
 
 def argmin(x, axis=None, out=None):
     """

--- a/heat/core/tensor.py
+++ b/heat/core/tensor.py
@@ -194,6 +194,45 @@ class tensor:
         """
         return operations.all(self, axis, out)
 
+    def allclose(self, other, rtol = 1e-05, atol = 1e-08, equal_nan = False):
+        """
+        Test whether self and other are element-wise equal within a tolerance. Returns True if |self - other| <= atol + rtol * |other| for all elements, False otherwise
+
+        Parameters:
+        -----------
+
+        other : ht.tensor
+            Input tensor to compare to
+
+        atol: float, optional
+            Absolute tolerance. Default is 1e-08
+
+        rtol: float, optional
+            Relative tolerance (with respect to y). Default is 1e-05
+
+        equal_nan: bool, optional
+            Whether to compare NaN’s as equal. If True, NaN’s in a will be considered equal to NaN’s in b in the output array.
+
+        Returns:
+        --------
+        allclose : bool
+        True if the two tensors are equal within the given tolerance; False otherwise.
+
+        Examples:
+        ---------
+        >>> a = ht.float32([[2, 2], [2, 2]])
+        >>> a.allclose(a)
+        True
+
+        >>> b = ht.float32([[2.00005,2.00005],[2.00005,2.00005]])
+        >>> a.allclose(b)
+        False
+        >>> a.allclose(b, atol=1e-04)
+        True
+
+        """
+        return operations.allclose(self, other, rtol, atol, equal_nan)
+
     def argmin(self, axis=None):
         """
         Returns the indices of the minimum values along an axis.

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -101,7 +101,7 @@ class TestOperations(unittest.TestCase):
 
     def test_sqrt(self):
         elements = 25
-        comparison = torch.arange(elements, dtype=torch.float64).sqrt()
+        comparison = ht.arange(elements, dtype=ht.float64).sqrt()
 
         # square roots of float32
         float32_tensor = ht.arange(elements, dtype=ht.float32)
@@ -109,7 +109,7 @@ class TestOperations(unittest.TestCase):
         self.assertIsInstance(float32_sqrt, ht.tensor)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_sqrt._tensor__array, comparison.type(torch.float32), 1e-06))
+        self.assertTrue(ht.allclose(float32_sqrt, comparison.astype(ht.float32), 1e-06))
 
         # square roots of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
@@ -117,7 +117,7 @@ class TestOperations(unittest.TestCase):
         self.assertIsInstance(float64_sqrt, ht.tensor)
         self.assertEqual(float64_sqrt.dtype, ht.float64)
         self.assertEqual(float64_sqrt.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_sqrt._tensor__array, comparison, 1e-06))
+        self.assertTrue(ht.allclose(float64_sqrt, comparison, 1e-06))
 
         # square roots of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
@@ -125,7 +125,7 @@ class TestOperations(unittest.TestCase):
         self.assertIsInstance(int32_sqrt, ht.tensor)
         self.assertEqual(int32_sqrt.dtype, ht.float64)
         self.assertEqual(int32_sqrt.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int32_sqrt._tensor__array, comparison, 1e-06))
+        self.assertTrue(ht.allclose(int32_sqrt, comparison, 1e-06))
 
         # square roots of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
@@ -133,7 +133,7 @@ class TestOperations(unittest.TestCase):
         self.assertIsInstance(int64_sqrt, ht.tensor)
         self.assertEqual(int64_sqrt.dtype, ht.float64)
         self.assertEqual(int64_sqrt.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_sqrt._tensor__array, comparison, 1e-06))
+        self.assertTrue(ht.allclose(int64_sqrt, comparison, 1e-06))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -143,35 +143,35 @@ class TestOperations(unittest.TestCase):
 
     def test_sqrt_method(self):
         elements = 25
-        comparison = torch.arange(elements, dtype=torch.float64).sqrt()
+        comparison = ht.arange(elements, dtype=ht.float64).sqrt()
 
         # square roots of float32
         float32_sqrt = ht.arange(elements, dtype=ht.float32).sqrt()
         self.assertIsInstance(float32_sqrt, ht.tensor)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_sqrt._tensor__array, comparison.type(torch.float32), 1e-05))
+        self.assertTrue(ht.allclose(float32_sqrt, comparison.astype(ht.float32), 1e-05))
 
         # square roots of float64
         float64_sqrt = ht.arange(elements, dtype=ht.float64).sqrt()
         self.assertIsInstance(float64_sqrt, ht.tensor)
         self.assertEqual(float64_sqrt.dtype, ht.float64)
         self.assertEqual(float64_sqrt.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_sqrt._tensor__array, comparison, 1e-05))
+        self.assertTrue(ht.allclose(float64_sqrt, comparison, 1e-05))
 
         # square roots of ints, automatic conversion to intermediate floats
         int32_sqrt = ht.arange(elements, dtype=ht.int32).sqrt()
         self.assertIsInstance(int32_sqrt, ht.tensor)
         self.assertEqual(int32_sqrt.dtype, ht.float64)
         self.assertEqual(int32_sqrt.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int32_sqrt._tensor__array, comparison, 1e-05))
+        self.assertTrue(ht.allclose(int32_sqrt, comparison, 1e-05))
 
         # square roots of longs, automatic conversion to intermediate floats
         int64_sqrt = ht.arange(elements, dtype=ht.int64).sqrt()
         self.assertIsInstance(int64_sqrt, ht.tensor)
         self.assertEqual(int64_sqrt.dtype, ht.float64)
         self.assertEqual(int64_sqrt.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_sqrt._tensor__array, comparison, 1e-05))
+        self.assertTrue(ht.allclose(int64_sqrt, comparison, 1e-05))
 
         # check exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -143,6 +143,18 @@ class TestOperations(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.ones(array_len).all(axis='bad_axis_type')
 
+    def test_allclose(self):
+        a = ht.float32([[2, 2], [2, 2]])
+        b = ht.float32([[2.00005, 2.00005], [2.00005, 2.00005]])
+
+        self.assertFalse(ht.allclose(a, b))
+        self.assertTrue(ht.allclose(a, b, atol = 1e-04))
+        self.assertTrue(ht.allclose(a,b, rtol = 1e-04))
+
+        with self.assertRaises(TypeError):
+            ht.allclose(a, (2,2,2,2))
+
+
     def test_argmin(self):
         data = ht.float32([
             [1, 2, 3],


### PR DESCRIPTION
Concerns #150 
Tunnels torch.allclose after check if input type is heat tensor, thus working in analogy to the numpy.allclose() (https://pytorch.org/docs/stable/torch.html#torch.allclose)
I already changed the syntax now for the sqrt tests to work on ht.allclose instead of torch.allclose