### PR TITLE
Features/347 average

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -483,6 +483,12 @@ class DNDarray:
 
         return self
 
+    def average(self, axis=None, weights=None, returned=False):
+        '''
+        #TODO: docs
+        '''
+        return statistics.average(self, axis=axis, weights=weights, returned=returned)
+
     def balance_(self):
         """
         Function for balancing a DNDarray between all nodes. To determine if this is needed use the is_balanced function.

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -539,17 +539,17 @@ class DNDarray:
         >>> data = ht.arange(1,5, dtype=float)
         >>> data
         tensor([1., 2., 3., 4.])
-        >>> ht.average(data)
+        >>> data.average()
         tensor(2.5000)
-        >>> ht.average(ht.arange(1,11, dtype=float), weights=ht.arange(10,0,-1))
+        >>> ht.arange(1,11, dtype=float).average(weights=ht.arange(10,0,-1))
         tensor([4.])
         >>> data = ht.array([[0, 1],
                              [2, 3],
                             [4, 5]], dtype=float, split=1)
         >>> weights = ht.array([1./4, 3./4])
-        >>> ht.average(data, axis=1, weights=weights)
+        >>> data.average(axis=1, weights=weights)
         tensor([0.7500, 2.7500, 4.7500])
-        >>> ht.average(data, weights=weights)
+        >>> data.average(weights=weights)
         Traceback (most recent call last):
         ...
         TypeError: Axis must be specified when shapes of x and weights differ.

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -486,7 +486,73 @@ class DNDarray:
 
     def average(self, axis=None, weights=None, returned=False):
         '''
-        #TODO: docs
+        Compute the weighted average along the specified axis.
+
+        Parameters
+        ----------
+        x : ht.tensor
+            Tensor containing data to be averaged. 
+
+        axis : None or int or tuple of ints, optional
+            Axis or axes along which to average x.  The default,
+            axis=None, will average over all of the elements of the input tensor.
+            If axis is negative it counts from the last to the first axis.
+
+            #TODO Issue #351: If axis is a tuple of ints, averaging is performed on all of the axes
+            specified in the tuple instead of a single axis or all the axes as
+            before.
+
+        weights : ht.tensor, optional
+            An tensor of weights associated with the values in x. Each value in
+            x contributes to the average according to its associated weight.
+            The weights tensor can either be 1D (in which case its length must be
+            the size of x along the given axis) or of the same shape as x.
+            If weights=None, then all data in x are assumed to have a
+            weight equal to one, the result is equivalent to ht.mean(x).
+
+        returned : bool, optional
+            Default is False. If True, the tuple (average, sum_of_weights)
+            is returned, otherwise only the average is returned.
+            If weights=None, sum_of_weights is equivalent to the number of
+            elements over which the average is taken.
+
+        Returns
+        -------
+        average, [sum_of_weights] : ht.tensor or tuple of ht.tensors
+            Return the average along the specified axis. When returned=True,
+            return a tuple with the average as the first element and the sum
+            of the weights as the second element. sum_of_weights is of the
+            same type as `average`. 
+
+        Raises
+        ------
+        ZeroDivisionError
+            When all weights along axis are zero. 
+
+        TypeError
+            When the length of 1D weights is not the same as the shape of x
+            along axis.
+
+
+        Examples
+        --------
+        >>> data = ht.arange(1,5, dtype=float)
+        >>> data
+        tensor([1., 2., 3., 4.])
+        >>> ht.average(data)
+        tensor(2.5000)
+        >>> ht.average(ht.arange(1,11, dtype=float), weights=ht.arange(10,0,-1))
+        tensor([4.])
+        >>> data = ht.array([[0, 1],
+                             [2, 3],
+                            [4, 5]], dtype=float, split=1)
+        >>> weights = ht.array([1./4, 3./4])
+        >>> ht.average(data, axis=1, weights=weights)
+        tensor([0.7500, 2.7500, 4.7500])
+        >>> ht.average(data, weights=weights)
+        Traceback (most recent call last):
+        ...
+        TypeError: Axis must be specified when shapes of x and weights differ.
         '''
         return statistics.average(self, axis=axis, weights=weights, returned=returned)
 

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -226,7 +226,7 @@ def average(x, axis=None, weights=None, returned=False):
         axis=None, will average over all of the elements of the input tensor.
         If axis is negative it counts from the last to the first axis.
 
-        #TODO: If axis is a tuple of ints, averaging is performed on all of the axes
+        #TODO Issue #351: If axis is a tuple of ints, averaging is performed on all of the axes
         specified in the tuple instead of a single axis or all the axes as
         before.
 

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -303,14 +303,14 @@ def average(x, axis=None, weights=None, returned=False):
                 raise TypeError(
                     "Axis must be specified when shapes of x and weights "
                     "differ.")
-            if weights.numpy().ndim != 1:
+            if weights.numdims != 1:
                 raise TypeError(
                     "1D weights expected when shapes of x and weights differ.")
             if weights.gshape[0] != x.gshape[axis]:
                 raise ValueError(
                     "Length of weights not compatible with specified axis.")
 
-        wgt = factories.empty_like(weights)
+        wgt = weights
 
         # Broadcast weights along axis
         if weights.numdims == 1 and axis is not None and axis != 0:

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -213,7 +213,6 @@ def argmin(x, axis=None, out=None, **kwargs):
 
 
 def average(x, axis=None, weights=None, returned=False):
-    #TODO: DOCUMENTATION
 
     # perform sanitation
     if not isinstance(x, dndarray.DNDarray):
@@ -257,6 +256,9 @@ def average(x, axis=None, weights=None, returned=False):
                 weights.resplit(x.split)
 
         result = (x * weights).sum(axis=axis) / cumwgt
+        if returned:
+            return (result, cumwgt)
+
         return result
 
 

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -304,8 +304,8 @@ def average(x, axis=None, weights=None, returned=False):
                     "Axis must be specified when shapes of x and weights "
                     "differ.")
             if isinstance(axis, tuple):
-                raise TypeError(
-                    "Shape of weights must be equal shape of x if axis is tuple of ints.")
+                raise NotImplementedError(
+                    "Weighted average over tuple axis not implemented yet.")
             if weights.numdims != 1:
                 raise TypeError(
                     "1D weights expected when shapes of x and weights differ.")

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -264,29 +264,23 @@ def average(x, axis=None, weights=None, returned=False):
 
     Examples
     --------
-    >>> data = list(range(1,5))
+    >>> data = ht.arange(1,5, dtype=float)
     >>> data
-    [1, 2, 3, 4]
-    >>> np.average(data)
-    2.5
-    >>> np.average(range(1,11), weights=range(10,0,-1))
-    4.0
-    >>> data = np.arange(6).reshape((3,2))
-    >>> data
-    array([[0, 1],
-           [2, 3],
-           [4, 5]])
-    >>> np.average(data, axis=1, weights=[1./4, 3./4])
-    array([0.75, 2.75, 4.75])
-    >>> np.average(data, weights=[1./4, 3./4])
+    tensor([1., 2., 3., 4.])
+    >>> ht.average(data)
+    tensor(2.5000)
+    >>> ht.average(ht.arange(1,11, dtype=float), weights=ht.arange(10,0,-1))
+    tensor([4.])
+    >>> data = ht.array([[0, 1],
+                         [2, 3],
+                        [4, 5]], dtype=float, split=1)
+    >>> weights = ht.array([1./4, 3./4])
+    >>> ht.average(data, axis=1, weights=weights)
+    tensor([0.7500, 2.7500, 4.7500])
+    >>> ht.average(data, weights=weights)
     Traceback (most recent call last):
         ...
-    TypeError: Axis must be specified when shapes of a and weights differ.
-    >>> a = np.ones(5, dtype=np.float128)
-    >>> w = np.ones(5, dtype=np.complex64)
-    >>> avg = np.average(a, weights=w)
-    >>> print(avg.dtype)
-    complex256
+    TypeError: Axis must be specified when shapes of x and weights differ.
     """
 
     # perform sanitation
