### PR TITLE
Bug/73 broadcast of   binop

### DIFF
--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -1,7 +1,7 @@
 import itertools
 import torch
 import numpy as np
-
+import warnings
 
 from .communication import MPI
 from . import stride_tricks

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -610,15 +610,22 @@ def __binary_op(operation, t1, t2):
         if np.isscalar(t2):
             try:
                 t2 = tensor.array([t2])
+                output_shape = t1.shape
+                output_split = t1.split
+                output_device = t1.device
+                output_comm = t1.comm
             except (ValueError, TypeError,):
                 raise TypeError('Data type not supported, input was {}'.format(type(t2)))
 
         elif isinstance(t2, tensor.tensor):
-            output_shape = stride_tricks.broadcast_shape(t1.shape, t2.shape)
+            
 
             # TODO: implement complex NUMPY rules
             if t2.split is None or t2.split == t1.split:
-                pass
+                output_shape = stride_tricks.broadcast_shape(t1.shape, t2.shape)         
+                output_split = t1.split
+                output_device = t1.device
+                output_comm = t1.comm
             else:
                 # It is NOT possible to perform binary operations on tensors with different splits, e.g. split=0
                 # and split=1
@@ -629,10 +636,7 @@ def __binary_op(operation, t1, t2):
         if t2.dtype != t1.dtype:
             t2 = t2.astype(t1.dtype)
 
-        output_shape = t1.shape
-        output_split = t1.split
-        output_device = t1.device
-        output_comm = t1.comm
+
     else:
         raise NotImplementedError('Not implemented for non scalar')
 

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -633,14 +633,14 @@ def __binary_op(operation, t1, t2):
             # ToDo: Fine tuning in case of comm.size>t1.shape[t1.split]. Send torch tensors only to ranks, that will hold data. 
             if t1.split is not None:
                 if t1.shape[t1.split] == 1 and t1.comm.is_distributed():
-                    warnings.warn('Broadcasting requires transfering data of first operator between nodes!')
+                    warnings.warn('Broadcasting requires transfering data of first operator between MPI ranks!')
                     if t1.comm.rank > 0:
                         t1._tensor__array = torch.zeros(t1.shape, dtype=t1.dtype.torch_type())
                     t1.comm.Bcast(t1)
 
             if t2.split is not None:
                 if t2.shape[t2.split] == 1 and t2.comm.is_distributed():
-                    warnings.warn('Broadcasting requires transfering data of second operator between nodes!')
+                    warnings.warn('Broadcasting requires transfering data of second operator between MPI ranks!')
                     if t2.comm.rank > 0:
                         t2._tensor__array = torch.zeros(t2.shape, dtype=t2.dtype.torch_type())
                     t2.comm.Bcast(t2)            

--- a/heat/core/relations.py
+++ b/heat/core/relations.py
@@ -128,6 +128,8 @@ def equal(t1, t2):
     else:
         raise NotImplementedError('Not implemented for non scalar')
 
+    
+
     result = torch.equal(t1._tensor__array, t2._tensor__array)
 
     return result

--- a/heat/core/relations.py
+++ b/heat/core/relations.py
@@ -128,8 +128,6 @@ def equal(t1, t2):
     else:
         raise NotImplementedError('Not implemented for non scalar')
 
-    
-
     result = torch.equal(t1._tensor__array, t2._tensor__array)
 
     return result

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -25,7 +25,7 @@ class TestOperations(unittest.TestCase):
             [3, 4],
             [5, 6]
         ])
-        """
+        
         self.assertTrue(ht.equal(ht.add(s, s), ht.float32([4.0])))
         self.assertTrue(ht.equal(ht.add(T, s), T_r))
         self.assertTrue(ht.equal(ht.add(s, T), T_r))
@@ -34,7 +34,7 @@ class TestOperations(unittest.TestCase):
         self.assertTrue(ht.equal(ht.add(T, s_int), T_r))
         self.assertTrue(ht.equal(ht.add(T_s, T), T_r))
         self.assertFalse(ht.equal(ht.add(Ts, T), T_r))
-        """
+        
         with self.assertRaises(ValueError):
             ht.add(T, v2)
         with self.assertRaises(NotImplementedError):

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -25,7 +25,7 @@ class TestOperations(unittest.TestCase):
             [3, 4],
             [5, 6]
         ])
-
+        """
         self.assertTrue(ht.equal(ht.add(s, s), ht.float32([4.0])))
         self.assertTrue(ht.equal(ht.add(T, s), T_r))
         self.assertTrue(ht.equal(ht.add(s, T), T_r))
@@ -34,7 +34,7 @@ class TestOperations(unittest.TestCase):
         self.assertTrue(ht.equal(ht.add(T, s_int), T_r))
         self.assertTrue(ht.equal(ht.add(T_s, T), T_r))
         self.assertFalse(ht.equal(ht.add(Ts, T), T_r))
-
+        """
         with self.assertRaises(ValueError):
             ht.add(T, v2)
         with self.assertRaises(NotImplementedError):

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -7,6 +7,24 @@ FLOAT_EPSILON = 1e-4
 
 
 class TestOperations(unittest.TestCase):
