### PR TITLE
Implemented possibility to set and modify default communicator

### DIFF
--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -538,5 +538,62 @@ class MPICommunication(Communication):
 MPI_WORLD = MPICommunication()
 MPI_SELF = MPICommunication(MPI.COMM_SELF)
 
+# set the default communicator to be MPI_WORLD
+__default_comm = MPI_WORLD
+
+
+def get_comm():
+    """
+    Retrieves the currently globally set default communication.
+
+    Returns
+    -------
+    comm : Communication
+        The currently set default communication.
+    """
+    return __default_comm
+
+
+def sanitize_comm(comm):
+    """
+    Sanitizes a device or device identifier, i.e. checks whether it is already an instance of Device or a string with
+    known device identifier and maps it to a proper Device.
+
+    Parameters
+    ----------
+    device : str, Device or None
+        The device to be sanitized
+
+    Returns
+    -------
+    sanitized_device : Device
+        The matching Device instance
+
+    Raises
+    ------
+    ValueError
+        If the given device id is not recognized
+    """
+    if comm is None:
+        return get_comm()
+    elif isinstance(comm, Communication):
+        return comm
+
+    raise TypeError('Unknown communication, must be instance of {}'.format(Communication))
+
+
+def use_comm(comm=None):
+    """
+    Sets the globally used default communication.
+
+    Parameters
+    ----------
+    device : Communication or None
+        The communication to be set
+    """
+    global __default_comm
+    __default_comm = sanitize_comm(comm)
+
+
 # tensor is imported at the very end to break circular dependency
 from . import dndarray

--- a/heat/core/devices.py
+++ b/heat/core/devices.py
@@ -5,9 +5,9 @@ from .communication import MPI_WORLD
 
 __all__ = [
     'cpu',
-    'get_backend',
+    'get_device',
     'sanitize_device',
-    'use_backend'
+    'use_device'
 ]
 
 
@@ -81,7 +81,7 @@ if torch.cuda.device_count() > 0:
     __all__.append('gpu')
 
 
-def get_backend():
+def get_device():
     """
     Retrieves the currently globally set default device.
 
@@ -114,7 +114,7 @@ def sanitize_device(device):
         If the given device id is not recognized
     """
     if device is None:
-        return get_backend()
+        return get_device()
 
     if isinstance(device, Device):
         return device
@@ -125,7 +125,7 @@ def sanitize_device(device):
         raise ValueError('Unknown device, must be one of {}'.format(', '.join(__device_mapping.keys())))
 
 
-def use_backend(device=None):
+def use_device(device=None):
     """
     Sets the globally used default device.
 

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -1,6 +1,6 @@
 import torch
 
-from .communication import MPI_WORLD
+from . import communication
 from . import devices
 from . import dndarray
 from . import types
@@ -14,7 +14,7 @@ def set_gseed(seed):
     torch.manual_seed(seed)
 
 
-def uniform(low=0.0, high=1.0, size=None, device=None, comm=MPI_WORLD):
+def uniform(low=0.0, high=1.0, size=None, device=None, comm=None):
     # TODO: comment me
     # TODO: test me
     # TODO: make me splitable
@@ -23,12 +23,13 @@ def uniform(low=0.0, high=1.0, size=None, device=None, comm=MPI_WORLD):
         size = (1,)
 
     device = devices.sanitize_device(device)
+    comm = communication.sanitize_comm(comm)
     data = torch.rand(*size, device=device.torch_device) * (high - low) + low
 
     return dndarray.DNDarray(data, size, types.float32, None, device, comm)
 
 
-def randn(*args, split=None, device=None, comm=MPI_WORLD):
+def randn(*args, split=None, device=None, comm=None):
     """
     Returns a tensor filled with random numbers from a standard normal distribution with zero mean and variance of one.
 
@@ -81,6 +82,7 @@ def randn(*args, split=None, device=None, comm=MPI_WORLD):
 
     # compose the local tensor
     device = devices.sanitize_device(device)
+    comm = communication.sanitize_comm(comm)
     data = torch.randn(args, device=device.torch_device)
 
     return dndarray.DNDarray(data, gshape, types.canonical_heat_type(data.dtype), split, device, comm)

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -148,6 +148,26 @@ class TestCommunication(unittest.TestCase):
         self.assertTrue((both_non_contiguous_data._DNDarray__array == both_non_contiguous_out._DNDarray__array).all())
         self.assertFalse(both_non_contiguous_out._DNDarray__array.is_contiguous())
 