@@ -296,6 +290,7 @@ def average(x, axis=None, weights=None, returned=False):
         raise TypeError('expected weights to be a ht.DNDarray, but was {}'.format(type(x)))
     axis = stride_tricks.sanitize_axis(x.shape, axis)
 
+    if is
     if weights is None:
         result = mean(x, axis)
         num_elements = x.gnumel/result.gnumel

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -317,8 +317,8 @@ def average(x, axis=None, weights=None, returned=False):
         wgt._DNDarray__array = weights._DNDarray__array
         wgt._DNDarray__split = weights.split
 
-        # Broadcast weights along specified axis
-        if wgt.numdims == 1 and axis != 0:
+        # Broadcast weights along specified axis if necessary
+        if wgt.numdims == 1 and x.numdims != 1:
             if wgt.split is not None:
                 wgt.resplit(None)
             weights_newshape = tuple(1 if i != axis else x.gshape[axis] for i in range(x.numdims))
@@ -329,7 +329,7 @@ def average(x, axis=None, weights=None, returned=False):
         if logical.any(cumwgt == 0.0):
             raise ZeroDivisionError("Weights sum to zero, can't be normalized")
 
-        # Distribution: if x is split, apply same split to weights if possible
+        # Distribution: if x is split, split to weights along same dimension if possible
         if x.split is not None and wgt.split != x.split:
             if wgt.gshape[x.split] != 1:
                 wgt.resplit(x.split)

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -226,7 +226,7 @@ def average(x, axis=None, weights=None, returned=False):
         axis=None, will average over all of the elements of the input tensor.
         If axis is negative it counts from the last to the first axis.
 
