### PR TITLE
added dtype to the recv data in balance to allow for 64bit datatypes

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -521,7 +521,7 @@ class DNDarray:
         """
         if self.is_balanced():
             return
-        sl_dtype = self._DNDarray__array.dtype
+        sl_dtype = self.dtype.torch_type()
         # units -> {pr, 1st index, 2nd index}
         lshape_map = factories.zeros((self.comm.size, len(self.gshape)), dtype=int)
         lshape_map[self.comm.rank, :] = torch.Tensor(self.lshape)
@@ -1231,6 +1231,8 @@ class DNDarray:
         (1/2) >>> tensor([0.])
         (2/2) >>> tensor([0., 0.])
         """
+        l_dtype = self.dtype.torch_type()
+        dtype = self.dtype
         if isinstance(key, DNDarray)and key.gshape[-1] != len(self.gshape):
             key = tuple(x.item() for x in key)
         if not self.is_distributed():
@@ -1381,7 +1383,7 @@ class DNDarray:
                 else:
                     gout[e] = self.comm.allreduce(gout[e], MPI.MAX)
 
-            return DNDarray(arr, gout if isinstance(gout, tuple) else tuple(gout), self.dtype, new_split, self.device, self.comm)
+            return DNDarray(arr.type(l_dtype), gout if isinstance(gout, tuple) else tuple(gout), self.dtype, new_split, self.device, self.comm)
 
     if torch.cuda.device_count() > 0:
         def gpu(self):

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -608,7 +608,7 @@ class DNDarray:
                 if self.comm.rank == pr and snt:
                     shp = list(self.gshape)
                     shp[self.split] = snt
-                    data = torch.zeros(shp)
+                    data = torch.zeros(shp, dtype=sl_dtype)
                     self.comm.Recv(data, source=spr, tag=pr + self.comm.size + spr)
                     self.__array = torch.cat((data, self.__array), dim=self.split)
                 lshape_map[pr, self.split] += snt

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -521,6 +521,7 @@ class DNDarray:
         """
         if self.is_balanced():
             return
+        sl_dtype = self._DNDarray__array.dtype
         # units -> {pr, 1st index, 2nd index}
         lshape_map = factories.zeros((self.comm.size, len(self.gshape)), dtype=int)
         lshape_map[self.comm.rank, :] = torch.Tensor(self.lshape)
@@ -569,7 +570,7 @@ class DNDarray:
                     if self.comm.rank == pr and snt:
                         shp = list(self.gshape)
                         shp[self.split] = snt
-                        data = torch.zeros(shp)
+                        data = torch.zeros(shp, dtype=sl_dtype)
                         self.comm.Recv(data, source=spr, tag=pr + self.comm.size + spr)
                         self.__array = torch.cat((self.__array, data), dim=self.split)
                     lshape_map[pr, self.split] += snt

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -40,6 +40,16 @@ class TestDNDarray(unittest.TestCase):
         data.balance_()
         self.assertTrue(data.is_balanced())
 
+        data = ht.zeros((70, 20), split=0, dtype=ht.float64)
+        data = data[:50]
+        data.balance_()
+        self.assertTrue(data.is_balanced())
+
+        data = ht.zeros((4, 120), split=1, dtype=ht.int64)
+        data = data[:, 40:70]
+        data.balance_()
+        self.assertTrue(data.is_balanced())
+
     def test_bool_cast(self):
         # simple scalar tensor
         a = ht.ones(1)


### PR DESCRIPTION
## Description

bug was caused by a faulty dtype for the array which received the data from the other processes. debugging this led to the discovery of another bug in getitem: local torch tensors were not being properly type cast. both errors now should be fixed.

Fixes: #329 

Changes proposed:
- added a dtype to the torch tensor which receives the data from the other process
- added type cast to the local arrays returned by getitem at core of the problem.

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

Have you handled and tested all split configurations?
    yes, standard testing passed. added tests also pass