+    def test_default_comm(self):
+        # default comm is world
+        a = ht.zeros((4, 5,))
+        self.assertIs(ht.get_comm(), ht.MPI_WORLD)
+        self.assertIs(a.comm, ht.MPI_WORLD)
+
+        # we can set a new comm that is being used for new allocation, old are not affected
+        ht.use_comm(ht.MPI_SELF)
+        b = ht.zeros((4, 5,))
+        self.assertIs(ht.get_comm(), ht.MPI_SELF)
+        self.assertIs(b.comm, ht.MPI_SELF)
+        self.assertIsNot(a.comm, ht.MPI_SELF)
+
+        # reset the comm
+        ht.use_comm(ht.MPI_WORLD)
+
+        # test for proper sanitation
+        with self.assertRaises(TypeError):
+            ht.use_comm('1')
+
     def test_allgather(self):
         # contiguous data
         data = ht.ones((1, 7,))

--- a/heat/core/tests/test_devices.py
+++ b/heat/core/tests/test_devices.py
@@ -5,7 +5,7 @@ import heat as ht
 
 class TestDevices(unittest.TestCase):
     def test_get_default_device(self):
-        self.assertIs(ht.get_backend(), ht.cpu)
+        self.assertIs(ht.get_device(), ht.cpu)
 
     def test_sanitize_device(self):
         self.assertIs(ht.sanitize_device('cpu'), ht.cpu)
@@ -20,14 +20,14 @@ class TestDevices(unittest.TestCase):
             self.assertIs(ht.sanitize_device(1), ht.cpu)
 
     def test_set_default_device(self):
-        ht.use_backend('cpu')
-        self.assertIs(ht.get_backend(), ht.cpu)
-        ht.use_backend(ht.cpu)
-        self.assertIs(ht.get_backend(), ht.cpu)
-        ht.use_backend(None)
-        self.assertIs(ht.get_backend(), ht.cpu)
+        ht.use_device('cpu')
+        self.assertIs(ht.get_device(), ht.cpu)
+        ht.use_device(ht.cpu)
+        self.assertIs(ht.get_device(), ht.cpu)
+        ht.use_device(None)
+        self.assertIs(ht.get_device(), ht.cpu)
 
         with self.assertRaises(ValueError):
-            ht.use_backend('fpu')
+            ht.use_device('fpu')
         with self.assertRaises(ValueError):
-            ht.use_backend(1)
+            ht.use_device(1)

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -25,8 +25,8 @@ import collections
 import numpy as np
 import torch
 
+from . import communication
 from . import devices
-from .communication import MPI_WORLD
 
 
 __all__ = [
@@ -61,7 +61,7 @@ __all__ = [
 
 class generic(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def __new__(cls, *value, device=None, comm=MPI_WORLD):
+    def __new__(cls, *value, device=None, comm=None):
         try:
             torch_type = cls.torch_type()
         except TypeError:
@@ -83,7 +83,8 @@ class generic(metaclass=abc.ABCMeta):
             # re-raise the exception to be consistent with numpy's exception interface
             raise ValueError(str(exception))
 
-        # sanitize the input device type
+        # sanitize the distributed processing flags
+        comm = communication.sanitize_comm(comm)
         device = devices.sanitize_device(device)
 
         return dndarray.DNDarray(array, tuple(array.shape), cls, split=None, device=device, comm=comm)

--- a/scripts/tutorial.ipynb
+++ b/scripts/tutorial.ipynb
@@ -704,7 +704,7 @@
     }
    ],
    "source": [
-    "ht.zeros((3,4,), device='gpu')"
+    "ht.zeros((3, 4,), device='gpu')"
    ]
   },
   {
@@ -733,8 +733,8 @@
     }
    ],
    "source": [
-    "a = ht.zeros((3,4,), device='gpu')\n",
-    "b = ht.ones((3,4,), device='gpu')\n",
+    "a = ht.zeros((3, 4,), device='gpu')\n",
+    "b = ht.ones((3, 4,), device='gpu')\n",
     "a + b"
    ]
   },
@@ -753,17 +753,17 @@
     {
      "ename": "RuntimeError",
      "evalue": "expected type torch.FloatTensor but got torch.cuda.FloatTensor",
-     "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mRuntimeError\u001b[0m                                  Traceback (most recent call last)\n",
       "\u001b[0;31mRuntimeError\u001b[0m: expected type torch.FloatTensor but got torch.cuda.FloatTensor"
-     ]
+     ],
+     "output_type": "error"
     }
    ],
    "source": [
-    "a = ht.full((3,4,), 4, device='cpu')\n",
-    "b = ht.ones((3,4,), device='gpu')\n",
+    "a = ht.full((3, 4,), 4, device='cpu')\n",
+    "b = ht.ones((3, 4,), device='gpu')\n",
     "a + b"
    ]
   },
@@ -793,7 +793,7 @@
     }
    ],
    "source": [
-    "a = ht.full((3,4,), 4, device='gpu')\n",
+    "a = ht.full((3, 4,), 4, device='gpu')\n",
     "a.cpu()"
    ]
   },
@@ -810,7 +810,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ht.use_backend('gpu')"
+    "ht.use_device('gpu')"
    ]
   },
   {


### PR DESCRIPTION
Resolves issue #263 

Allows to get, set and modify the default communicator for DNDarrays. Adjusted factories to use the default communicator now.