-        If axis is a tuple of ints, averaging is performed on all of the axes
+        #TODO: If axis is a tuple of ints, averaging is performed on all of the axes
         specified in the tuple instead of a single axis or all the axes as
         before.
 
@@ -303,6 +303,9 @@ def average(x, axis=None, weights=None, returned=False):
                 raise TypeError(
                     "Axis must be specified when shapes of x and weights "
                     "differ.")
+            if isinstance(axis, tuple):
+                raise NotImplementedError(
+                    "Weighted average over tuple axis not implemented yet.")
             if weights.numdims != 1:
                 raise TypeError(
                     "1D weights expected when shapes of x and weights differ.")
@@ -310,7 +313,8 @@ def average(x, axis=None, weights=None, returned=False):
                 raise ValueError(
                     "Length of weights not compatible with specified axis.")
 
-        wgt = weights
+        wgt = factories.empty_like(weights)
+        wgt._DNDarray__array = weights._DNDarray__array
 
         # Broadcast weights along axis
         if weights.numdims == 1 and axis is not None and axis != 0:

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -315,13 +315,14 @@ def average(x, axis=None, weights=None, returned=False):
 
         wgt = factories.empty_like(weights)
         wgt._DNDarray__array = weights._DNDarray__array
+        wgt._DNDarray__split = weights.split
 
-        # Broadcast weights along axis
-        if weights.numdims == 1 and axis is not None and axis != 0:
-            if weights.split is not None:
-                weights.resplit(None)
+        # Broadcast weights along specified axis
+        if wgt.numdims == 1 and axis != 0:
+            if wgt.split is not None:
+                wgt.resplit(None)
             weights_newshape = tuple(1 if i != axis else x.gshape[axis] for i in range(x.numdims))
-            wgt._DNDarray__array = torch.reshape(weights._DNDarray__array, weights_newshape)
+            wgt._DNDarray__array = torch.reshape(wgt._DNDarray__array, weights_newshape)
             wgt._DNDarray__gshape = weights_newshape
 
         cumwgt = wgt.sum(axis=axis)

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -334,8 +334,15 @@ def average(x, axis=None, weights=None, returned=False):
                 weights.resplit(x.split)
 
         result = (x * weights).sum(axis=axis) / cumwgt
