### PR TITLE
Hotfix for failing test on docker build

### DIFF
--- a/heat/core/linalg.py
+++ b/heat/core/linalg.py
@@ -63,7 +63,7 @@ def transpose(a, axes=None):
 
         return dndarray.DNDarray(transposed_data, transposed_shape, a.dtype, transposed_split, a.device, a.comm)
     # if not possible re- raise any torch exception as ValueError
-    except RuntimeError as exception:
+    except Exception as exception:
         raise ValueError(str(exception))
 
 


### PR DESCRIPTION
The most recent builds of travis were all failing because of a failing docker run.
This was caused by a rather weird behavior:
Locally calling transpose with an out of bound dimension resulted in an RuntimeError, but on the Docker this resulted in an IndexError and was therefore unexpected.

Because the transpose function wants to reraise all torch errors as a ValueError anyways, I changed it to catch all Exceptions not just the RuntimeErrors.