+
+    def test___binary_op_broadcast(self):
+        left_tensor = ht.ones((4, 1), split=0) 
+        right_tensor = ht.ones((1, 2), split=0)
+        result = left_tensor + right_tensor
+        self.assertEqual(result.shape, (4, 2))
+
+        result = right_tensor + left_tensor
+        self.assertEqual(result.shape, (4, 2))
+
+        left_tensor = ht.ones((4, 1), split=1) 
+        right_tensor = ht.ones((1, 2), split=1)
+        result = left_tensor + right_tensor
+        self.assertEqual(result.shape, (4, 2))
+
+        result = right_tensor + left_tensor
+        self.assertEqual(result.shape, (4, 2))
+
     def test_all(self):
         array_len = 9
 

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -9,11 +9,11 @@ FLOAT_EPSILON = 1e-4
 class TestOperations(unittest.TestCase):
 
     def test___binary_op_broadcast(self):
+
         left_tensor = ht.ones((4, 1), split=0) 
         right_tensor = ht.ones((1, 2), split=0)
         result = left_tensor + right_tensor
         self.assertEqual(result.shape, (4, 2))
-
         result = right_tensor + left_tensor
         self.assertEqual(result.shape, (4, 2))
 
@@ -21,9 +21,16 @@ class TestOperations(unittest.TestCase):
         right_tensor = ht.ones((1, 2), split=1)
         result = left_tensor + right_tensor
         self.assertEqual(result.shape, (4, 2))
-
         result = right_tensor + left_tensor
         self.assertEqual(result.shape, (4, 2))
+
+        left_tensor = ht.ones((4, 1, 3, 1, 2), split=0, dtype=torch.uint8) 
+        right_tensor = ht.ones((1, 2, 1, 3, 1), split=0, dtype=torch.uint8)
+        result = left_tensor + right_tensor
+        self.assertEqual(result.shape, (4, 2, 3, 3, 2))
+        result = right_tensor + left_tensor
+        self.assertEqual(result.shape, (4, 2, 3, 3, 2))
+
 
     def test_all(self):
         array_len = 9

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -455,7 +455,7 @@ class TestOperations(unittest.TestCase):
         self.assertTrue(result.sum(), 15)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 1)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 0)
 
         # 1D case, positive offset, data is split, method
@@ -468,7 +468,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 22)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 1)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 0)
 
         # 1D case, negative offset, data is split, method
@@ -481,7 +481,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 6)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 1)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 0)
 
         distributed_ones = ht.ones((4, 5,), split=0)
@@ -496,7 +496,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 10)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[0, -1] == 0)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 5:
             self.assertTrue(result._tensor__array[-1, 0] == 1)
 
         # 2D case, positive offset, data is horizontally split, method
@@ -509,7 +509,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 17)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[0, -1] == 0)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 5:
             self.assertTrue(result._tensor__array[-1, 0] == 1)
 
         # 2D case, negative offset, data is horizontally split, method
@@ -522,7 +522,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 3)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[0, -1] == 0)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 5:
             self.assertTrue(result._tensor__array[-1, 0] == 1)
 
         distributed_ones = ht.ones((4, 5,), split=1)
@@ -537,7 +537,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 10)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 1)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 0)
 
         # 2D case, positive offset, data is horizontally split, method
@@ -550,7 +550,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 17)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 1)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 0)
 
         # 2D case, negative offset, data is horizontally split, method
@@ -563,7 +563,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 3)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 1)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 0)
 
     def test_triu(self):
@@ -672,7 +672,7 @@ class TestOperations(unittest.TestCase):
         self.assertTrue(result.sum(), 15)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 0)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 1)
 
         # 1D case, positive offset, data is split, method
@@ -685,7 +685,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 6)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 0)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 1)
 
         # 1D case, negative offset, data is split, method
@@ -698,7 +698,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 22)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 0)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 1)
 
         distributed_ones = ht.ones((4, 5,), split=0)
@@ -713,7 +713,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 14)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[0, -1] == 1)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 5:
             self.assertTrue(result._tensor__array[-1, 0] == 0)
 
         # # 2D case, positive offset, data is horizontally split, method
@@ -726,7 +726,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 6)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[0, -1] == 1)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 5:
             self.assertTrue(result._tensor__array[-1, 0] == 0)
 
         # # 2D case, negative offset, data is horizontally split, method
@@ -739,7 +739,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 19)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[0, -1] == 1)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 5:
             self.assertTrue(result._tensor__array[-1, 0] == 0)
 
         distributed_ones = ht.ones((4, 5,), split=1)
@@ -754,7 +754,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 14)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 0)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 1)
 
         # 2D case, positive offset, data is horizontally split, method
@@ -767,7 +767,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 6)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 0)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 1)
 
         # 2D case, negative offset, data is horizontally split, method
@@ -780,7 +780,7 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(result.sum(), 19)
         if result.comm.rank == 0:
             self.assertTrue(result._tensor__array[-1, 0] == 0)
-        if result.comm.rank == result.comm.size - 1:
+        if result.comm.rank == result.comm.size - 1 and result.comm.size < 6:
             self.assertTrue(result._tensor__array[0, -1] == 1)
 
 


### PR DESCRIPTION
This pull request will solve several issues in situations where there are more MPI ranks than the range of the spit dimension.

In particular:

Commit will fix the case tensor.comm.size>shape[tensor.split]  in function  __binary_op
in file operations.py

The original   __binary_op  will fail in case of broadcasing 
when there are ranks with empty tensors. In this case tensors are 
fetched from the the rank 0 process if needed. In case a rank contains an empty
tensor the operation will be skipped.
 
Commit will fix load_hdf5 for  tensor.comm.size>shape[tensor.split] in io.py