+        if axis is not None:
+            # Bring weights back to 1D
+            weights = weights.squeeze()
 
     if returned:
+        if cumwgt.gshape != result.gshape:
+            cumwgt._DNDarray__array = torch.broadcast_tensors(cumwgt._DNDarray__array, result._DNDarray__array)[0]
+            cumwgt._DNDarray__gshape = result.gshape
+            cumwgt._DNDarray__split = result.split
         return (result, cumwgt)
 
     return result

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -304,8 +304,8 @@ def average(x, axis=None, weights=None, returned=False):
                     "Axis must be specified when shapes of x and weights "
                     "differ.")
             if isinstance(axis, tuple):
-                raise NotImplementedError(
-                    "Weighted average over tuple axis not implemented yet.")
+                raise TypeError(
+                    "Shape of weights must be equal shape of x if axis is tuple of ints.")
             if weights.numdims != 1:
                 raise TypeError(
                     "1D weights expected when shapes of x and weights differ.")

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -290,7 +290,6 @@ def average(x, axis=None, weights=None, returned=False):
         raise TypeError('expected weights to be a ht.DNDarray, but was {}'.format(type(x)))
     axis = stride_tricks.sanitize_axis(x.shape, axis)
 
-    if is
     if weights is None:
         result = mean(x, axis)
         num_elements = x.gnumel/result.gnumel

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -355,6 +355,103 @@ class TestStatistics(unittest.TestCase):
         with self.assertRaises(ValueError):
             ht.max(ht_array, axis=-4)
 
