### PR TITLE
Features/37 minimum

### DIFF
--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -11,6 +11,7 @@ from . import types
 
 __all__ = []
 
+
 def __binary_op(operation, t1, t2):
     """
     Generic wrapper for element-wise binary operations of two operands (either can be tensor or scalar).
@@ -99,7 +100,7 @@ def __binary_op(operation, t1, t2):
                     warnings.warn('Broadcasting requires transferring data of second operator between MPI ranks!')
                     if t2.comm.rank > 0:
                         t2._DNDarray__array = torch.zeros(t2.shape, dtype=t2.dtype.torch_type())
-                    t2.comm.Bcast(t2) 
+                    t2.comm.Bcast(t2)
 
         else:
             raise TypeError('Only tensors and numeric scalars are supported, but input was {}'.format(type(t2)))
@@ -110,7 +111,6 @@ def __binary_op(operation, t1, t2):
     else:
         raise NotImplementedError('Not implemented for non scalar')
 
-
     promoted_type = types.promote_types(t1.dtype, t2.dtype).torch_type()
     if t1.split is not None:
         if len(t1.lshape) > t1.split and t1.lshape[t1.split] == 0:
@@ -118,7 +118,7 @@ def __binary_op(operation, t1, t2):
         else:
             result = operation(t1._DNDarray__array.type(promoted_type), t2._DNDarray__array.type(promoted_type))
     elif t2.split is not None:
-        
+
         if len(t2.lshape) > t2.split and t2.lshape[t2.split] == 0:
             result = t2._DNDarray__array.type(promoted_type)
         else:

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -604,7 +604,6 @@ def minimum(x1, x2, out=None, **kwargs):
     x._DNDarray__split = x1.split  # assumes x1.split = x2.split
     x._DNDarray__device = x1.device
     x._DNDarray__comm = x1.comm
-<<<<<<< HEAD
 
     # If distributed, collect local results
     if x.split is not None:
@@ -633,20 +632,6 @@ def minimum(x1, x2, out=None, **kwargs):
 
     # if not distributed, write to out through __reduce_op()
     result_l = operations.__reduce_op(x, local_min, MPI_MINIMUM, axis=0, out=out)
-=======
-    result_l = operations.__reduce_op(x, local_min, MPI_MINIMUM, axis = 0, out = None)
-    
-    #If distributed, gather local results into global one
-    if x1.split is not None or x2.split is not None:
-        split = None
-        if x.comm.is_distributed():
-            output_gshape = stride_tricks.broadcast_shape(x1.gshape, x2.gshape)
-            result = factories.empty(output_gshape)
-            x.comm.Allgather(result_l, result)
-            result._DNDarray__split = split                
-            return result
-            
->>>>>>> 2b8d0672201ad2dd7c18ee34a2faa88df34ab382
     return result_l
 
 

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -545,10 +545,12 @@ def minimum(x1, x2, out=None, **kwargs):
     A location into which the result is stored. If provided, it must have a shape that the inputs broadcast to. If not provided or None, a freshly-allocated array is returned. A tuple (possible only as a keyword argument) must have length equal to the number of outputs.
     '''
 
+    # Broadcasting
     output_shape = stride_tricks.broadcast_shape(x1.lshape, x2.lshape)
-    bc_x1 = x1._DNDarray__array.expand(output_shape) if not (x1.shape == output_shape) else x1._DNDarray__array
-    bc_x2 = x2._DNDarray__array.expand(output_shape) if not (x2.shape == output_shape) else x2._DNDarray__array
+    bc_x1 = x1._DNDarray__array.expand(output_shape) if not (x1.lshape == output_shape) else x1._DNDarray__array
+    bc_x2 = x2._DNDarray__array.expand(output_shape) if not (x2.lshape == output_shape) else x2._DNDarray__array
 
+    # Concatenating (expanded) x1 and x2 into x to satisfy __reduce_op()
     x = factories.empty((2,) + output_shape)
     x._DNDarray__array = torch.cat((bc_x1, bc_x2)).reshape((2,) + output_shape)
     # TODO: what happens if e.g. x1 and x2 have different splits?
@@ -556,8 +558,7 @@ def minimum(x1, x2, out=None, **kwargs):
     x._DNDarray__device = x1.device
     x._DNDarray__comm = x1.comm
 
-    result = operations.__reduce_op(x, local_min, MPI_MINIMUM, axis=0, out=out)
-    return result
+    return operations.__reduce_op(x, local_min, MPI_MINIMUM, axis=0, out=out)
 
 
 def local_min(*args, **kwargs):

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -532,17 +532,63 @@ def min(x, axis=None, out=None, keepdim=None):
 
 def minimum(x1, x2, out=None, **kwargs):
     '''
-    Element-wise minimum of array elements.
+    Compares two tensors and returns a new tensor containing the element-wise minima. 
+    TODO: If one of the elements being compared is a NaN, then that element is returned. If both elements are NaNs then the first is returned. 
+    The latter distinction is important for complex NaNs, which are defined as at least one of the real or imaginary parts being a NaN. The net effect is that NaNs are propagated.
 
-    Compare two arrays and returns a new array containing the element-wise minima. If one of the elements being compared is a NaN, then that element is returned. If both elements are NaNs then the first is returned. The latter distinction is important for complex NaNs, which are defined as at least one of the real or imaginary parts being a NaN. The net effect is that NaNs are propagated.
     Parameters:
+    -----------
 
-    x1, x2 : array_like
+    x1, x2 : ht.DNDarray
+            The tensors containing the elements to be compared. They must have the same shape, or shapes that can be broadcast to a single shape.
+            For broadcasting semantics, see: https://pytorch.org/docs/stable/notes/broadcasting.html
 
-    The arrays holding the elements to be compared. They must have the same shape, or shapes that can be broadcast to a single shape.
-    out : ndarray, None, or tuple of ndarray and None, optional
+    out : ht.DNDarray or None, optional
+        A location into which the result is stored. If provided, it must have a shape that the inputs broadcast to. 
+        If not provided or None, a freshly-allocated tensor is returned.
 
-    A location into which the result is stored. If provided, it must have a shape that the inputs broadcast to. If not provided or None, a freshly-allocated array is returned. A tuple (possible only as a keyword argument) must have length equal to the number of outputs.
+    Returns:
+    --------
+
+    minimum: ht.DNDarray
+            Element-wise minimum of the two input tensors.
+
+    Examples:
+    ---------          
+    >>> import heat as ht
+    >>> import torch
+    >>> torch.manual_seed(1)
+    <torch._C.Generator object at 0x105c50b50>
+
+    >>> a = ht.random.randn(3,4)
+    >>> a
+    tensor([[-0.1955, -0.9656,  0.4224,  0.2673],
+        [-0.4212, -0.5107, -1.5727, -0.1232],
+        [ 3.5870, -1.8313,  1.5987, -1.2770]])
+
+    >>> b = ht.random.randn(3,4)
+    >>> b
+    tensor([[ 0.8310, -0.2477, -0.8029,  0.2366],
+        [ 0.2857,  0.6898, -0.6331,  0.8795],
+        [-0.6842,  0.4533,  0.2912, -0.8317]])
+
+    >>> ht.minimum(a,b)
+    tensor([[-0.1955, -0.9656, -0.8029,  0.2366],
+        [-0.4212, -0.5107, -1.5727, -0.1232],
+        [-0.6842, -1.8313,  0.2912, -1.2770]])
+
+    >>> c = ht.random.randn(1,4)
+    >>> c
+    tensor([[-1.6428,  0.9803, -0.0421, -0.8206]])
+
+    >>> ht.minimum(a,c)
+    tensor([[-1.6428, -0.9656, -0.0421, -0.8206],
+        [-1.6428, -0.5107, -1.5727, -0.8206],
+        [-1.6428, -1.8313, -0.0421, -1.2770]])
+
+    >>> d = ht.random.randn(3,4,5)
+    >>> ht.minimum(a,d)
+    ValueError: operands could not be broadcast, input shapes (3, 4) (3, 4, 5)
     '''
 
     # Broadcasting

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -596,7 +596,8 @@ def minimum(x1, x2, out=None, **kwargs):
     bc_x1 = x1._DNDarray__array.expand(output_shape) if not (x1.lshape == output_shape) else x1._DNDarray__array
     bc_x2 = x2._DNDarray__array.expand(output_shape) if not (x2.lshape == output_shape) else x2._DNDarray__array
 
-    # Concatenating (expanded) x1 and x2 into x to satisfy __reduce_op()
+    # Concatenating (expanded) x1 and x2 into x to satisfy __reduce_op(),
+    # then enforce axis = 0 for torch.min()
     x = factories.empty((2,) + output_shape)
     x._DNDarray__array = torch.cat((bc_x1, bc_x2)).reshape((2,) + output_shape)
     # TODO: what happens if e.g. x1 and x2 have different splits?

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -533,7 +533,7 @@ def min(x, axis=None, out=None, keepdim=None):
 def minimum(x1, x2, out=None, **kwargs):
     '''
     Compares two tensors and returns a new tensor containing the element-wise minima. 
-    TODO: If one of the elements being compared is a NaN, then that element is returned. If both elements are NaNs then the first is returned. 
+    If one of the elements being compared is a NaN, then that element is returned. TODO: Check this: If both elements are NaNs then the first is returned. 
     The latter distinction is important for complex NaNs, which are defined as at least one of the real or imaginary parts being a NaN. The net effect is that NaNs are propagated.
 
     Parameters:
@@ -563,19 +563,19 @@ def minimum(x1, x2, out=None, **kwargs):
     >>> a = ht.random.randn(3,4)
     >>> a
     tensor([[-0.1955, -0.9656,  0.4224,  0.2673],
-        [-0.4212, -0.5107, -1.5727, -0.1232],
-        [ 3.5870, -1.8313,  1.5987, -1.2770]])
+            [-0.4212, -0.5107, -1.5727, -0.1232],
+            [ 3.5870, -1.8313,  1.5987, -1.2770]])
 
     >>> b = ht.random.randn(3,4)
     >>> b
     tensor([[ 0.8310, -0.2477, -0.8029,  0.2366],
-        [ 0.2857,  0.6898, -0.6331,  0.8795],
-        [-0.6842,  0.4533,  0.2912, -0.8317]])
+            [ 0.2857,  0.6898, -0.6331,  0.8795],
+            [-0.6842,  0.4533,  0.2912, -0.8317]])
 
     >>> ht.minimum(a,b)
     tensor([[-0.1955, -0.9656, -0.8029,  0.2366],
-        [-0.4212, -0.5107, -1.5727, -0.1232],
-        [-0.6842, -1.8313,  0.2912, -1.2770]])
+            [-0.4212, -0.5107, -1.5727, -0.1232],
+            [-0.6842, -1.8313,  0.2912, -1.2770]])
 
     >>> c = ht.random.randn(1,4)
     >>> c
@@ -583,8 +583,18 @@ def minimum(x1, x2, out=None, **kwargs):
 
     >>> ht.minimum(a,c)
     tensor([[-1.6428, -0.9656, -0.0421, -0.8206],
-        [-1.6428, -0.5107, -1.5727, -0.8206],
-        [-1.6428, -1.8313, -0.0421, -1.2770]])
+            [-1.6428, -0.5107, -1.5727, -0.8206],
+            [-1.6428, -1.8313, -0.0421, -1.2770]])
+
+    >>> b.__setitem__((0,1), ht.nan) 
+    >>> b
+    tensor([[ 0.8310,     nan, -0.8029,  0.2366],
+            [ 0.2857,  0.6898, -0.6331,  0.8795],
+            [-0.6842,  0.4533,  0.2912, -0.8317]])
+    >>> ht.minimum(a,b)
+    tensor([[-0.1955,     nan, -0.8029,  0.2366],
+            [-0.4212, -0.5107, -1.5727, -0.1232],
+            [-0.6842, -1.8313,  0.2912, -1.2770]])
 
     >>> d = ht.random.randn(3,4,5)
     >>> ht.minimum(a,d)
@@ -596,8 +606,7 @@ def minimum(x1, x2, out=None, **kwargs):
     bc_x1 = x1._DNDarray__array.expand(output_lshape) if not (x1.lshape == output_lshape) else x1._DNDarray__array
     bc_x2 = x2._DNDarray__array.expand(output_lshape) if not (x2.lshape == output_lshape) else x2._DNDarray__array
 
-    # Concatenating (expanded, local) x1 and x2 into x to satisfy operations.__reduce_op(),
-    # enforcing axis = 0 for torch.min()
+    # Concatenating (expanded, local) x1 and x2 into x to satisfy operations.__reduce_op(x, ...)
     x = factories.empty((2,) + output_lshape)
     x._DNDarray__array = torch.cat((bc_x1, bc_x2)).reshape((2,) + output_lshape)
     # TODO: what happens if e.g. x1 and x2 have different splits?

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -440,6 +440,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(minimum.split, None)
         self.assertEqual(minimum.dtype, ht.int64)
         self.assertEqual(minimum._DNDarray__array.dtype, torch.int64)
+        self.assertTrue((minimum._DNDarray__array == torch.min(comparison1, comparison2)).all())
 
         # check minimum over float elements of split 3d tensor
         # TODO: add check for uneven distribution of dimensions (see Issue #273)
@@ -470,6 +471,12 @@ class TestStatistics(unittest.TestCase):
         random_volume_3 = ht.array(ht.random.randn(4, 2, 3), split=0)
         with self.assertRaises(ValueError):
             ht.minimum(random_volume_1, random_volume_3)
+        random_volume_3 = torch.ones(12, 3, 3)
+        with self.assertRaises(TypeError):
+            ht.minimum(random_volume_1, random_volume_3)
+        output = torch.ones(12, 3, 3)
+        with self.assertRaises(TypeError):
+            ht.minimum(random_volume_1, random_volume_2, out=output)
 
     def test_std(self):
         # test raises

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -453,7 +453,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(minimum_volume.lshape, (ht.MPI_WORLD.size * 12, 3, 3))
         self.assertEqual(minimum_volume.dtype, ht.float32)
         self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float32)
-        self.assertEqual(minimum_volume.split, None)
+        self.assertEqual(minimum_volume.split, random_volume_1.split)
 
         # check output buffer
         out_shape = ht.stride_tricks.broadcast_shape(random_volume_1.gshape, random_volume_2.gshape)
@@ -464,7 +464,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(output.lshape, (ht.MPI_WORLD.size * 12, 3, 3))
         self.assertEqual(output.dtype, ht.float32)
         self.assertEqual(output._DNDarray__array.dtype, torch.float32)
-        self.assertEqual(output.split, None)
+        self.assertEqual(output.split, random_volume_1.split)
 
         # check exceptions
         random_volume_3 = ht.array(ht.random.randn(4, 2, 3), split=0)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -412,6 +412,53 @@ class TestStatistics(unittest.TestCase):
         with self.assertRaises(ValueError):
             ht.min(ht_array, axis=-4)
 
+    def test_minimum(self):
+        data1 = [
+            [1,   2,  3],
+            [4,   5,  6],
+            [7,   8,  9],
+            [10, 11, 12]
+        ]
+        data2 = [
+            [0,   3,  2],
+            [5,   4,  7],
+            [6,   9,  8],
+            [9, 10, 11]
+        ]
+
+        ht_array1 = ht.array(data1)
+        ht_array2 = ht.array(data2)
+        comparison1 = torch.tensor(data1)
+        comparison2 = torch.tensor(data2)
+
+        # check minimum
+        minimum = ht.minimum(ht_array1, ht_array2)
+
+        self.assertIsInstance(minimum, ht.DNDarray)
+        self.assertEqual(minimum.shape, (4, 3))
+        self.assertEqual(minimum.lshape, (4, 3))
+        self.assertEqual(minimum.split, None)
+        self.assertEqual(minimum.dtype, ht.int64)
+        self.assertEqual(minimum._DNDarray__array.dtype, torch.int64)
+
+        # check minimum over float elements of split 3d tensor
+        torch.manual_seed(1)
+        random_volume_1 = ht.array(ht.random.randn(12, 3, 3), is_split=0)
+        random_volume_2 = ht.array(ht.random.randn(12, 1, 3), is_split=0)
+        minimum_volume = ht.minimum(random_volume_1, random_volume_2)
+
+        self.assertIsInstance(minimum_volume, ht.DNDarray)
+        self.assertEqual(minimum_volume.shape, (12, 3, 3))
+        self.assertEqual(minimum_volume.lshape, (12, 3, 3))
+        self.assertEqual(minimum_volume.dtype, ht.float32)
+        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(minimum_volume.split, None)
+
+        # check exceptions
+        random_volume_3 = ht.array(ht.random.randn(4, 2, 3), split=0)
+        with self.assertRaises(ValueError):
+            ht.minimum(random_volume_1, random_volume_3)
+
     def test_std(self):
         # test raises
         x = ht.zeros((2, 3, 4))


### PR DESCRIPTION
Hi all,

here's a HeAt implementation of np.minimum(x1, x2), providing the element-wise minimum of two tensors (Issue #37). This is equivalent to torch.min(x1, x2).

Some open questions:
1) I'm not entirely sure how torch.min handles NaN propagation when both elements are NaN. np.minimum reports: 

> If one of the elements being compared is a NaN, then that element is returned. (Claudia: this works). If both elements are NaNs then the first is returned. The latter distinction is important for complex NaNs, which are defined as at least one of the real or imaginary parts being a NaN. 

https://docs.scipy.org/doc/numpy/reference/generated/numpy.minimum.html

2) Ideas on how to handle x1.split != x2.split? Right now the code is a bit brutal (x1.split rules).  

Thanks for your comments!