### PR TITLE
Bug/assorted bug fixes 0

### DIFF
--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -48,6 +48,7 @@ class Communication:
 class MPICommunication(Communication):
     # static mapping of torch types to the respective MPI type handle
     __mpi_type_mappings = {
+        torch.bool: MPI.BOOL,
         torch.uint8: MPI.UNSIGNED_CHAR,
         torch.int8: MPI.SIGNED_CHAR,
         torch.int16: MPI.SHORT_INT,

--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -173,7 +173,7 @@ class MPICommunication(Communication):
         mpi_type, elements = cls.__mpi_type_mappings[obj.dtype], torch.numel(obj)
 
         # simple case, continuous memory can be transmitted as is
-        if obj.is_contiguous() :
+        if obj.is_contiguous():
             if counts is None:
                 return mpi_type, elements
             else:
@@ -394,8 +394,6 @@ class MPICommunication(Communication):
         if not isinstance(sendbuf, torch.Tensor):
             if send_axis != 0:
                 raise TypeError('sendbuf of type {} does not support send_axis != 0'.format(type(sendbuf)))
-            #else:
-            #    sendbuf = torch.tensor(sendbuf)
 
         # unpack the receive buffer
         if isinstance(recvbuf, tuple):
@@ -405,8 +403,6 @@ class MPICommunication(Communication):
         if not isinstance(recvbuf, torch.Tensor):
             if send_axis != 0:
                 raise TypeError('recvbuf of type {} does not support send_axis != 0'.format(type(recvbuf)))
-            #else:
-            #    recvbuf = torch.tensor(recvbuf)
 
         # keep a reference to the original buffer object
         original_recvbuf = recvbuf
@@ -524,7 +520,6 @@ class MPICommunication(Communication):
 
         return exit_code
 
-
     def Alltoall(self, sendbuf, recvbuf, axis=0, recv_axis=None):
         return self.__scatter_like(
             self.handle.Alltoall, sendbuf, recvbuf, axis, recv_axis, send_factor=self.size, recv_factor=self.size
@@ -544,7 +539,6 @@ class MPICommunication(Communication):
     def Gatherv(self, sendbuf, recvbuf, root=0, axis=0, recv_axis=None):
         return self.__scatter_like(self.handle.Gatherv, sendbuf, recvbuf, axis, recv_axis, root=root)
     Gatherv.__doc__ = MPI.Comm.Gatherv.__doc__
-
 
     def Ialltoall(self, sendbuf, recvbuf, axis=0, recv_axis=None):
         return self.__scatter_like(
@@ -635,18 +629,18 @@ def sanitize_comm(comm):
 
     Parameters
     ----------
-    device : str, Device or None
-        The device to be sanitized
+    comm : Communication
+        The comm to be sanitized
 
     Returns
     -------
-    sanitized_device : Device
-        The matching Device instance
+    Communication
+        The matching Communication instance
 
     Raises
     ------
-    ValueError
-        If the given device id is not recognized
+    TypeError
+        If the given communication is not the proper type
     """
     if comm is None:
         return get_comm()
@@ -662,7 +656,7 @@ def use_comm(comm=None):
 
     Parameters
     ----------
-    device : Communication or None
+    comm : Communication or None
         The communication to be set
     """
     global __default_comm

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -686,7 +686,6 @@ class DNDarray:
         """
         return rounding.ceil(self, out)
 
-
     def trunc(self, out=None):
         """
         Return the trunc of the input, element-wise.
@@ -718,7 +717,6 @@ class DNDarray:
         tensor([-2., -1., -1., -0., -0.,  0.,  0.,  0.,  1.,  1.])
         """
         return rounding.trunc(self, out)
-
 
     def clip(self, a_min, a_max, out=None):
         """
@@ -1019,7 +1017,6 @@ class DNDarray:
         tensor([ 1.0000,  2.7183,  7.3891, 20.0855, 54.5981])
         """
         return exponential.exp(self, out)
-
 
     def expm1(self, out=None):
         """
@@ -1563,7 +1560,7 @@ class DNDarray:
 
         Parameters
         ----------
-        x : ht.DNDarray
+        self : ht.DNDarray
             The value for which to compute the logarithm.
         out : ht.DNDarray or None, optional
             A location in which to store the results. If provided, it must have a broadcastable shape. If not provided
@@ -1588,7 +1585,7 @@ class DNDarray:
 
         Parameters
         ----------
-        x : ht.DNDarray
+        self : ht.DNDarray
             The value for which to compute the logarithm.
         out : ht.DNDarray or None, optional
             A location in which to store the results. If provided, it must have a broadcastable shape. If not provided
@@ -1613,7 +1610,7 @@ class DNDarray:
 
         Parameters
         ----------
-        x : ht.DNDarray
+        self : ht.DNDarray
             The value for which to compute the logarithm.
         out : ht.DNDarray or None, optional
             A location in which to store the results. If provided, it must have a broadcastable shape. If not provided
@@ -1690,7 +1687,7 @@ class DNDarray:
 
         Parameters
         ----------
-        x : ht.DNDarray
+        self : ht.DNDarray
             Values for which the mean is calculated for
         axis : None, Int, iterable
             axis which the mean is taken in.
@@ -1750,37 +1747,37 @@ class DNDarray:
 
     def __mod__(self, other):
         """
-            Element-wise division remainder of values of self by values of operand other (i.e. self % other), not commutative.
-            Takes the two operands (scalar or tensor) whose elements are to be divided (operand 1 by operand 2)
-            as arguments.
+        Element-wise division remainder of values of self by values of operand other (i.e. self % other), not commutative.
+        Takes the two operands (scalar or tensor) whose elements are to be divided (operand 1 by operand 2)
+        as arguments.
 
-            Parameters
-            ----------
-            other: tensor or scalar
-                The second operand by whose values it self to be divided.
+        Parameters
+        ----------
+        other: tensor or scalar
+            The second operand by whose values it self to be divided.
 
-            Returns
-            -------
-            result: ht.DNDarray
-                A tensor containing the remainder of the element-wise division of self by other.
+        Returns
+        -------
+        result: ht.DNDarray
+            A tensor containing the remainder of the element-wise division of self by other.
 
-            Examples:
-            ---------
-            >>> import heat as ht
-            >>> ht.mod(2, 2)
-            tensor([0])
+        Examples:
+        ---------
+        >>> import heat as ht
+        >>> ht.mod(2, 2)
+        tensor([0])
 
-            >>> T1 = ht.int32([[1, 2], [3, 4]])
-            >>> T2 = ht.int32([[2, 2], [2, 2]])
-            >>> T1 % T2
-            tensor([[1, 0],
-                    [1, 0]], dtype=torch.int32)
+        >>> T1 = ht.int32([[1, 2], [3, 4]])
+        >>> T2 = ht.int32([[2, 2], [2, 2]])
+        >>> T1 % T2
+        tensor([[1, 0],
+                [1, 0]], dtype=torch.int32)
 
-            >>> s = ht.int32([2])
-            >>> s % T1
-            tensor([[0, 0]
-                    [2, 2]], dtype=torch.int32)
-            """
+        >>> s = ht.int32([2])
+        >>> s % T1
+        tensor([[0, 0]
+                [2, 2]], dtype=torch.int32)
+        """
         return arithmetics.mod(self, other)
 
     def __mul__(self, other):
@@ -1853,7 +1850,7 @@ class DNDarray:
 
         Parameters
         ----------
-        a: ht.DNDarray
+        self: ht.DNDarray
 
         Returns
         -------
@@ -2034,7 +2031,6 @@ class DNDarray:
             self.__split = axis
 
         return self
-
 
     def __rfloordiv__(self, other):
         """

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -227,10 +227,10 @@ def array(obj, dtype=None, copy=True, ndmin=0, split=None, is_split=None, device
 
     # reshape the object to encompass additional dimensions
     ndmin_abs = abs(ndmin) - len(obj.shape)
-    if ndmin_abs > 0 and ndmin>0:
+    if ndmin_abs > 0 and ndmin > 0:
         obj = obj.reshape(obj.shape + ndmin_abs * (1,))
-    if ndmin_abs > 0 and ndmin<0:
-        obj = obj.reshape(ndmin_abs * (1,) + obj.shape )
+    if ndmin_abs > 0 > ndmin:
+        obj = obj.reshape(ndmin_abs * (1,) + obj.shape)
 
     # sanitize the split axes, ensure mutual exclusiveness
     split = sanitize_axis(obj.shape, split)
@@ -602,7 +602,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, spli
     ----------
     start: scalar, scalar-convertible
         The starting value of the sample interval, maybe a sequence if convertible to scalar
-    end: scalar, scalar-convertible
+    stop: scalar, scalar-convertible
         The end value of the sample interval, unless is set to False. In that case, the sequence consists of all but the
         last of num + 1 evenly spaced samples, so that stop is excluded. Note that the step size changes when endpoint
         is False.

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -74,7 +74,7 @@ def nonzero(a):
         gout = list(lcl_nonzero.size())
         gout[0] = a.comm.allreduce(gout[0], MPI.SUM)
 
-        return dndarray.DNDarray(lcl_nonzero, tuple(gout), types.int, 0, a.device, a.comm)
+        return dndarray.DNDarray(lcl_nonzero, gshape=tuple(gout), dtype=types.int, split=0, device=a.device, comm=a.comm)
 
 
 def where(cond, x=None, y=None):
@@ -117,6 +117,7 @@ def where(cond, x=None, y=None):
         if (isinstance(x, dndarray.DNDarray) and cond.split != x.split) or (isinstance(y, dndarray.DNDarray) and cond.split != y.split):
             raise NotImplementedError("binary op not implemented for different split axes")
     if isinstance(x, (dndarray.DNDarray, int, float)) and isinstance(y, (dndarray.DNDarray, int, float)):
+        cond = types.float(cond)
         return (cond == 0) * y + cond * x
     elif x is None and y is None:
         return nonzero(cond)

--- a/heat/core/io.py
+++ b/heat/core/io.py
@@ -269,7 +269,7 @@ else:
 
         # actually load the data
         with nc.Dataset(path, 'r', parallel=__nc_has_par, comm=comm.handle) as handle:
-            data = handle[variable][:]
+            data = handle[variable]
 
             # prepare meta information
             gshape = tuple(data.shape)

--- a/heat/core/linalg.py
+++ b/heat/core/linalg.py
@@ -1,5 +1,4 @@
 import itertools
-import sys
 import torch
 
 from .communication import MPI

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -447,7 +447,7 @@ def sort(a, axis=None, descending=False, out=None):
         comp_op = torch.gt if descending else torch.lt
         # Iterate over all pivots and store which pivot is the first greater than the elements value
         for idx, p in enumerate(global_pivots):
-            lt = comp_op(local_sorted, p)
+            lt = comp_op(local_sorted, p).int()
             if idx > 0:
                 lt_partitions[idx] = lt - last
             else:

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -271,7 +271,7 @@ def concatenate(arrays, axis=0):
                     arr1._DNDarray__array.unsqueeze_(axis)
 
             # now that the data is in the proper shape, need to concatenate them on the nodes where they both exist for the others, just set them equal
-            out = factories.empty((out_shape), split=s0 if s0 is not None else s1, dtype=out_dtype)
+            out = factories.empty(out_shape, split=s0 if s0 is not None else s1, dtype=out_dtype)
             res = torch.cat((arr0._DNDarray__array, arr1._DNDarray__array), dim=axis)
             out._DNDarray__array = res
             return out
@@ -404,7 +404,7 @@ def squeeze(x, axis=None):
         axis = tuple(i for i, dim in enumerate(x.shape) if dim == 1)
     if isinstance(axis, int):
         axis = (axis,)
-    out_lshape = tuple(x.lshape[dim] for dim in range(len(x.lshape)) if not dim in axis)
+    out_lshape = tuple(x.lshape[dim] for dim in range(len(x.lshape)) if dim not in axis)
     x_lsqueezed = x._DNDarray__array.reshape(out_lshape)
 
     # Calculate split axis according to squeezed shape
@@ -419,7 +419,7 @@ def squeeze(x, axis=None):
             if x.split in axis:
                 raise ValueError('Cannot split AND squeeze along same axis. Split is {}, axis is {} for shape {}'.format(
                     x.split, axis, x.shape))
-            out_gshape = tuple(x.gshape[dim] for dim in range(len(x.gshape)) if not dim in axis)
+            out_gshape = tuple(x.gshape[dim] for dim in range(len(x.gshape)) if dim not in axis)
             x_gsqueezed = factories.empty(out_gshape, dtype=x.dtype)
             loffset = factories.zeros(1, dtype=types.int64)
             loffset.__setitem__(0, x.comm.chunk(x.gshape, x.split)[0])

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -219,8 +219,8 @@ def __reduce_op(x, partial_op, reduction_op, **kwargs):
                 partial = partial_op(partial, dim=dim, keepdim=True)
                 output_shape = output_shape[:dim] + (1,) + output_shape[dim + 1:]
         if not keepdim and not len(partial.shape) == 1:
-            gshape_losedim = tuple(x.gshape[dim] for dim in range(len(x.gshape)) if not dim in axis)
-            lshape_losedim = tuple(x.lshape[dim] for dim in range(len(x.lshape)) if not dim in axis)
+            gshape_losedim = tuple(x.gshape[dim] for dim in range(len(x.gshape)) if dim not in axis)
+            lshape_losedim = tuple(x.lshape[dim] for dim in range(len(x.lshape)) if dim not in axis)
             output_shape = gshape_losedim
             # Take care of special cases argmin and argmax: keep partial.shape[0]
             if (0 in axis and partial.shape[0] != 1):

--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -1,10 +1,7 @@
 import torch
-import numpy as np
 
 from .communication import MPI
-from . import factories
 from . import operations
-from . import dndarray
 
 __all__ = [
     'eq',

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -127,7 +127,7 @@ def argmin(x, axis=None, out=None, **kwargs):
         Input array.
     axis : int, optional
         By default, the index is into the flattened tensor, otherwise along the specified axis.
-    # out : ht.DNDarray, optional. Issue #100
+    out : ht.DNDarray, optional. Issue #100
         If provided, the result will be inserted into this tensor. It should be of the appropriate shape and dtype.
 
     Returns
@@ -217,7 +217,7 @@ def max(x, axis=None, out=None, keepdim=None):
 
     Parameters
     ----------
-    a : ht.DNDarray
+    x : ht.DNDarray
         Input data.
     axis : None or int or tuple of ints, optional
         Axis or axes along which to operate. By default, flattened input is used.
@@ -226,6 +226,9 @@ def max(x, axis=None, out=None, keepdim=None):
     out : ht.DNDarray, optional
         Tuple of two output tensors (max, max_indices). Must be of the same shape and buffer length as the expected
         output. The minimum value of an output element. Must be present to allow computation on empty slice.
+    keepdim : bool, optional
+        If this is set to True, the axes which are reduced are left in the result as dimensions with size one.
+        With this option, the result will broadcast correctly against the original arr.
 
     Returns
     -------
@@ -259,8 +262,8 @@ def max(x, axis=None, out=None, keepdim=None):
     return operations.__reduce_op(x, local_max, MPI.MAX, axis=axis, out=out, keepdim=keepdim)
 
 
-def maximum(x1, x2, out=None, **kwargs):
-    '''
+def maximum(x1, x2, out=None):
+    """
     Compares two tensors and returns a new tensor containing the element-wise maxima. 
     If one of the elements being compared is a NaN, then that element is returned. TODO: Check this: If both elements are NaNs then the first is returned. 
     The latter distinction is important for complex NaNs, which are defined as at least one of the real or imaginary parts being a NaN. The net effect is that NaNs are propagated.
@@ -289,46 +292,46 @@ def maximum(x1, x2, out=None, **kwargs):
     >>> torch.manual_seed(1)
     <torch._C.Generator object at 0x105c50b50>
 
-    >>> a = ht.random.randn(3,4)
+    >>> a = ht.random.randn(3, 4)
     >>> a
     tensor([[-0.1955, -0.9656,  0.4224,  0.2673],
             [-0.4212, -0.5107, -1.5727, -0.1232],
             [ 3.5870, -1.8313,  1.5987, -1.2770]])
 
-    >>> b = ht.random.randn(3,4)
+    >>> b = ht.random.randn(3, 4)
     >>> b
     tensor([[ 0.8310, -0.2477, -0.8029,  0.2366],
             [ 0.2857,  0.6898, -0.6331,  0.8795],
             [-0.6842,  0.4533,  0.2912, -0.8317]])
 
-    >>> ht.maximum(a,b)
+    >>> ht.maximum(a, b)
     tensor([[ 0.8310, -0.2477,  0.4224,  0.2673],
             [ 0.2857,  0.6898, -0.6331,  0.8795],
             [ 3.5870,  0.4533,  1.5987, -0.8317]])
 
-    >>> c = ht.random.randn(1,4)
+    >>> c = ht.random.randn(1, 4)
     >>> c
     tensor([[-1.6428,  0.9803, -0.0421, -0.8206]])
 
-    >>> ht.maximum(a,c)
+    >>> ht.maximum(a, c)
     tensor([[-0.1955,  0.9803,  0.4224,  0.2673],
             [-0.4212,  0.9803, -0.0421, -0.1232],
             [ 3.5870,  0.9803,  1.5987, -0.8206]])
 
-    >>> b.__setitem__((0,1), ht.nan) 
+    >>> b.__setitem__((0, 1), ht.nan)
     >>> b
     tensor([[ 0.8310,     nan, -0.8029,  0.2366],
             [ 0.2857,  0.6898, -0.6331,  0.8795],
             [-0.6842,  0.4533,  0.2912, -0.8317]])
-    >>> ht.maximum(a,b)
+    >>> ht.maximum(a, b)
     tensor([[ 0.8310,     nan,  0.4224,  0.2673],
             [ 0.2857,  0.6898, -0.6331,  0.8795],
             [ 3.5870,  0.4533,  1.5987, -0.8317]])
 
-    >>> d = ht.random.randn(3,4,5)
-    >>> ht.maximum(a,d)
+    >>> d = ht.random.randn(3, 4, 5)
+    >>> ht.maximum(a, d)
     ValueError: operands could not be broadcast, input shapes (3, 4) (3, 4, 5)
-    '''
+    """
     # perform sanitation
     if not isinstance(x1, dndarray.DNDarray) or not isinstance(x2, dndarray.DNDarray):
         raise TypeError('expected x1 and x2 to be a ht.DNDarray, but were {}, {} '.format(type(x1), type(x2)))
@@ -337,9 +340,9 @@ def maximum(x1, x2, out=None, **kwargs):
 
     # apply split semantics
     if x1.split is not None or x2.split is not None:
-        if x1.split == None:
+        if x1.split is None:
             x1.resplit(x2.split)
-        if x2.split == None:
+        if x2.split is None:
             x2.resplit(x1.split)
         if x1.split != x2.split:
             if np.prod(x1.gshape) < np.prod(x2.gshape):
@@ -629,7 +632,7 @@ def min(x, axis=None, out=None, keepdim=None):
 
     Parameters
     ----------
-    a : ht.DNDarray
+    x : ht.DNDarray
         Input data.
     axis : None or int or tuple of ints
         Axis or axes along which to operate. By default, flattened input is used.
@@ -638,6 +641,9 @@ def min(x, axis=None, out=None, keepdim=None):
     out : ht.DNDarray, optional
         Tuple of two output tensors (min, min_indices). Must be of the same shape and buffer length as the expected
         output. The maximum value of an output element. Must be present to allow computation on empty slice.
+    keepdim : bool, optional
+        If this is set to True, the axes which are reduced are left in the result as dimensions with size one.
+        With this option, the result will broadcast correctly against the original arr.
 
     Returns
     -------
@@ -672,8 +678,8 @@ def min(x, axis=None, out=None, keepdim=None):
     return operations.__reduce_op(x, local_min, MPI.MIN, axis=axis, out=out, keepdim=keepdim)
 
 
-def minimum(x1, x2, out=None, **kwargs):
-    '''
+def minimum(x1, x2, out=None):
+    """
     Compares two tensors and returns a new tensor containing the element-wise minima. 
     If one of the elements being compared is a NaN, then that element is returned. TODO: Check this: If both elements are NaNs then the first is returned. 
     The latter distinction is important for complex NaNs, which are defined as at least one of the real or imaginary parts being a NaN. The net effect is that NaNs are propagated.
@@ -741,7 +747,7 @@ def minimum(x1, x2, out=None, **kwargs):
     >>> d = ht.random.randn(3,4,5)
     >>> ht.minimum(a,d)
     ValueError: operands could not be broadcast, input shapes (3, 4) (3, 4, 5)
-    '''
+    """
     # perform sanitation
     if not isinstance(x1, dndarray.DNDarray) or not isinstance(x2, dndarray.DNDarray):
         raise TypeError('expected x1 and x2 to be a ht.DNDarray, but were {}, {} '.format(type(x1), type(x2)))
@@ -750,9 +756,9 @@ def minimum(x1, x2, out=None, **kwargs):
 
     # apply split semantics
     if x1.split is not None or x2.split is not None:
-        if x1.split == None:
+        if x1.split is None:
             x1.resplit(x2.split)
-        if x2.split == None:
+        if x2.split is None:
             x2.resplit(x1.split)
         if x1.split != x2.split:
             if np.prod(x1.gshape) < np.prod(x2.gshape):

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -384,7 +384,6 @@ class TestCommunication(unittest.TestCase):
         self.assertTrue((output[0] == first_line).all())
         self.assertTrue((output[output.lshape[0]-1] == last_line).all())
 
-
     def test_allreduce(self):
         # contiguous data
         data = ht.ones((10, 2,), dtype=ht.int8)
@@ -1753,7 +1752,6 @@ class TestCommunication(unittest.TestCase):
         data.comm.Alltoall(ht.MPI.IN_PLACE, data)
         self.assertTrue((data._DNDarray__array == ht.MPI_WORLD.rank).all())
 
-
     def test_reduce(self):
         # contiguous data
         data = ht.ones((10, 2,), dtype=ht.int32)
@@ -2071,7 +2069,6 @@ class TestCommunication(unittest.TestCase):
         data[1, 2, 3] = 123
 
         result = data
-
 
         data.resplit(axis=0)
 

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -45,7 +45,6 @@ class TestExponential(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.exp('hello world')
 
-
     def test_expm1(self):
         elements = 10
         tmp = torch.arange(elements, dtype=torch.float64).expm1()
@@ -171,7 +170,6 @@ class TestExponential(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.log('hello world')
 
-
     def test_log2(self):
         elements = 15
         tmp = torch.arange(1, elements, dtype=torch.float64).log2()
@@ -258,7 +256,6 @@ class TestExponential(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.log10('hello world')
 
-
     def test_log1p(self):
         elements = 15
         tmp = torch.arange(1, elements, dtype=torch.float64).log1p()
@@ -301,7 +298,6 @@ class TestExponential(unittest.TestCase):
             ht.log1p([1, 2, 3])
         with self.assertRaises(TypeError):
             ht.log1p('hello world')
-
 
     def test_sqrt(self):
         elements = 25

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -157,7 +157,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(d.split, None)
         self.assertTrue((d._DNDarray__array == torch.tensor(vector_data).reshape(-1, 1, 1)).all())
 
-       # basic array function, unsplit data, additional dimensions
+        # basic array function, unsplit data, additional dimensions
         vector_data = [4.0, 5.0, 6.0]
         d = ht.array(vector_data, ndmin=-3)
         self.assertIsInstance(d, ht.DNDarray)
@@ -295,8 +295,6 @@ class TestFactories(unittest.TestCase):
                 [1.0, 2.0, 3.0],
                 [1.0, 2.0, 3.0]
             ], split=1, is_split=1)
-
-
 
         # non iterable type
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -20,7 +20,7 @@ class TestIO(unittest.TestCase):
 
         # load comparison data from csv
         csv_path = os.path.join(os.getcwd(), 'heat/datasets/data/iris.csv')
-        cls.IRIS = torch.from_numpy(np.loadtxt(csv_path, delimiter=';')).type(torch.float32)
+        cls.IRIS = torch.from_numpy(np.loadtxt(csv_path, delimiter=';')).float()
 
     def tearDown(self):
         # synchronize all nodes

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -19,6 +19,7 @@ class TestIO(unittest.TestCase):
         cls.NETCDF_VARIABLE = 'data'
 
         # load comparison data from csv
+        cls.CSV_PATH = os.path.join(os.getcwd(), 'heat/datasets/data/iris.csv')
         cls.IRIS = torch.from_numpy(np.loadtxt(cls.CSV_PATH, delimiter=';')).float()
 
     def tearDown(self):

--- a/heat/core/tests/test_linalg.py
+++ b/heat/core/tests/test_linalg.py
@@ -4,6 +4,7 @@ import unittest
 import heat as ht
 import numpy as np
 
+
 class TestLinalg(unittest.TestCase):
     def test_matmul(self):
         # cases to test:

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -16,7 +16,7 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(x.shape, (1,))
         self.assertEqual(x.lshape, (1,))
         self.assertEqual(x.dtype, ht.bool)
-        self.assertEqual(x._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(x._DNDarray__array.dtype, torch.bool)
         self.assertEqual(x.split, None)
         self.assertEqual(x._DNDarray__array, 1)
 
@@ -32,7 +32,7 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(floats_is_one.shape, (1,))
         self.assertEqual(floats_is_one.lshape, (1,))
         self.assertEqual(floats_is_one.dtype, ht.bool)
-        self.assertEqual(floats_is_one._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(floats_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(floats_is_one.split, None)
         self.assertEqual(floats_is_one._DNDarray__array, 1)
 
@@ -48,7 +48,7 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(int_is_one.shape, (1,))
         self.assertEqual(int_is_one.lshape, (1,))
         self.assertEqual(int_is_one.dtype, ht.bool)
-        self.assertEqual(int_is_one._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(int_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(int_is_one.split, None)
         self.assertEqual(int_is_one._DNDarray__array, 1)
 
@@ -64,7 +64,7 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(split_int_is_one.shape, (1,))
         self.assertEqual(split_int_is_one.lshape, (1,))
         self.assertEqual(split_int_is_one.dtype, ht.bool)
-        self.assertEqual(split_int_is_one._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(split_int_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(split_int_is_one.split, None)
         self.assertEqual(split_int_is_one._DNDarray__array, 1)
 
@@ -80,7 +80,7 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(volume_is_one.shape, (1,))
         self.assertEqual(volume_is_one.lshape, (1,))
         self.assertEqual(volume_is_one.dtype, ht.bool)
-        self.assertEqual(volume_is_one._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(volume_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(volume_is_one.split, None)
         self.assertEqual(volume_is_one._DNDarray__array, 1)
 
@@ -96,7 +96,7 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(sequence_is_one.shape, (1,))
         self.assertEqual(sequence_is_one.lshape, (1,))
         self.assertEqual(sequence_is_one.dtype, ht.bool)
-        self.assertEqual(sequence_is_one._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(sequence_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(sequence_is_one.split, None)
         self.assertEqual(sequence_is_one._DNDarray__array, 0)
 
@@ -111,7 +111,7 @@ class TestLogical(unittest.TestCase):
         self.assertIsInstance(float_volume_is_one, ht.DNDarray)
         self.assertEqual(float_volume_is_one.shape, (3, 3))
         self.assertEqual(float_volume_is_one.all(axis=1).dtype, ht.bool)
-        self.assertEqual(float_volume_is_one._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(float_volume_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(float_volume_is_one.split, None)
 
         out_noaxis = ht.zeros((3, 3,))
@@ -124,7 +124,7 @@ class TestLogical(unittest.TestCase):
         self.assertIsInstance(float_volume_is_one, ht.DNDarray)
         self.assertEqual(float_volume_is_one.shape, (3,))
         self.assertEqual(float_volume_is_one.all(axis=0).dtype, ht.bool)
-        self.assertEqual(float_volume_is_one._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(float_volume_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(float_volume_is_one.split, None)
 
         # check all over all float elements of split 5d tensor with negative axis
@@ -134,7 +134,7 @@ class TestLogical(unittest.TestCase):
         self.assertIsInstance(float_5d_is_one, ht.DNDarray)
         self.assertEqual(float_5d_is_one.shape, (1, 2, 3, 5))
         self.assertEqual(float_5d_is_one.dtype, ht.bool)
-        self.assertEqual(float_5d_is_one._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(float_5d_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(float_5d_is_one.split, 1)
 
         out_noaxis = ht.zeros((1, 2, 3, 5))

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -255,7 +255,7 @@ class TestManipulations(unittest.TestCase):
         # None None 0
         x = ht.zeros((16,), split=None)
         y = ht.ones((16,), split=None)
-        res = ht.concatenate((x,y), axis=0)
+        res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32,))
         self.assertEqual(res.dtype, ht.float)
         # None 0 0
@@ -300,7 +300,6 @@ class TestManipulations(unittest.TestCase):
             ht.concatenate((ht.zeros((12, 12)), ht.zeros((2, 2))), axis=0)
         with self.assertRaises(RuntimeError):
             ht.concatenate((ht.zeros((2, 2), split=0), ht.zeros((2, 2), split=1)), axis=0)
-
 
     def test_expand_dims(self):
         # vector data

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -15,7 +15,6 @@ class TestOperations(unittest.TestCase):
         result = right_tensor + left_tensor
         self.assertEqual(result.shape, (4, 2))
 
-
         # broadcast with split=0 for both operants 
         left_tensor = ht.ones((4, 1), split=0)
         right_tensor = ht.ones((1, 2), split=0)

--- a/heat/core/tests/test_rounding.py
+++ b/heat/core/tests/test_rounding.py
@@ -95,7 +95,7 @@ class TestRounding(unittest.TestCase):
         self.assertIsInstance(float32_floor, ht.DNDarray)
         self.assertEqual(float32_floor.dtype, ht.float32)
         self.assertEqual(float32_floor.dtype, ht.float32)
-        self.assertTrue((float32_floor._DNDarray__array == comparison.type(torch.float32)).all())
+        self.assertTrue((float32_floor._DNDarray__array == comparison.float()).all())
 
         # exponential of float64
         float64_tensor = ht.arange(start, end, step, dtype=ht.float64)
@@ -146,7 +146,7 @@ class TestRounding(unittest.TestCase):
         self.assertIsInstance(float32_floor, ht.DNDarray)
         self.assertEqual(float32_floor.dtype, ht.float32)
         self.assertEqual(float32_floor.dtype, ht.float32)
-        self.assertTrue((float32_floor._DNDarray__array == comparison.type(torch.float32)).all())
+        self.assertTrue((float32_floor._DNDarray__array == comparison.float()).all())
 
         # exponential of float64
         float64_tensor = ht.arange(start, end, step, dtype=ht.float64)
@@ -172,7 +172,7 @@ class TestRounding(unittest.TestCase):
         float32_floor = float32_tensor.trunc()
         self.assertIsInstance(float32_floor, ht.DNDarray)
         self.assertEqual(float32_floor.dtype, ht.float32)
-        self.assertTrue((float32_floor._DNDarray__array == comparison.type(torch.float32)).all())
+        self.assertTrue((float32_floor._DNDarray__array == comparison.float()).all())
 
         # trunc of float64
         float64_tensor = ht.array(base_array, dtype=ht.float64)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -325,14 +325,14 @@ class TestStatistics(unittest.TestCase):
         maximum_volume_splitdiff = ht.maximum(random_volume_1_splitdiff, random_volume_2_splitdiff)
         self.assertEqual(maximum_volume_splitdiff.split, 0)
 
-        random_volume_1_splitNone = ht.array(ht.random.randn(size*3, size*3, 4), split=None)
+        random_volume_1_split_none = ht.array(ht.random.randn(size*3, size*3, 4), split=None)
         random_volume_2_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=1)
-        maximum_volume_splitdiff = ht.maximum(random_volume_1_splitNone, random_volume_2_splitdiff)
+        maximum_volume_splitdiff = ht.maximum(random_volume_1_split_none, random_volume_2_splitdiff)
         self.assertEqual(maximum_volume_splitdiff.split, 1)
 
-        random_volume_1_splitNone = ht.array(ht.random.randn(size*3, size*3, 4), split=0)
+        random_volume_1_split_none = ht.array(ht.random.randn(size*3, size*3, 4), split=0)
         random_volume_2_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=None)
-        maximum_volume_splitdiff = ht.maximum(random_volume_1_splitNone, random_volume_2_splitdiff)
+        maximum_volume_splitdiff = ht.maximum(random_volume_1_split_none, random_volume_2_splitdiff)
         self.assertEqual(maximum_volume_splitdiff.split, 0)
 
         # check output buffer
@@ -571,14 +571,14 @@ class TestStatistics(unittest.TestCase):
         minimum_volume_splitdiff = ht.minimum(random_volume_1_splitdiff, random_volume_2_splitdiff)
         self.assertEqual(minimum_volume_splitdiff.split, 0)
 
-        random_volume_1_splitNone = ht.array(ht.random.randn(size*3, size*3, 4), split=None)
+        random_volume_1_split_none = ht.array(ht.random.randn(size*3, size*3, 4), split=None)
         random_volume_2_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=1)
-        minimum_volume_splitdiff = ht.minimum(random_volume_1_splitNone, random_volume_2_splitdiff)
+        minimum_volume_splitdiff = ht.minimum(random_volume_1_split_none, random_volume_2_splitdiff)
         self.assertEqual(minimum_volume_splitdiff.split, 1)
 
-        random_volume_1_splitNone = ht.array(ht.random.randn(size*3, size*3, 4), split=0)
+        random_volume_1_split_none = ht.array(ht.random.randn(size*3, size*3, 4), split=0)
         random_volume_2_splitdiff = ht.array(ht.random.randn(size*3, size*3, 4), split=None)
-        minimum_volume_splitdiff = ht.minimum(random_volume_1_splitNone, random_volume_2_splitdiff)
+        minimum_volume_splitdiff = ht.minimum(random_volume_1_split_none, random_volume_2_splitdiff)
         self.assertEqual(minimum_volume_splitdiff.split, 0)
 
         # check output buffer

--- a/heat/core/tests/test_trigonometrics.py
+++ b/heat/core/tests/test_trigonometrics.py
@@ -7,7 +7,7 @@ import heat as ht
 class TestTrigonometrics(unittest.TestCase):
     def test_rad2deg(self):
         # base elements
-        elements = [0.,0.2,0.6,0.9,1.2,2.7,3.14]
+        elements = [0., 0.2, 0.6, 0.9, 1.2, 2.7, 3.14]
         comparison = 180. * torch.tensor(elements, dtype=torch.float64) / 3.141592653589793
 
         # rad2deg with float32
@@ -15,14 +15,14 @@ class TestTrigonometrics(unittest.TestCase):
         float32_rad2deg = ht.rad2deg(float32_tensor)
         self.assertIsInstance(float32_rad2deg, ht.DNDarray)
         self.assertEqual(float32_rad2deg.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_rad2deg._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_rad2deg._DNDarray__array.double(), comparison))
   
         # rad2deg with float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_rad2deg = ht.rad2deg(float64_tensor)
         self.assertIsInstance(float64_rad2deg, ht.DNDarray)
         self.assertEqual(float64_rad2deg.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_rad2deg._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_rad2deg._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -32,7 +32,7 @@ class TestTrigonometrics(unittest.TestCase):
 
     def test_degrees(self):
         # base elements
-        elements = [0.,0.2,0.6,0.9,1.2,2.7,3.14]
+        elements = [0., 0.2, 0.6, 0.9, 1.2, 2.7, 3.14]
         comparison = 180. * torch.tensor(elements,dtype=torch.float64) / 3.141592653589793
 
         # degrees with float32
@@ -40,14 +40,14 @@ class TestTrigonometrics(unittest.TestCase):
         float32_degrees = ht.degrees(float32_tensor)
         self.assertIsInstance(float32_degrees, ht.DNDarray)
         self.assertEqual(float32_degrees.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_degrees._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_degrees._DNDarray__array.double(), comparison))
   
         # degrees with float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_degrees = ht.degrees(float64_tensor)
         self.assertIsInstance(float64_degrees, ht.DNDarray)
         self.assertEqual(float64_degrees.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_degrees._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_degrees._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -57,7 +57,7 @@ class TestTrigonometrics(unittest.TestCase):
 
     def test_deg2rad(self):
         # base elements
-        elements = [0.,20.,45.,78.,94.,120.,180., 270., 311.]
+        elements = [0., 20., 45., 78., 94., 120., 180., 270., 311.]
         comparison = 3.141592653589793 * torch.tensor(elements, dtype=torch.float64) / 180.
 
         # deg2rad with float32
@@ -65,14 +65,14 @@ class TestTrigonometrics(unittest.TestCase):
         float32_deg2rad = ht.deg2rad(float32_tensor)
         self.assertIsInstance(float32_deg2rad, ht.DNDarray)
         self.assertEqual(float32_deg2rad.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_deg2rad._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_deg2rad._DNDarray__array.double(), comparison))
   
         # deg2rad with float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_deg2rad = ht.deg2rad(float64_tensor)
         self.assertIsInstance(float64_deg2rad, ht.DNDarray)
         self.assertEqual(float64_deg2rad.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_deg2rad._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_deg2rad._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -82,7 +82,7 @@ class TestTrigonometrics(unittest.TestCase):
 
     def test_radians(self):
         # base elements
-        elements = [0.,20.,45.,78.,94.,120.,180., 270., 311.]
+        elements = [0., 20., 45., 78., 94., 120., 180., 270., 311.]
         comparison = 3.141592653589793 * torch.tensor(elements, dtype=torch.float64) / 180.
 
         # radians with float32
@@ -90,14 +90,14 @@ class TestTrigonometrics(unittest.TestCase):
         float32_radians = ht.radians(float32_tensor)
         self.assertIsInstance(float32_radians, ht.DNDarray)
         self.assertEqual(float32_radians.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_radians._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_radians._DNDarray__array.double(), comparison))
   
         # radians with float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_radians = ht.radians(float64_tensor)
         self.assertIsInstance(float64_radians, ht.DNDarray)
         self.assertEqual(float64_radians.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_radians._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_radians._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -115,28 +115,28 @@ class TestTrigonometrics(unittest.TestCase):
         float32_arctan = ht.arctan(float32_tensor)
         self.assertIsInstance(float32_arctan, ht.DNDarray)
         self.assertEqual(float32_arctan.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arctan._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_arctan._DNDarray__array.double(), comparison))
 
         # arctan of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_arctan = ht.arctan(float64_tensor)
         self.assertIsInstance(float64_arctan, ht.DNDarray)
         self.assertEqual(float64_arctan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_arctan._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_arctan._DNDarray__array.double(), comparison))
 
         # arctan of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_arctan = ht.arctan(int32_tensor)
         self.assertIsInstance(int32_arctan, ht.DNDarray)
         self.assertEqual(int32_arctan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float32_arctan._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_arctan._DNDarray__array.double(), comparison))
 
         # arctan of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_arctan = ht.arctan(int64_tensor)
         self.assertIsInstance(int64_arctan, ht.DNDarray)
         self.assertEqual(int64_arctan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_arctan._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int64_arctan._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -146,7 +146,7 @@ class TestTrigonometrics(unittest.TestCase):
 
     def test_arcsin(self):
         # base elements
-        elements = [-1.,-0.83,-0.12,0.,0.24,0.67,1.]
+        elements = [-1., -0.83, -0.12, 0., 0.24, 0.67, 1.]
         comparison = torch.tensor(elements, dtype=torch.float64).asin()
 
         # arcsin of float32
@@ -154,14 +154,14 @@ class TestTrigonometrics(unittest.TestCase):
         float32_arcsin = ht.arcsin(float32_tensor)
         self.assertIsInstance(float32_arcsin, ht.DNDarray)
         self.assertEqual(float32_arcsin.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arcsin._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_arcsin._DNDarray__array.double(), comparison))
         
         # arcsin of float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_arcsin = ht.arcsin(float64_tensor)
         self.assertIsInstance(float64_arcsin, ht.DNDarray)
         self.assertEqual(float64_arcsin.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_arcsin._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_arcsin._DNDarray__array.double(), comparison))
        
         # arcsin of value out of domain 
         nan_tensor = ht.array([1.2])
@@ -178,7 +178,7 @@ class TestTrigonometrics(unittest.TestCase):
 
     def test_arccos(self):
         # base elements
-        elements = [-1.,-0.83,-0.12,0.,0.24,0.67,1.]
+        elements = [-1., -0.83, -0.12, 0., 0.24, 0.67, 1.]
         comparison = torch.tensor(elements, dtype=torch.float64).acos()
 
         # arccos of float32
@@ -186,14 +186,14 @@ class TestTrigonometrics(unittest.TestCase):
         float32_arccos = ht.arccos(float32_tensor)
         self.assertIsInstance(float32_arccos, ht.DNDarray)
         self.assertEqual(float32_arccos.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arccos._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_arccos._DNDarray__array.double(), comparison))
         
         # arccos of float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_arccos = ht.arccos(float64_tensor)
         self.assertIsInstance(float64_arccos, ht.DNDarray)
         self.assertEqual(float64_arccos.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_arccos._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_arccos._DNDarray__array.double(), comparison))
        
         # arccos of value out of domain 
         nan_tensor = ht.array([1.2])
@@ -218,28 +218,28 @@ class TestTrigonometrics(unittest.TestCase):
         float32_cos = ht.cos(float32_tensor)
         self.assertIsInstance(float32_cos, ht.DNDarray)
         self.assertEqual(float32_cos.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_cos._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_cos._DNDarray__array.double(), comparison))
 
         # cosine of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_cos = ht.cos(float64_tensor)
         self.assertIsInstance(float64_cos, ht.DNDarray)
         self.assertEqual(float64_cos.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_cos._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_cos._DNDarray__array.double(), comparison))
 
         # cosine of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_cos = ht.cos(int32_tensor)
         self.assertIsInstance(int32_cos, ht.DNDarray)
         self.assertEqual(int32_cos.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float32_cos._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_cos._DNDarray__array.double(), comparison))
 
         # cosine of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_cos = int64_tensor.cos()
         self.assertIsInstance(int64_cos, ht.DNDarray)
         self.assertEqual(int64_cos.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_cos._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int64_cos._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -257,28 +257,28 @@ class TestTrigonometrics(unittest.TestCase):
         float32_cosh = float32_tensor.cosh()
         self.assertIsInstance(float32_cosh, ht.DNDarray)
         self.assertEqual(float32_cosh.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_cosh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_cosh._DNDarray__array.double(), comparison))
 
         # hyperbolic cosine of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_cosh = ht.cosh(float64_tensor)
         self.assertIsInstance(float64_cosh, ht.DNDarray)
         self.assertEqual(float64_cosh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_cosh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_cosh._DNDarray__array.double(), comparison))
 
         # hyperbolic cosine of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_cosh = ht.cosh(int32_tensor)
         self.assertIsInstance(int32_cosh, ht.DNDarray)
         self.assertEqual(int32_cosh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float32_cosh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_cosh._DNDarray__array.double(), comparison))
 
         # hyperbolic cosine of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_cosh = ht.cosh(int64_tensor)
         self.assertIsInstance(int64_cosh, ht.DNDarray)
         self.assertEqual(int64_cosh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_cosh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int64_cosh._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -296,28 +296,28 @@ class TestTrigonometrics(unittest.TestCase):
         float32_sin = float32_tensor.sin()
         self.assertIsInstance(float32_sin, ht.DNDarray)
         self.assertEqual(float32_sin.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_sin._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_sin._DNDarray__array.double(), comparison))
 
         # sine of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_sin = ht.sin(float64_tensor)
         self.assertIsInstance(float64_sin, ht.DNDarray)
         self.assertEqual(float64_sin.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_sin._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_sin._DNDarray__array.double(), comparison))
 
         # sine of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_sin = ht.sin(int32_tensor)
         self.assertIsInstance(int32_sin, ht.DNDarray)
         self.assertEqual(int32_sin.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int32_sin._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int32_sin._DNDarray__array.double(), comparison))
 
         # sine of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_sin = ht.sin(int64_tensor)
         self.assertIsInstance(int64_sin, ht.DNDarray)
         self.assertEqual(int64_sin.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_sin._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int64_sin._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -335,28 +335,28 @@ class TestTrigonometrics(unittest.TestCase):
         float32_sinh = float32_tensor.sinh()
         self.assertIsInstance(float32_sinh, ht.DNDarray)
         self.assertEqual(float32_sinh.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_sinh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_sinh._DNDarray__array.double(), comparison))
 
         # hyperbolic sine of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_sinh = ht.sinh(float64_tensor)
         self.assertIsInstance(float64_sinh, ht.DNDarray)
         self.assertEqual(float64_sinh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_sinh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_sinh._DNDarray__array.double(), comparison))
 
         # hyperbolic sine of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_sinh = ht.sinh(int32_tensor)
         self.assertIsInstance(int32_sinh, ht.DNDarray)
         self.assertEqual(int32_sinh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int32_sinh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int32_sinh._DNDarray__array.double(), comparison))
 
         # hyperbolic sine of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_sinh = ht.sinh(int64_tensor)
         self.assertIsInstance(int64_sinh, ht.DNDarray)
         self.assertEqual(int64_sinh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_sinh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int64_sinh._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -374,28 +374,28 @@ class TestTrigonometrics(unittest.TestCase):
         float32_tan = float32_tensor.tan()
         self.assertIsInstance(float32_tan, ht.DNDarray)
         self.assertEqual(float32_tan.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_tan._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_tan._DNDarray__array.double(), comparison))
 
         # tangent of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_tan = ht.tan(float64_tensor)
         self.assertIsInstance(float64_tan, ht.DNDarray)
         self.assertEqual(float64_tan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_tan._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_tan._DNDarray__array.double(), comparison))
 
         # tangent of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_tan = ht.tan(int32_tensor)
         self.assertIsInstance(int32_tan, ht.DNDarray)
         self.assertEqual(int32_tan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int32_tan._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int32_tan._DNDarray__array.double(), comparison))
 
         # tangent of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_tan = ht.tan(int64_tensor)
         self.assertIsInstance(int64_tan, ht.DNDarray)
         self.assertEqual(int64_tan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_tan._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int64_tan._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -413,28 +413,28 @@ class TestTrigonometrics(unittest.TestCase):
         float32_tanh = float32_tensor.tanh()
         self.assertIsInstance(float32_tanh, ht.DNDarray)
         self.assertEqual(float32_tanh.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_tanh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float32_tanh._DNDarray__array.double(), comparison))
 
         # hyperbolic tangent of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_tanh = ht.tanh(float64_tensor)
         self.assertIsInstance(float64_tanh, ht.DNDarray)
         self.assertEqual(float64_tanh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_tanh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(float64_tanh._DNDarray__array.double(), comparison))
 
         # hyperbolic tangent of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_tanh = ht.tanh(int32_tensor)
         self.assertIsInstance(int32_tanh, ht.DNDarray)
         self.assertEqual(int32_tanh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int32_tanh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int32_tanh._DNDarray__array.double(), comparison))
 
         # hyperbolic tangent of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_tanh = ht.tanh(int64_tensor)
         self.assertIsInstance(int64_tanh, ht.DNDarray)
         self.assertEqual(int64_tanh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_tanh._DNDarray__array.type(torch.double), comparison))
+        self.assertTrue(torch.allclose(int64_tanh._DNDarray__array.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_types.py
+++ b/heat/core/tests/test_types.py
@@ -45,8 +45,8 @@ class TestTypes(unittest.TestCase):
         self.assert_non_instantiable_heat_type(ht.generic)
 
     def test_bool(self):
-        self.assert_is_instantiable_heat_type(ht.bool, torch.uint8)
-        self.assert_is_instantiable_heat_type(ht.bool_, torch.uint8)
+        self.assert_is_instantiable_heat_type(ht.bool, torch.bool)
+        self.assert_is_instantiable_heat_type(ht.bool_, torch.bool)
 
     def test_number(self):
         self.assert_non_instantiable_heat_type(ht.number)

--- a/heat/core/trigonometrics.py
+++ b/heat/core/trigonometrics.py
@@ -204,7 +204,7 @@ def degrees(x, out=None):
     >>> ht.degrees(ht.array([0.,0.2,0.6,0.9,1.2,2.7,3.14])) 
     tensor([  0.0000,  11.4592,  34.3775,  51.5662,  68.7549, 154.6986, 179.9088])
     """
-    return rad2deg(x, out=None)  
+    return rad2deg(x, out=out)
 
 
 def rad2deg(x, out=None):
@@ -235,7 +235,7 @@ def rad2deg(x, out=None):
             raise TypeError("Input is not a torch tensor but {}".format(type(torch_tensor)))
         return 180. * torch_tensor / pi
 
-    return local_op(torch_rad2deg, x, out)
+    return local_op(torch_rad2deg, x, out=out)
 
 
 def radians(x, out=None):
@@ -272,6 +272,9 @@ def sin(x, out=None):
     ----------
     x : ht.DNDarray
         The value for which to compute the trigonometric tangent.
+    out : ht.DNDarray or None, optional
+        A location in which to store the results. If provided, it must have a broadcastable shape. If not provided
+        or set to None, a fresh tensor is allocated.
 
     Returns
     -------

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -106,7 +106,7 @@ class generic:
 class bool(generic):
     @classmethod
     def torch_type(cls):
-        return torch.uint8
+        return torch.bool
 
     @classmethod
     def char(cls):
@@ -259,6 +259,7 @@ __type_mappings = {
     np.float64:     float64,
 
     # torch types
+    torch.bool:     bool,
     torch.uint8:    uint8,
     torch.int8:     int8,
     torch.int16:    int16,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'mpi4py>=3.0.0',
         'numpy>=1.13.0',
-        'torch>=1.0.0'
+        'torch>=1.2.0'
     ],
     extras_require={
         'hdf5':  ['h5py>=2.8.0'],


### PR DESCRIPTION
## Description

This is a package of a few different bug fixes, small improvements, and formatting corrections

Fixes: #346 #358 

Changes proposed:
- pep8 formatting corrections
- the load netcdf function no longer creates a numpy masked array, there is no need for this
- updated torch dependency to 1.2.0
- added support fro torch 1.2.0 (addition of torch.bool is what required the change)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue) -> tests failing with torch 1.2.0
- [X] New feature (non-breaking change which adds functionality) -> bools
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) **-> hings will fail with torch < 1.2.0**
- [ ] This change requires a documentation update

Have you handled and tested all split configurations?
yes, no new tests required. all tests running without fail locally