+    def test_maximum(self):
+        data1 = [
+            [1,   2,  3],
+            [4,   5,  6],
+            [7,   8,  9],
+            [10, 11, 12]
+        ]
+        data2 = [
+            [0,   3,  2],
+            [5,   4,  7],
+            [6,   9,  8],
+            [9, 10, 11]
+        ]
+
+        ht_array1 = ht.array(data1)
+        ht_array2 = ht.array(data2)
+        comparison1 = torch.tensor(data1)
+        comparison2 = torch.tensor(data2)
+
+        # check maximum
+        maximum = ht.maximum(ht_array1, ht_array2)
+
+        self.assertIsInstance(maximum, ht.DNDarray)
+        self.assertEqual(maximum.shape, (4, 3))
+        self.assertEqual(maximum.lshape, (4, 3))
+        self.assertEqual(maximum.split, None)
+        self.assertEqual(maximum.dtype, ht.int64)
+        self.assertEqual(maximum._DNDarray__array.dtype, torch.int64)
+        self.assertTrue((maximum._DNDarray__array == torch.max(comparison1, comparison2)).all())
+
+        # check maximum over float elements of split 3d tensors
+        # TODO: add check for uneven distribution of dimensions (see Issue #273)
+        size = ht.MPI_WORLD.size
+        torch.manual_seed(1)
+        random_volume_1 = ht.array(ht.random.randn(12, 3, 3), is_split=0)
+        random_volume_2 = ht.array(ht.random.randn(12, 1, 3), is_split=0)
+        maximum_volume = ht.maximum(random_volume_1, random_volume_2)
+
+        self.assertIsInstance(maximum_volume, ht.DNDarray)
+        self.assertEqual(maximum_volume.shape, (size * 12, 3, 3))
+        self.assertEqual(maximum_volume.lshape, (size * 12, 3, 3))
+        self.assertEqual(maximum_volume.dtype, ht.float32)
+        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(maximum_volume.split, random_volume_1.split)
+
+        # check maximum over float elements of split 3d tensors with different split axis
+        torch.manual_seed(1)
+        random_volume_1_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=0)
+        random_volume_2_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=1)
+        maximum_volume_splitdiff = ht.maximum(random_volume_1_splitdiff, random_volume_2_splitdiff)
+        self.assertIsInstance(maximum_volume_splitdiff, ht.DNDarray)
+        self.assertEqual(maximum_volume_splitdiff.shape, (size*3, size*3, 4))
+        self.assertEqual(maximum_volume_splitdiff.lshape, (size*3, size*3, 4))
+        self.assertEqual(maximum_volume_splitdiff.dtype, ht.float32)
+        self.assertEqual(maximum_volume_splitdiff._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(maximum_volume_splitdiff.split, 0)
+
+        random_volume_1_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=1)
+        random_volume_2_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=0)
+        maximum_volume_splitdiff = ht.maximum(random_volume_1_splitdiff, random_volume_2_splitdiff)
+        self.assertEqual(maximum_volume_splitdiff.split, 0)
+
+        random_volume_1_splitNone = ht.array(ht.random.randn(size*3, size*3, 4), split=None)
+        random_volume_2_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=1)
+        maximum_volume_splitdiff = ht.maximum(random_volume_1_splitNone, random_volume_2_splitdiff)
+        self.assertEqual(maximum_volume_splitdiff.split, 1)
+
+        random_volume_1_splitNone = ht.array(ht.random.randn(size*3, size*3, 4), split=0)
+        random_volume_2_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=None)
+        maximum_volume_splitdiff = ht.maximum(random_volume_1_splitNone, random_volume_2_splitdiff)
+        self.assertEqual(maximum_volume_splitdiff.split, 0)
+
+        # check output buffer
+        out_shape = ht.stride_tricks.broadcast_shape(random_volume_1.gshape, random_volume_2.gshape)
+        output = ht.empty(out_shape)
+        ht.maximum(random_volume_1, random_volume_2, out=output)
+        self.assertIsInstance(output, ht.DNDarray)
+        self.assertEqual(output.shape, (ht.MPI_WORLD.size * 12, 3, 3))
+        self.assertEqual(output.lshape, (ht.MPI_WORLD.size * 12, 3, 3))
+        self.assertEqual(output.dtype, ht.float32)
+        self.assertEqual(output._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(output.split, random_volume_1.split)
+
+        # check exceptions
+        random_volume_3 = ht.array(ht.random.randn(4, 2, 3), split=0)
+        with self.assertRaises(ValueError):
+            ht.maximum(random_volume_1, random_volume_3)
+        random_volume_3 = torch.ones(12, 3, 3)
+        with self.assertRaises(TypeError):
+            ht.maximum(random_volume_1, random_volume_3)
+        output = torch.ones(12, 3, 3)
+        with self.assertRaises(TypeError):
+            ht.maximum(random_volume_1, random_volume_2, out=output)
+        output = ht.ones((12, 4, 3))
+        with self.assertRaises(ValueError):
+            ht.maximum(random_volume_1, random_volume_2, out=output)
+
     def test_mean(self):
         array_0_len = 5
         array_1_len = 5

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -234,15 +234,12 @@ class TestStatistics(unittest.TestCase):
         # check average over all float elements of split 3d tensor, tuple axis
         # TODO: insert check for weights
         random_volume = ht.array(ht.random.randn(3, 3, 3), split=0)
-        print('RANDOM_VOLUME = ', random_volume)
         avg_volume = ht.average(random_volume, axis=(1, 2))
         alt_avg_volume = ht.average(random_volume, axis=(2, 1))
 
         self.assertIsInstance(avg_volume, ht.DNDarray)
         self.assertEqual(avg_volume.shape, (3,))
-        print('AVG_VOLUME = ', avg_volume)
-        # TODO: fix this
-#        self.assertEqual(avg_volume.lshape, (3,))
+        self.assertEqual(avg_volume.lshape[0], random_volume.lshape[0])
         self.assertEqual(avg_volume.dtype, ht.float32)
         self.assertEqual(avg_volume._DNDarray__array.dtype, torch.float32)
         self.assertEqual(avg_volume.split, 0)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -235,7 +235,6 @@ class TestStatistics(unittest.TestCase):
         self.assertAlmostEqual(avg_volume.numpy().all(), np_avg_volume.all())
 
         # check average over all float elements of split 3d tensor, tuple axis
-        # TODO: insert check for weights
         random_volume = ht.array(ht.random.randn(3, 3, 3), split=0)
         avg_volume = ht.average(random_volume, axis=(1, 2))
         alt_avg_volume = ht.average(random_volume, axis=(2, 1))
@@ -247,11 +246,11 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(avg_volume._DNDarray__array.dtype, torch.float32)
         self.assertEqual(avg_volume.split, 0)
 
-        # check average over all float elements of split 5d tensor, along split axis
+        # check weighted average over all float elements of split 5d tensor, along split axis
         random_5d = ht.array(ht.random.randn(1, 2, 3, 4, 5), is_split=0)
         axis = 1
         random_weights = ht.random.randn(random_5d.gshape[axis])
-        avg_5d = ht.average(random_5d, weights=random_weights, axis=axis)
+        avg_5d = random_5d.average(weights=random_weights, axis=axis)
 
         self.assertIsInstance(avg_5d, ht.DNDarray)
         self.assertEqual(avg_5d.gshape, (size, 3, 4, 5))

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -261,11 +261,27 @@ class TestStatistics(unittest.TestCase):
 
         # check exceptions
         with self.assertRaises(TypeError):
+            ht.average(comparison)
+        with self.assertRaises(TypeError):
+            ht.average(random_5d, weights=random_weights.numpy(), axis=axis)
+        with self.assertRaises(TypeError):
+            ht.average(random_5d, weights=random_weights, axis=None)
+        with self.assertRaises(NotImplementedError):
+            ht.average(random_5d, weights=random_weights, axis=(1, 2))
+        random_weights = ht.random.randn(random_5d.gshape[axis], random_5d.gshape[axis+1])
+        with self.assertRaises(TypeError):
+            ht.average(random_5d, weights=random_weights, axis=axis)
+        random_weights = ht.random.randn(random_5d.gshape[axis] + 1)
+        with self.assertRaises(ValueError):
+            ht.average(random_5d, weights=random_weights, axis=axis)
+        with self.assertRaises(TypeError):
             ht_array.average(axis=1.1)
         with self.assertRaises(TypeError):
             ht_array.average(axis='y')
         with self.assertRaises(ValueError):
             ht.average(ht_array, axis=-4)
+
+
 
     def test_max(self):
         data = [

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -233,6 +233,12 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(avg_volume._DNDarray__array.dtype, torch.float64)
         self.assertEqual(avg_volume.split, None)
         self.assertAlmostEqual(avg_volume.numpy().all(), np_avg_volume.all())
+        avg_volume_with_cumwgt = ht.average(random_volume, weights=random_weights, axis=1, returned=True)
+        self.assertIsInstance(avg_volume_with_cumwgt, tuple)
+        self.assertIsInstance(avg_volume_with_cumwgt[1], ht.DNDarray)
+        self.assertEqual(avg_volume_with_cumwgt[1].gshape, avg_volume_with_cumwgt[0].gshape)
+        self.assertEqual(avg_volume_with_cumwgt[1].split, avg_volume_with_cumwgt[0].split)
+        
 
         # check average over all float elements of split 3d tensor, tuple axis
         random_volume = ht.array(ht.random.randn(3, 3, 3), split=0)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -274,6 +274,9 @@ class TestStatistics(unittest.TestCase):
         random_weights = ht.random.randn(random_5d.gshape[axis] + 1)
         with self.assertRaises(ValueError):
             ht.average(random_5d, weights=random_weights, axis=axis)
+        random_weights = ht.zeros((random_5d.gshape[axis]))
+        with self.assertRaises(ZeroDivisionError):
+            ht.average(random_5d, weights=random_weights, axis=axis)
         with self.assertRaises(TypeError):
             ht_array.average(axis=1.1)
         with self.assertRaises(TypeError):


### PR DESCRIPTION
## Description

Addresses Issue #347 

Unlike mean(), average() allows to calculate a _weighted_ average of a tensor, or along a specific axis. 

The implementation is equivalent to numpy.average(). 

Averaging across multiple axes (axis is tuple) not supported yet (see Issue #351)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

Have you handled and tested all split configurations?
Yes.