### PR TITLE
Bundled coverage report for multiple mpi runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,13 @@ cache:
   - $HOME/virtualenv/python3.5/share
 before_install:
   - sudo apt-get install -y libopenmpi-dev openmpi-bin libhdf5-dev libnetcdf-dev
-  - pip install codecov pytest pytest-cov
+  - pip install codecov pytest coverage
 install:
   - pip install . -e .[hdf5] .[netcdf]
 script:
-  - mpirun -np 2 pytest
-  - mpirun pytest --cov=heat heat/
+  - for i in {1..4}; do mpirun -np $i coverage run --source=heat --parallel-mode -m pytest heat/; done
+  - coverage combine
+  - coverage report
 after_success:
   - codecov
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ before_install:
 install:
   - pip install . -e .[hdf5] .[netcdf]
 script:
+  # Running mpi with 1 - 4 processes and generating a unique coverage report for each process in each run (10 in total)
   - for i in {1..4}; do mpirun -np $i coverage run --source=heat --parallel-mode -m pytest heat/; done
+  # Combining the unique coverage reports into one file (.coverage)
   - coverage combine
+  # Displaying the coverage results in the travis log, not necessary for build process
   - coverage report
 after_success:
   - codecov


### PR DESCRIPTION
This pull request targets issue #200.

With these changes, pytest is run with mpi on 1 to 4 different processes. Each process in each run creates a unique coverage report. This in to total 10 coverage reports are bundled after finishing all test.

To achieve this behaviour I had to switch from pytest-cov to coverage.py to create the reports. 
pytest-cov was performing inconsistently and dindn't create the unique named reports for each process.
I don't see and pitfalls in changing to coverage.py.