### PR TITLE
added mean support for ints on local level, also a correctness test

### DIFF
--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -479,8 +479,8 @@ def mean(x, axis=None):
         # full matrix calculation
         if not x.is_distributed():
             # if x is not distributed do a torch.mean on x
-            ret = torch.mean(x._DNDarray__array)
-            return dndarray.DNDarray(ret, tuple(ret.shape), x.dtype, None, x.device, x.comm)
+            ret = torch.mean(x._DNDarray__array.float())
+            return dndarray.DNDarray(ret, tuple(ret.shape), types.canonical_heat_type(ret.dtype), None, x.device, x.comm)
         else:
             # if x is distributed and no axis is given: return mean of the whole set
             if x.lshape[x.split] != 0:

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -980,8 +980,8 @@ def var(x, axis=None, bessel=True):
     # ----------------------------------------------------------------------------------------------------
     if axis is None:  # no axis given
         if not x.is_distributed():  # not distributed (full tensor on one node)
-            ret = torch.var(x._DNDarray__array, unbiased=bessel)
-            return dndarray.DNDarray(ret, tuple(ret.shape), x.dtype, None, x.device, x.comm)
+            ret = torch.var(x._DNDarray__array.float(), unbiased=bessel)
+            return dndarray.DNDarray(ret, tuple(ret.shape), types.canonical_heat_type(ret.dtype), None, x.device, x.comm)
 
         else:  # case for full matrix calculation (axis is None)
             if x.lshape[x.split] != 0:

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -635,6 +635,9 @@ class TestStatistics(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.var(x, axis='01')
 
+        a = ht.arange(1, 5)
+        self.assertEqual(a.var(), 2.5)
+
         # ones
         dimensions = []
         for d in [array_0_len, array_1_len, array_2_len]:

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -373,6 +373,9 @@ class TestStatistics(unittest.TestCase):
         with self.assertRaises(ValueError):
             ht.mean(x, axis=(0, '10'))
 
+        a = ht.arange(1, 5)
+        self.assertEqual(a.mean(), 2.5)
+
         # ones
         dimensions = []
 

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -636,7 +636,7 @@ class TestStatistics(unittest.TestCase):
             ht.var(x, axis='01')
 
         a = ht.arange(1, 5)
-        self.assertEqual(a.var(), 1.2910)
+        self.assertEqual(a.var(), 1.6667)
 
         # ones
         dimensions = []

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -636,7 +636,7 @@ class TestStatistics(unittest.TestCase):
             ht.var(x, axis='01')
 
         a = ht.arange(1, 5)
-        self.assertEqual(a.var(), 1.6667)
+        self.assertEqual(a.var(), 1.666666666666666)
 
         # ones
         dimensions = []

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -636,7 +636,7 @@ class TestStatistics(unittest.TestCase):
             ht.var(x, axis='01')
 
         a = ht.arange(1, 5)
-        self.assertEqual(a.var(), 2.5)
+        self.assertEqual(a.var(), 1.2910)
 
         # ones
         dimensions = []


### PR DESCRIPTION
## Description

adds support for ints to mean and variance. The problem was at the pytorch level, the solution was to cast the array to a float. all tests run without failure

Fixes: #349 (and parallel problem with var although it was not previously pointed out)

Changes proposed:
- casting of the torch tensor to float in the non-distributed case for both mean and var (has no effect if the tensor is already a float)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

Have you handled and tested all split configurations?
Yes