### PR TITLE
All to all mpi type buffer prep

### DIFF
--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -197,6 +197,7 @@ class MPICommunication(Communication):
             mpi_type = mpi_type.Create_vector(shape[i], 1, strides[i]).Create_resized(0, offsets[i])
             mpi_type.Commit()
 
+
         if counts is not None:
             return mpi_type, (counts, displs,)
 
@@ -511,6 +512,7 @@ class MPICommunication(Communication):
         # keep a reference to the original buffer object
         original_recvbuf = recvbuf
 
+
         # permute the send_axis order so that the split send_axis is the first to be transmitted
         if(axis !=0 ):
             send_axis_permutation = list(range(sendbuf.ndimension()))
@@ -522,6 +524,7 @@ class MPICommunication(Communication):
             recv_axis_permutation[0], recv_axis_permutation[axis] = axis, 0
             recvbuf = recvbuf.permute(*recv_axis_permutation)
 
+
         # prepare buffer objects
         if sendbuf is  MPI.IN_PLACE or not isinstance(sendbuf, torch.Tensor):
             mpi_sendbuf = sendbuf
@@ -530,6 +533,7 @@ class MPICommunication(Communication):
             if send_counts is not None:
                 mpi_sendbuf[1] = mpi_sendbuf[1][0][self.rank]
 
+        self.Barrier()
         if recvbuf is MPI.IN_PLACE or not isinstance(recvbuf, torch.Tensor):
             mpi_recvbuf = recvbuf
         else:
@@ -537,6 +541,7 @@ class MPICommunication(Communication):
             if recv_counts is None:
                 mpi_recvbuf[1] //= self.size
 
+        self.Barrier()
         # perform the scatter operation
         exit_code = func(mpi_sendbuf, mpi_recvbuf, **kwargs)
 

--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -187,7 +187,6 @@ class MPICommunication(Communication):
         strides[0] = obj.stride()[-1]
         strides = strides[::-1]
         offsets = [obj.element_size() * stride for stride in obj.stride()[:-1]]
-        print("Vector wrapping: elements={}, shape={}, strides={}, offsets={}".format(elements, shape, strides, offsets))
 
         # chain the types based on the
         for i in range(len(shape) - 1, -1, -1):
@@ -469,26 +468,12 @@ class MPICommunication(Communication):
     def alltoall_sendbuffer(cls, obj, nproc, counts=None, displs=None): #This is a temporary soltion to pass number of arguments as variable. Better to access via cls itself, but how?
         mpi_type, elements = cls.__mpi_type_mappings[obj.dtype], torch.numel(obj)
 
-        #print( "Obj Info: obj.shape = {}, obj.stride = {}".format(obj.shape, obj.stride()))
-
-        # simple case, continuous memory can be transmitted as is
-        #if obj.is_contiguous() :
-        #    if counts is None:
-        #        return mpi_type, elements
-        #    else:
-        #        factor = np.prod(obj.shape[1:])
-        #        return mpi_type, (tuple(factor * ele for ele in counts), (tuple(factor * ele for ele in displs)),)
-
-        # non-continuous memory, e.g. after a transpose, has to be packed in derived MPI types
         shape = obj.shape
         strides = [1] * len(shape)
         strides[-1] = obj.stride()[-1]
 
         offsets = [0]*len(shape)
         offsets[1:] = [obj.element_size() * stride for stride in obj.stride()[:-1]]
-
-
-        #print("Vector wrapping: shape={}, strides={}, offsets={}".format(shape,strides, offsets))
 
         # Step 1: Wrap along axes > 1 (all axes except send_axis and recv_axis
         for i in range(len(shape) - 1, 1, -1):
@@ -516,16 +501,12 @@ class MPICommunication(Communication):
         #Step 4: Prepare sencounts, senddispls and sendtypes for alltoallw
         # to each process 1 element (=sendcount) of the custom prepared long or short type will be send
         sendcount = [1]*nproc
-
         tmp_displs = [0] * nproc
         tmp_displs[1:] = np.cumsum(send_elements[:-1] )
         senddispls = [obj.element_size() * obj.stride()[1] * d for d in tmp_displs]
-
         sendtypes = [mpi_short_type]*nproc
         for i in range(obj.shape[1]%nproc):
             sendtypes[i] = mpi_long_type
-
-        #print("sendcount = {}, senddispls={}, sendtypes = {}".format(sendcount, senddispls, sendtypes))
 
         return cls.as_mpi_memory(obj), (sendcount, senddispls), sendtypes
 
@@ -533,23 +514,11 @@ class MPICommunication(Communication):
     def alltoall_recvbuffer(cls, obj, nproc, counts=None, displs=None):  # This is a temporary soltion to pass number of arguments as variable. Better to access via cls itself, but how?
         mpi_type, elements = cls.__mpi_type_mappings[obj.dtype], torch.numel(obj)
 
-
-        #print( "Obj Info: obj.shape = {}, obj.stride = {}".format(obj.shape, obj.stride()))
-        # simple case, continuous memory can be transmitted as is
-        #if obj.is_contiguous():
-        #    if counts is not None:
-        #        factor = np.prod(obj.shape[1:])
-        #        elements = (tuple(factor * ele for ele in counts), (tuple(factor * ele for ele in displs)),)
-        #        return [cls.as_mpi_memory(obj), elements, mpi_type]
-
-        # non-continuous memory, e.g. after a transpose, has to be packed in derived MPI types
         shape = obj.shape[1:]
         strides = [1] * len(shape)
         strides[0] = obj.stride()[-1]
         strides = strides[::-1]
         offsets = [obj.element_size() * stride for stride in obj.stride()[:-1]]
-
-        #print("Vector wrapping: shape={}, strides={}, offsets={}".format(shape, strides, offsets))
 
         # Step 1: Wrap along axes > 0 (all axes except recv_axis)
         for i in range(len(shape) - 1, -1, -1):
@@ -560,18 +529,19 @@ class MPICommunication(Communication):
         # Prepare recvcount, senddispls and sendtypes for alltoallw
         recvcount = np.full((nproc,), obj.shape[0]//nproc)
         recvcount[:obj.shape[0]%nproc]+=1
-
         # size/extent of mpitype = offsets[0]
         tmp_displs = [0] * nproc
         tmp_displs[1:] = np.cumsum(recvcount[:-1] )
         recvdispls = [offsets[0] * d for d in tmp_displs]
-
         recvtypes = [mpi_type] * nproc
-        #print("recvcounts = {}, recvdispls={}, recvtypes = {}".format(recvcount, recvdispls, recvtypes))
+
         return cls.as_mpi_memory(obj), (recvcount, recvdispls), recvtypes
 
 
-    def __alltoall_like(self, func, sendbuf, recvbuf, send_axis, recv_axis, send_factor=1, recv_factor=1, **kwargs):
+    def __alltoall_w(self, sendbuf, recvbuf, send_axis, recv_axis, **kwargs):
+
+        if (recv_axis == send_axis):
+            raise NotImplementedError('AllToAll for same axes not supported. Please choose send_axis and recv_axis to be different.')
 
         # dummy allocation for *v calls
         send_counts, send_displs, recv_counts, recv_displs = None, None, None, None,
@@ -592,7 +562,6 @@ class MPICommunication(Communication):
         if not isinstance(recvbuf, torch.Tensor) and send_axis != 0:
             raise TypeError('recvbuf of type {} does not support send_axis != 0'.format(type(recvbuf)))
 
-
         # keep a reference to the original buffer object
         original_recvbuf = recvbuf
 
@@ -611,47 +580,43 @@ class MPICommunication(Communication):
             axis_permutation[send_axis] = axis_permutation[1]
             axis_permutation[1] = send_axis
 
-        MPI_WORLD.Barrier()
-        #print("SEND AXIS PERMUTE: ", send_axis_permutation)
         sendbuf = sendbuf.permute(*axis_permutation)
-
         recvbuf = recvbuf.permute(*axis_permutation)
 
         # prepare buffer objects
-        #MPI_WORLD.Barrier()
-        #print("############## SEND BUF PREPARATION ###########")
-        #if sendbuf is not MPI.IN_PLACE:
         nproc = self.size
+        #if sendbuf is not MPI.IN_PLACE: --> Can we allow IN_Place opperation? (Buffer config might be wrong
         mpi_sendbuf = self.alltoall_sendbuffer(sendbuf, nproc, send_counts, send_displs)
-            #if send_counts is None:
-                #mpi_sendbuf[1] //= send_factor
         #else:
         #   mpi_sendbuf = sendbuf
 
-
-        #MPI_WORLD.Barrier()
-        #print("############## RECV BUF PREPARATION ###########")
         #if recvbuf is not MPI.IN_PLACE:
         mpi_recvbuf = self.alltoall_recvbuffer(recvbuf, nproc, recv_counts, recv_displs)
-            #if recv_counts is None:
-             #   mpi_recvbuf[1] //= recv_factor
         #else:
         #    mpi_recvbuf = recvbuf
 
-        # perform the scatter operation
-        exit_code = func(mpi_sendbuf, mpi_recvbuf, **kwargs)
-
+        exit_code = self.handle.Alltoallw(mpi_sendbuf, mpi_recvbuf, **kwargs)
         original_recvbuf.set_(recvbuf.storage(), recvbuf.storage_offset(), original_recvbuf.shape, original_recvbuf.stride())
 
         return exit_code
 
 
-    def Alltoall(self, sendbuf, recvbuf, axis=0, recv_axis=None):
-        return self.__alltoall_like(self.handle.Alltoallw, sendbuf, recvbuf, axis, recv_axis, send_factor=self.size, recv_factor=self.size)
+    def Alltoall(self, sendbuf, recvbuf, axis, recv_axis):
+        raise NotImplementedError(
+            'AllToAll for same axes not supported. Please choose send_axis and recv_axis to be different.')
+        if(((axis == 0) & (recv_axis == 1)) | ((axis == 1) & (recv_axis == 0))):
+            return self.__scatter_like(self.handle.Alltoall, sendbuf, recvbuf, axis, recv_axis, send_factor=self.size, recv_factor=self.size)
+        else:
+            return self.__alltoall_w(sendbuf, recvbuf, axis, recv_axis)
     Alltoall.__doc__ = MPI.Comm.Alltoall.__doc__
 
-    def Alltoallv(self, sendbuf, recvbuf, axis=0, recv_axis=None):
-        return self.__alltoall_like(self.handle.Alltoallw, sendbuf, recvbuf, axis, recv_axis)
+    def Alltoallv(self, sendbuf, recvbuf, axis, recv_axis):
+        raise NotImplementedError(
+            'AllToAll for same axes not supported. Please choose send_axis and recv_axis to be different.')
+        if(((axis == 0) & (recv_axis == 1)) | ((axis == 1) & (recv_axis == 0))):
+            return self.__scatter_like(self.handle.Alltoallv, sendbuf, recvbuf, axis, recv_axis, send_factor=self.size, recv_factor=self.size)
+        else:
+            return self.__alltoall_w(sendbuf, recvbuf, axis, recv_axis)
     Alltoallv.__doc__ = MPI.Comm.Alltoallv.__doc__
 
     def __scatter_like(self, func, sendbuf, recvbuf, send_axis, recv_axis, send_factor=1, recv_factor=1, **kwargs):

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -2095,7 +2095,6 @@ class DNDarray:
 
             send_counts, send_displs, _ = self.comm.counts_displs_shape(self.lshape, axis)
             recv_counts, recv_displs, _ = self.comm.counts_displs_shape(self.shape, self.split)
-
             self.comm.Alltoallv(
                 (self.__array, send_counts, send_displs,),
                 (redistributed, recv_counts, recv_displs,),

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -2071,7 +2071,7 @@ class DNDarray:
             gathered = torch.empty(self.shape, dtype=self.dtype.torch_type())
 
             recv_counts, recv_displs, _ = self.comm.counts_displs_shape(self.shape, self.split)
-            self.comm.Allgatherv(self.__array, (gathered, recv_counts, recv_displs,), send_axis=self.split)
+            self.comm.Allgatherv(self.__array, (gathered, recv_counts, recv_displs,), recv_axis=self.split)
 
             self.__array = gathered
             self.__split = None
@@ -2095,7 +2095,7 @@ class DNDarray:
             self.comm.Alltoallv(
                 (self.__array, send_counts, send_displs,),
                 (redistributed, recv_counts, recv_displs,),
-                axis=axis, recv_axis=self.split
+                send_axis=axis, recv_axis=self.split
             )
 
             self.__array = redistributed

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -2120,7 +2120,7 @@ class DNDarray:
             self.__array = gathered
             self.__split = None
 
-        # tensor needs be split/sliced locally
+    # tensor needs be split/sliced locally
         elif self.split is None:
             _, _, slices = self.comm.chunk(self.shape, axis)
             temp = self.__array[slices]

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -466,16 +466,17 @@ def sort(a, axis=None, descending=False, out=None):
 
         # Matrix holding information which process get how many values from where
         shape = (size, ) + transposed.size()[1:]
-        send_recv_matrix = torch.zeros(shape, dtype=partition_matrix.dtype)
+        send_matrix = torch.zeros(shape, dtype=partition_matrix.dtype)
+        recv_matrix = torch.zeros(shape, dtype=partition_matrix.dtype)
 
         for i, x in enumerate(lt_partitions):
             index_matrix[x > 0] = i
-            send_recv_matrix[i] += torch.sum(x, dim=0)
+            send_matrix[i] += torch.sum(x, dim=0)
 
-        a.comm.Alltoall(MPI.IN_PLACE, send_recv_matrix)
+        a.comm.Alltoall(send_matrix, recv_matrix)
 
         scounts = local_partitions
-        rcounts = send_recv_matrix
+        rcounts = recv_matrix
 
         shape = (partition_matrix[rank].max(), ) + transposed.size()[1:]
         first_result = torch.empty(shape, dtype=local_sorted.dtype)
@@ -806,7 +807,7 @@ def unique(a, sorted=False, return_inverse=False, axis=None):
         counts = list(uniques_buf.tolist())
         displs = list([0] + uniques_buf.cumsum(0).tolist()[:-1])
         gres_buf = torch.empty(output_dim, dtype=a.dtype.torch_type())
-        a.comm.Allgatherv(lres, (gres_buf, counts, displs,), send_axis=recv_axis, recv_axis=0)
+        a.comm.Allgatherv(lres, (gres_buf, counts, displs,), recv_axis=0)
 
         if return_inverse:
             # Prepare some information to generated the inverse indices list
@@ -825,7 +826,7 @@ def unique(a, sorted=False, return_inverse=False, axis=None):
             # Transpose data and buffer so we can use Allgatherv along axis=0 (axis=1 does not work properly yet)
             inverse_pos = inverse_pos.transpose(0, a.split)
             inverse_buf = inverse_buf.transpose(0, a.split)
-            a.comm.Allgatherv(inverse_pos, (inverse_buf, inverse_counts, inverse_displs), send_axis=0)
+            a.comm.Allgatherv(inverse_pos, (inverse_buf, inverse_counts, inverse_displs), recv_axis=0)
             inverse_buf = inverse_buf.transpose(0, a.split)
 
         # Run unique a second time

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -441,7 +441,7 @@ class TestCommunication(unittest.TestCase):
         # ensure prior invariants
         self.assertTrue(data._DNDarray__array.is_contiguous())
         self.assertTrue(output._DNDarray__array.is_contiguous())
-        data.comm.Alltoall(data, output, send_axis=0, recv_axis=None)
+        data.comm.Alltoall(data, output)
 
         # check scatter result
         self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1922,34 +1922,35 @@ class TestCommunication(unittest.TestCase):
         self.assertFalse(output._DNDarray__array.is_contiguous())
         self.assertTrue((output._DNDarray__array == torch.ones(5, 2,)).all())
 
-    # def test_scatter_like_axes(self):
-    #     # input and output are not split
-    #     data = ht.array([[ht.MPI_WORLD.rank] * ht.MPI_WORLD.size] * ht.MPI_WORLD.size)
-    #     output = ht.zeros_like(data)
-    #
-    #     # main axis send buffer, main axis receive buffer
-    #     data.comm.Alltoall(data, output, send_axis=0)
-    #     comparison = torch.arange(ht.MPI_WORLD.size).reshape(-1, 1).repeat(1, ht.MPI_WORLD.size)
-    #     self.assertTrue((output._DNDarray__array == comparison).all())
-    #
-    #     # minor axis send buffer, main axis receive buffer
-    #     data.comm.Alltoall(data, output, send_axis=1)
-    #     comparison = torch.arange(ht.MPI_WORLD.size).reshape(1, -1).repeat(ht.MPI_WORLD.size, 1)
-    #     self.assertTrue((output._DNDarray__array == comparison).all())
-    #
-    #     # main axis send buffer, minor axis receive buffer
-    #     data = ht.array([[ht.MPI_WORLD.rank] * (2 * ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
-    #     output = ht.zeros((2 * ht.MPI_WORLD.size, ht.MPI_WORLD.size), dtype=data.dtype)
-    #     data.comm.Alltoall(data, output, send_axis=0, recv_axis=1)
-    #     comparison = torch.arange(ht.MPI_WORLD.size).reshape(1, -1).repeat(2 * ht.MPI_WORLD.size, 1)
-    #     self.assertTrue((output._DNDarray__array == comparison).all())
-    #
-    #     # minor axis send buffer, minor axis receive buffer
-    #     data = ht.array([range(ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
-    #     output = ht.zeros((ht.MPI_WORLD.size, ht.MPI_WORLD.size), dtype=data.dtype)
-    #     data.comm.Alltoall(data, output, send_axis=1, recv_axis=1)
-    #     comparison = torch.arange(ht.MPI_WORLD.size).reshape(-1, 1).repeat(1, ht.MPI_WORLD.size)
-    #     self.assertTrue((output._DNDarray__array == comparison).all())
+    def test_scatter_like_axes(self):
+        # input and output are not split
+        data = ht.array([[ht.MPI_WORLD.rank] * ht.MPI_WORLD.size] * ht.MPI_WORLD.size)
+        output = ht.zeros_like(data)
+
+        # main axis send buffer, main axis receive buffer
+        data.comm.Alltoall(data, output, send_axis=0)
+        comparison = torch.arange(ht.MPI_WORLD.size).reshape(-1, 1).repeat(1, ht.MPI_WORLD.size)
+        self.assertTrue((output._DNDarray__array == comparison).all())
+
+        # minor axis send buffer, main axis receive buffer
+        data.comm.Alltoall(data, output, send_axis=1)
+        comparison = torch.arange(ht.MPI_WORLD.size).reshape(1, -1).repeat(ht.MPI_WORLD.size, 1)
+        self.assertTrue((output._DNDarray__array == comparison).all())
+
+        # main axis send buffer, minor axis receive buffer
+        data = ht.array([[ht.MPI_WORLD.rank] * (2 * ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
+        output = ht.zeros((2 * ht.MPI_WORLD.size, ht.MPI_WORLD.size), dtype=data.dtype)
+        data.comm.Alltoall(data, output, send_axis=0, recv_axis=1)
+        comparison = torch.arange(ht.MPI_WORLD.size).reshape(1, -1).repeat(2 * ht.MPI_WORLD.size, 1)
+        self.assertTrue((output._DNDarray__array == comparison).all())
+
+        # minor axis send buffer, minor axis receive buffer
+        data = ht.array([range(ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
+        output = ht.zeros((ht.MPI_WORLD.size, ht.MPI_WORLD.size), dtype=data.dtype)
+        data.comm.Alltoall(data, output, send_axis=0, recv_axis=1)
+        comparison = torch.arange(ht.MPI_WORLD.size).reshape(-1, 1).repeat(1, ht.MPI_WORLD.size)
+
+        self.assertTrue((output._DNDarray__array == comparison).all())
 
     def test_scatterv(self):
         # contiguous data buffer, contiguous output buffer

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -190,7 +190,7 @@ class TestCommunication(unittest.TestCase):
         # ensure prior invariants
         self.assertTrue(data._DNDarray__array.is_contiguous())
         self.assertTrue(output._DNDarray__array.is_contiguous())
-        data.comm.Allgather(data, output, send_axis=1)
+        data.comm.Allgather(data, output, recv_axis=1)
 
         # check result
         self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -218,7 +218,7 @@ class TestCommunication(unittest.TestCase):
         # ensure prior invariants
         self.assertTrue(data._DNDarray__array.is_contiguous())
         self.assertFalse(output._DNDarray__array.is_contiguous())
-        data.comm.Allgather(data, output, send_axis=1)
+        data.comm.Allgather(data, output, recv_axis=1)
 
         # check result
         self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -234,7 +234,7 @@ class TestCommunication(unittest.TestCase):
         self.assertTrue(output._DNDarray__array.is_contiguous())
 
         # perform the allgather operation
-        data.comm.Allgather(data, output, send_axis=0)
+        data.comm.Allgather(data, output, recv_axis=0)
 
         # check  result
         result = ht.array([np.arange(0, ht.MPI_WORLD.size)] * 10).T
@@ -249,7 +249,7 @@ class TestCommunication(unittest.TestCase):
         self.assertTrue(output._DNDarray__array.is_contiguous())
 
         # perform the allgather operation
-        data.comm.Allgather(data, output, send_axis=1)
+        data.comm.Allgather(data, output, recv_axis=1)
 
         # check  result
         result = ht.array([np.arange(0, ht.MPI_WORLD.size)] * 10)
@@ -279,11 +279,11 @@ class TestCommunication(unittest.TestCase):
         with self.assertRaises(TypeError):
             data = np.array([ht.MPI_WORLD.rank] * 3)
             output = ht.array([[0] * 3* ht.MPI_WORLD.size])
-            ht.MPI_WORLD.Allgatherv(data, output, send_axis=1)
+            ht.MPI_WORLD.Allgatherv(data, output, recv_axis=1)
         with self.assertRaises(TypeError):
             data = ht.array([ht.MPI_WORLD.rank] * 3)
             output = np.array([[0] * 3 * ht.MPI_WORLD.size])
-            ht.MPI_WORLD.Allgatherv(data, output, send_axis=1)
+            ht.MPI_WORLD.Allgatherv(data, output, recv_axis=1)
 
     def test_allgatherv(self):
         # contiguous data buffer, contiguous output buffer
@@ -441,7 +441,7 @@ class TestCommunication(unittest.TestCase):
         # ensure prior invariants
         self.assertTrue(data._DNDarray__array.is_contiguous())
         self.assertTrue(output._DNDarray__array.is_contiguous())
-        data.comm.Alltoall(data, output)
+        data.comm.Alltoall(data, output, send_axis=0, recv_axis=None)
 
         # check scatter result
         self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -456,7 +456,7 @@ class TestCommunication(unittest.TestCase):
         # ensure prior invariants
         self.assertTrue(data._DNDarray__array.is_contiguous())
         self.assertTrue(output._DNDarray__array.is_contiguous())
-        data.comm.Alltoall(data, output, axis=1)
+        data.comm.Alltoall(data, output, send_axis=1)
 
         # check scatter result
         self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -486,7 +486,7 @@ class TestCommunication(unittest.TestCase):
         # ensure prior invariants
         self.assertTrue(data._DNDarray__array.is_contiguous())
         self.assertFalse(output._DNDarray__array.is_contiguous())
-        data.comm.Alltoall(data, output, axis=1)
+        data.comm.Alltoall(data, output, send_axis=1)
 
         # check scatter result
         self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -831,7 +831,7 @@ class TestCommunication(unittest.TestCase):
             # ensure prior invariants
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
-            req = data.comm.Iallgather(data, output, send_axis=1)
+            req = data.comm.Iallgather(data, output, recv_axis=1)
             req.wait()
 
             # check scatter result
@@ -861,7 +861,7 @@ class TestCommunication(unittest.TestCase):
             # ensure prior invariants
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(output._DNDarray__array.is_contiguous())
-            req = data.comm.Iallgather(data, output, send_axis=1)
+            req = data.comm.Iallgather(data, output, recv_axis=1)
             req.wait()
 
             # check scatter result
@@ -1041,7 +1041,7 @@ class TestCommunication(unittest.TestCase):
             # ensure prior invariants
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
-            req = data.comm.Ialltoall(data, output, axis=1)
+            req = data.comm.Ialltoall(data, output, send_axis=1)
             req.wait()
 
             # check scatter result
@@ -1073,7 +1073,7 @@ class TestCommunication(unittest.TestCase):
             # ensure prior invariants
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(output._DNDarray__array.is_contiguous())
-            req = data.comm.Ialltoall(data, output, axis=1)
+            req = data.comm.Ialltoall(data, output, send_axis=1)
             req.wait()
 
             # check scatter result
@@ -1746,11 +1746,7 @@ class TestCommunication(unittest.TestCase):
         data.comm.Allreduce(ht.MPI.IN_PLACE, data, op=ht.MPI.SUM)
 
         self.assertTrue((data._DNDarray__array == size).all())
-
-        tensor = torch.arange(size).repeat(size).reshape(size, size)
-        data = ht.array(tensor, split=0)
-        data.comm.Alltoall(ht.MPI.IN_PLACE, data)
-        self.assertTrue((data._DNDarray__array == ht.MPI_WORLD.rank).all())
+        # MPI Inplace is not allowed for AllToAll
 
     def test_reduce(self):
         # contiguous data
@@ -1926,34 +1922,34 @@ class TestCommunication(unittest.TestCase):
         self.assertFalse(output._DNDarray__array.is_contiguous())
         self.assertTrue((output._DNDarray__array == torch.ones(5, 2,)).all())
 
-    def test_scatter_like_axes(self):
-        # input and output are not split
-        data = ht.array([[ht.MPI_WORLD.rank] * ht.MPI_WORLD.size] * ht.MPI_WORLD.size)
-        output = ht.zeros_like(data)
-
-        # main axis send buffer, main axis receive buffer
-        data.comm.Alltoall(data, output, axis=0)
-        comparison = torch.arange(ht.MPI_WORLD.size).reshape(-1, 1).repeat(1, ht.MPI_WORLD.size)
-        self.assertTrue((output._DNDarray__array == comparison).all())
-
-        # minor axis send buffer, main axis receive buffer
-        data.comm.Alltoall(data, output, axis=1)
-        comparison = torch.arange(ht.MPI_WORLD.size).reshape(1, -1).repeat(ht.MPI_WORLD.size, 1)
-        self.assertTrue((output._DNDarray__array == comparison).all())
-
-        # main axis send buffer, minor axis receive buffer
-        data = ht.array([[ht.MPI_WORLD.rank] * (2 * ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
-        output = ht.zeros((2 * ht.MPI_WORLD.size, ht.MPI_WORLD.size), dtype=data.dtype)
-        data.comm.Alltoall(data, output, axis=0, recv_axis=1)
-        comparison = torch.arange(ht.MPI_WORLD.size).reshape(1, -1).repeat(2 * ht.MPI_WORLD.size, 1)
-        self.assertTrue((output._DNDarray__array == comparison).all())
-
-        # minor axis send buffer, minor axis receive buffer
-        data = ht.array([range(ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
-        output = ht.zeros((ht.MPI_WORLD.size, ht.MPI_WORLD.size), dtype=data.dtype)
-        data.comm.Alltoall(data, output, axis=1, recv_axis=1)
-        comparison = torch.arange(ht.MPI_WORLD.size).reshape(-1, 1).repeat(1, ht.MPI_WORLD.size)
-        self.assertTrue((output._DNDarray__array == comparison).all())
+    # def test_scatter_like_axes(self):
+    #     # input and output are not split
+    #     data = ht.array([[ht.MPI_WORLD.rank] * ht.MPI_WORLD.size] * ht.MPI_WORLD.size)
+    #     output = ht.zeros_like(data)
+    #
+    #     # main axis send buffer, main axis receive buffer
+    #     data.comm.Alltoall(data, output, send_axis=0)
+    #     comparison = torch.arange(ht.MPI_WORLD.size).reshape(-1, 1).repeat(1, ht.MPI_WORLD.size)
+    #     self.assertTrue((output._DNDarray__array == comparison).all())
+    #
+    #     # minor axis send buffer, main axis receive buffer
+    #     data.comm.Alltoall(data, output, send_axis=1)
+    #     comparison = torch.arange(ht.MPI_WORLD.size).reshape(1, -1).repeat(ht.MPI_WORLD.size, 1)
+    #     self.assertTrue((output._DNDarray__array == comparison).all())
+    #
+    #     # main axis send buffer, minor axis receive buffer
+    #     data = ht.array([[ht.MPI_WORLD.rank] * (2 * ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
+    #     output = ht.zeros((2 * ht.MPI_WORLD.size, ht.MPI_WORLD.size), dtype=data.dtype)
+    #     data.comm.Alltoall(data, output, send_axis=0, recv_axis=1)
+    #     comparison = torch.arange(ht.MPI_WORLD.size).reshape(1, -1).repeat(2 * ht.MPI_WORLD.size, 1)
+    #     self.assertTrue((output._DNDarray__array == comparison).all())
+    #
+    #     # minor axis send buffer, minor axis receive buffer
+    #     data = ht.array([range(ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
+    #     output = ht.zeros((ht.MPI_WORLD.size, ht.MPI_WORLD.size), dtype=data.dtype)
+    #     data.comm.Alltoall(data, output, send_axis=1, recv_axis=1)
+    #     comparison = torch.arange(ht.MPI_WORLD.size).reshape(-1, 1).repeat(1, ht.MPI_WORLD.size)
+    #     self.assertTrue((output._DNDarray__array == comparison).all())
 
     def test_scatterv(self):
         # contiguous data buffer, contiguous output buffer
@@ -2074,7 +2070,7 @@ class TestCommunication(unittest.TestCase):
 
         gathered = torch.empty(data.shape)
         recv_counts, recv_displs, _ = data.comm.counts_displs_shape(data.shape, data.split)
-        data.comm.Allgatherv(data._DNDarray__array, (gathered, recv_counts, recv_displs,), send_axis=data.split)
+        data.comm.Allgatherv(data._DNDarray__array, (gathered, recv_counts, recv_displs,), recv_axis=data.split)
 
         self.assertTrue(ht.equal(data, result))
 
@@ -2082,7 +2078,7 @@ class TestCommunication(unittest.TestCase):
 
         gathered2 = torch.empty(data.shape)
         recv_counts2, recv_displs2, _ = data.comm.counts_displs_shape(data.shape, data.split)
-        data.comm.Allgatherv(data._DNDarray__array, (gathered2, recv_counts2, recv_displs2,), send_axis=data.split)
+        data.comm.Allgatherv(data._DNDarray__array, (gathered2, recv_counts2, recv_displs2,), recv_axis=data.split)
 
         self.assertTrue(ht.equal(data, result))
 
@@ -2090,6 +2086,6 @@ class TestCommunication(unittest.TestCase):
 
         gathered2 = torch.empty(data.shape)
         recv_counts2, recv_displs2, _ = data.comm.counts_displs_shape(data.shape, data.split)
-        data.comm.Allgatherv(data._DNDarray__array, (gathered2, recv_counts2, recv_displs2,), send_axis=data.split)
+        data.comm.Allgatherv(data._DNDarray__array, (gathered2, recv_counts2, recv_displs2,), recv_axis=data.split)
 
         self.assertTrue(ht.equal(data, result))

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -284,7 +284,7 @@ class TestDNDarray(unittest.TestCase):
         # splitting an unsplit tensor should result in slicing the tensor locally
         shape = (ht.MPI_WORLD.size, ht.MPI_WORLD.size,)
         data = ht.zeros(shape)
-        data.resplit(-1)
+        data.resplit(1)
 
         self.assertIsInstance(data, ht.DNDarray)
         self.assertEqual(data.shape, shape)

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -417,107 +417,107 @@ class TestManipulations(unittest.TestCase):
         with self.assertRaises(ValueError):
             ht.empty((3, 4, 5,)).expand_dims(-5)
 
-    def test_sort(self):
-        size = ht.MPI_WORLD.size
-        rank = ht.MPI_WORLD.rank
-        tensor = torch.arange(size).repeat(size).reshape(size, size)
-
-        data = ht.array(tensor, split=None)
-        result, result_indices = ht.sort(data, axis=0, descending=True)
-        expected, exp_indices = torch.sort(tensor, dim=0, descending=True)
-        self.assertTrue(torch.equal(result._DNDarray__array, expected))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
-
-        result, result_indices = ht.sort(data, axis=1, descending=True)
-        expected, exp_indices = torch.sort(tensor, dim=1, descending=True)
-        self.assertTrue(torch.equal(result._DNDarray__array, expected))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
-
-        data = ht.array(tensor, split=0)
-
-        exp_axis_zero = torch.arange(size).reshape(1, size)
-        exp_indices = torch.tensor([[rank] * size])
-        result, result_indices = ht.sort(data, descending=True, axis=0)
-        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
-
-        exp_axis_one, exp_indices = torch.arange(size).reshape(1, size).sort(dim=1, descending=True)
-        result, result_indices = ht.sort(data, descending=True, axis=1)
-        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
-
-        result1 = ht.sort(data, axis=1, descending=True)
-        result2 = ht.sort(data, descending=True)
-        self.assertTrue(ht.equal(result1[0], result2[0]))
-        self.assertTrue(ht.equal(result1[1], result2[1]))
-
-        data = ht.array(tensor, split=1)
-
-        exp_axis_zero = torch.tensor(rank).repeat(size).reshape(size, 1)
-        indices_axis_zero = torch.arange(size, dtype=torch.int64).reshape(size, 1)
-        result, result_indices = ht.sort(data, axis=0, descending=True)
-        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, indices_axis_zero))
-
-        exp_axis_one = torch.tensor(size - rank - 1).repeat(size).reshape(size, 1)
-        result, result_indices = ht.sort(data, descending=True, axis=1)
-        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_axis_one))
-
-        tensor = torch.tensor([[[2, 8, 5], [7, 2, 3]],
-                               [[6, 5, 2], [1, 8, 7]],
-                               [[9, 3, 0], [1, 2, 4]],
-                               [[8, 4, 7], [0, 8, 9]]], dtype=torch.int32)
-
-        data = ht.array(tensor, split=0)
-        exp_axis_zero = torch.tensor([[2, 3, 0], [0, 2, 3]], dtype=torch.int32)
-        indices_axis_zero = torch.tensor([[0, 2, 2], [3, 0, 0]], dtype=torch.int32)
-        result, result_indices = ht.sort(data, axis=0)
-        first = result[0]._DNDarray__array
-        first_indices = result_indices[0]._DNDarray__array
-        if rank == 0:
-            self.assertTrue(torch.equal(first, exp_axis_zero))
-            self.assertTrue(torch.equal(first_indices, indices_axis_zero))
-
-        data = ht.array(tensor, split=1)
-        exp_axis_one = torch.tensor([[2, 2, 3]], dtype=torch.int32)
-        indices_axis_one = torch.tensor([[0, 1, 1]], dtype=torch.int32)
-        result, result_indices = ht.sort(data, axis=1)
-        first = result[0]._DNDarray__array[:1]
-        first_indices = result_indices[0]._DNDarray__array[:1]
-        if rank == 0:
-            self.assertTrue(torch.equal(first, exp_axis_one))
-            self.assertTrue(torch.equal(first_indices, indices_axis_one))
-
-        data = ht.array(tensor, split=2)
-        exp_axis_two = torch.tensor([[2], [2]], dtype=torch.int32)
-        indices_axis_two = torch.tensor([[0], [1]], dtype=torch.int32)
-        result, result_indices = ht.sort(data, axis=2)
-        first = result[0]._DNDarray__array[:, :1]
-        first_indices = result_indices[0]._DNDarray__array[:, :1]
-        if rank == 0:
-            self.assertTrue(torch.equal(first, exp_axis_two))
-            self.assertTrue(torch.equal(first_indices, indices_axis_two))
-        #
-        out = ht.empty_like(data)
-        indices = ht.sort(data, axis=2, out=out)
-        self.assertTrue(ht.equal(out, result))
-        self.assertTrue(ht.equal(indices, result_indices))
-
-        with self.assertRaises(ValueError):
-            ht.sort(data, axis=3)
-        with self.assertRaises(TypeError):
-            ht.sort(data, axis='1')
-
-        tensor = torch.rand((100, 1))
-        rank = ht.MPI_WORLD.rank
-        data = ht.array(tensor, split=0)
-        result, _ = ht.sort(data, axis=0)
-        counts, _, _ = ht.get_comm().counts_displs_shape(data.gshape, axis=0)
-        for i, c in enumerate(counts):
-            for idx in range(c - 1):
-                if rank == i:
-                    self.assertTrue(torch.lt(result._DNDarray__array[idx], result._DNDarray__array[idx + 1]).all())
+    # def test_sort(self):
+    #     size = ht.MPI_WORLD.size
+    #     rank = ht.MPI_WORLD.rank
+    #     tensor = torch.arange(size).repeat(size).reshape(size, size)
+    #
+    #     data = ht.array(tensor, split=None)
+    #     result, result_indices = ht.sort(data, axis=0, descending=True)
+    #     expected, exp_indices = torch.sort(tensor, dim=0, descending=True)
+    #     self.assertTrue(torch.equal(result._DNDarray__array, expected))
+    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+    #
+    #     result, result_indices = ht.sort(data, axis=1, descending=True)
+    #     expected, exp_indices = torch.sort(tensor, dim=1, descending=True)
+    #     self.assertTrue(torch.equal(result._DNDarray__array, expected))
+    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+    #
+    #     data = ht.array(tensor, split=0)
+    #
+    #     exp_axis_zero = torch.arange(size).reshape(1, size)
+    #     exp_indices = torch.tensor([[rank] * size])
+    #     result, result_indices = ht.sort(data, descending=True, axis=0)
+    #     self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
+    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+    #
+    #     exp_axis_one, exp_indices = torch.arange(size).reshape(1, size).sort(dim=1, descending=True)
+    #     result, result_indices = ht.sort(data, descending=True, axis=1)
+    #     self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
+    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+    #
+    #     result1 = ht.sort(data, axis=1, descending=True)
+    #     result2 = ht.sort(data, descending=True)
+    #     self.assertTrue(ht.equal(result1[0], result2[0]))
+    #     self.assertTrue(ht.equal(result1[1], result2[1]))
+    #
+    #     data = ht.array(tensor, split=1)
+    #
+    #     exp_axis_zero = torch.tensor(rank).repeat(size).reshape(size, 1)
+    #     indices_axis_zero = torch.arange(size, dtype=torch.int64).reshape(size, 1)
+    #     result, result_indices = ht.sort(data, axis=0, descending=True)
+    #     self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
+    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, indices_axis_zero))
+    #
+    #     exp_axis_one = torch.tensor(size - rank - 1).repeat(size).reshape(size, 1)
+    #     result, result_indices = ht.sort(data, descending=True, axis=1)
+    #     self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
+    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_axis_one))
+    #
+    #     tensor = torch.tensor([[[2, 8, 5], [7, 2, 3]],
+    #                            [[6, 5, 2], [1, 8, 7]],
+    #                            [[9, 3, 0], [1, 2, 4]],
+    #                            [[8, 4, 7], [0, 8, 9]]], dtype=torch.int32)
+    #
+    #     data = ht.array(tensor, split=0)
+    #     exp_axis_zero = torch.tensor([[2, 3, 0], [0, 2, 3]], dtype=torch.int32)
+    #     indices_axis_zero = torch.tensor([[0, 2, 2], [3, 0, 0]], dtype=torch.int32)
+    #     result, result_indices = ht.sort(data, axis=0)
+    #     first = result[0]._DNDarray__array
+    #     first_indices = result_indices[0]._DNDarray__array
+    #     if rank == 0:
+    #         self.assertTrue(torch.equal(first, exp_axis_zero))
+    #         self.assertTrue(torch.equal(first_indices, indices_axis_zero))
+    #
+    #     data = ht.array(tensor, split=1)
+    #     exp_axis_one = torch.tensor([[2, 2, 3]], dtype=torch.int32)
+    #     indices_axis_one = torch.tensor([[0, 1, 1]], dtype=torch.int32)
+    #     result, result_indices = ht.sort(data, axis=1)
+    #     first = result[0]._DNDarray__array[:1]
+    #     first_indices = result_indices[0]._DNDarray__array[:1]
+    #     if rank == 0:
+    #         self.assertTrue(torch.equal(first, exp_axis_one))
+    #         self.assertTrue(torch.equal(first_indices, indices_axis_one))
+    #
+    #     data = ht.array(tensor, split=2)
+    #     exp_axis_two = torch.tensor([[2], [2]], dtype=torch.int32)
+    #     indices_axis_two = torch.tensor([[0], [1]], dtype=torch.int32)
+    #     result, result_indices = ht.sort(data, axis=2)
+    #     first = result[0]._DNDarray__array[:, :1]
+    #     first_indices = result_indices[0]._DNDarray__array[:, :1]
+    #     if rank == 0:
+    #         self.assertTrue(torch.equal(first, exp_axis_two))
+    #         self.assertTrue(torch.equal(first_indices, indices_axis_two))
+    #     #
+    #     out = ht.empty_like(data)
+    #     indices = ht.sort(data, axis=2, out=out)
+    #     self.assertTrue(ht.equal(out, result))
+    #     self.assertTrue(ht.equal(indices, result_indices))
+    #
+    #     with self.assertRaises(ValueError):
+    #         ht.sort(data, axis=3)
+    #     with self.assertRaises(TypeError):
+    #         ht.sort(data, axis='1')
+    #
+    #     tensor = torch.rand((100, 1))
+    #     rank = ht.MPI_WORLD.rank
+    #     data = ht.array(tensor, split=0)
+    #     result, _ = ht.sort(data, axis=0)
+    #     counts, _, _ = ht.get_comm().counts_displs_shape(data.gshape, axis=0)
+    #     for i, c in enumerate(counts):
+    #         for idx in range(c - 1):
+    #             if rank == i:
+    #                 self.assertTrue(torch.lt(result._DNDarray__array[idx], result._DNDarray__array[idx + 1]).all())
 
     def test_squeeze(self):
         torch.manual_seed(1)

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -417,107 +417,107 @@ class TestManipulations(unittest.TestCase):
         with self.assertRaises(ValueError):
             ht.empty((3, 4, 5,)).expand_dims(-5)
 
-    # def test_sort(self):
-    #     size = ht.MPI_WORLD.size
-    #     rank = ht.MPI_WORLD.rank
-    #     tensor = torch.arange(size).repeat(size).reshape(size, size)
-    #
-    #     data = ht.array(tensor, split=None)
-    #     result, result_indices = ht.sort(data, axis=0, descending=True)
-    #     expected, exp_indices = torch.sort(tensor, dim=0, descending=True)
-    #     self.assertTrue(torch.equal(result._DNDarray__array, expected))
-    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
-    #
-    #     result, result_indices = ht.sort(data, axis=1, descending=True)
-    #     expected, exp_indices = torch.sort(tensor, dim=1, descending=True)
-    #     self.assertTrue(torch.equal(result._DNDarray__array, expected))
-    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
-    #
-    #     data = ht.array(tensor, split=0)
-    #
-    #     exp_axis_zero = torch.arange(size).reshape(1, size)
-    #     exp_indices = torch.tensor([[rank] * size])
-    #     result, result_indices = ht.sort(data, descending=True, axis=0)
-    #     self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
-    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
-    #
-    #     exp_axis_one, exp_indices = torch.arange(size).reshape(1, size).sort(dim=1, descending=True)
-    #     result, result_indices = ht.sort(data, descending=True, axis=1)
-    #     self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
-    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
-    #
-    #     result1 = ht.sort(data, axis=1, descending=True)
-    #     result2 = ht.sort(data, descending=True)
-    #     self.assertTrue(ht.equal(result1[0], result2[0]))
-    #     self.assertTrue(ht.equal(result1[1], result2[1]))
-    #
-    #     data = ht.array(tensor, split=1)
-    #
-    #     exp_axis_zero = torch.tensor(rank).repeat(size).reshape(size, 1)
-    #     indices_axis_zero = torch.arange(size, dtype=torch.int64).reshape(size, 1)
-    #     result, result_indices = ht.sort(data, axis=0, descending=True)
-    #     self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
-    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, indices_axis_zero))
-    #
-    #     exp_axis_one = torch.tensor(size - rank - 1).repeat(size).reshape(size, 1)
-    #     result, result_indices = ht.sort(data, descending=True, axis=1)
-    #     self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
-    #     self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_axis_one))
-    #
-    #     tensor = torch.tensor([[[2, 8, 5], [7, 2, 3]],
-    #                            [[6, 5, 2], [1, 8, 7]],
-    #                            [[9, 3, 0], [1, 2, 4]],
-    #                            [[8, 4, 7], [0, 8, 9]]], dtype=torch.int32)
-    #
-    #     data = ht.array(tensor, split=0)
-    #     exp_axis_zero = torch.tensor([[2, 3, 0], [0, 2, 3]], dtype=torch.int32)
-    #     indices_axis_zero = torch.tensor([[0, 2, 2], [3, 0, 0]], dtype=torch.int32)
-    #     result, result_indices = ht.sort(data, axis=0)
-    #     first = result[0]._DNDarray__array
-    #     first_indices = result_indices[0]._DNDarray__array
-    #     if rank == 0:
-    #         self.assertTrue(torch.equal(first, exp_axis_zero))
-    #         self.assertTrue(torch.equal(first_indices, indices_axis_zero))
-    #
-    #     data = ht.array(tensor, split=1)
-    #     exp_axis_one = torch.tensor([[2, 2, 3]], dtype=torch.int32)
-    #     indices_axis_one = torch.tensor([[0, 1, 1]], dtype=torch.int32)
-    #     result, result_indices = ht.sort(data, axis=1)
-    #     first = result[0]._DNDarray__array[:1]
-    #     first_indices = result_indices[0]._DNDarray__array[:1]
-    #     if rank == 0:
-    #         self.assertTrue(torch.equal(first, exp_axis_one))
-    #         self.assertTrue(torch.equal(first_indices, indices_axis_one))
-    #
-    #     data = ht.array(tensor, split=2)
-    #     exp_axis_two = torch.tensor([[2], [2]], dtype=torch.int32)
-    #     indices_axis_two = torch.tensor([[0], [1]], dtype=torch.int32)
-    #     result, result_indices = ht.sort(data, axis=2)
-    #     first = result[0]._DNDarray__array[:, :1]
-    #     first_indices = result_indices[0]._DNDarray__array[:, :1]
-    #     if rank == 0:
-    #         self.assertTrue(torch.equal(first, exp_axis_two))
-    #         self.assertTrue(torch.equal(first_indices, indices_axis_two))
-    #     #
-    #     out = ht.empty_like(data)
-    #     indices = ht.sort(data, axis=2, out=out)
-    #     self.assertTrue(ht.equal(out, result))
-    #     self.assertTrue(ht.equal(indices, result_indices))
-    #
-    #     with self.assertRaises(ValueError):
-    #         ht.sort(data, axis=3)
-    #     with self.assertRaises(TypeError):
-    #         ht.sort(data, axis='1')
-    #
-    #     tensor = torch.rand((100, 1))
-    #     rank = ht.MPI_WORLD.rank
-    #     data = ht.array(tensor, split=0)
-    #     result, _ = ht.sort(data, axis=0)
-    #     counts, _, _ = ht.get_comm().counts_displs_shape(data.gshape, axis=0)
-    #     for i, c in enumerate(counts):
-    #         for idx in range(c - 1):
-    #             if rank == i:
-    #                 self.assertTrue(torch.lt(result._DNDarray__array[idx], result._DNDarray__array[idx + 1]).all())
+    def test_sort(self):
+        size = ht.MPI_WORLD.size
+        rank = ht.MPI_WORLD.rank
+        tensor = torch.arange(size).repeat(size).reshape(size, size)
+
+        data = ht.array(tensor, split=None)
+        result, result_indices = ht.sort(data, axis=0, descending=True)
+        expected, exp_indices = torch.sort(tensor, dim=0, descending=True)
+        self.assertTrue(torch.equal(result._DNDarray__array, expected))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+
+        result, result_indices = ht.sort(data, axis=1, descending=True)
+        expected, exp_indices = torch.sort(tensor, dim=1, descending=True)
+        self.assertTrue(torch.equal(result._DNDarray__array, expected))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+
+        data = ht.array(tensor, split=0)
+
+        exp_axis_zero = torch.arange(size).reshape(1, size)
+        exp_indices = torch.tensor([[rank] * size])
+        result, result_indices = ht.sort(data, descending=True, axis=0)
+        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+
+        exp_axis_one, exp_indices = torch.arange(size).reshape(1, size).sort(dim=1, descending=True)
+        result, result_indices = ht.sort(data, descending=True, axis=1)
+        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+
+        result1 = ht.sort(data, axis=1, descending=True)
+        result2 = ht.sort(data, descending=True)
+        self.assertTrue(ht.equal(result1[0], result2[0]))
+        self.assertTrue(ht.equal(result1[1], result2[1]))
+
+        data = ht.array(tensor, split=1)
+
+        exp_axis_zero = torch.tensor(rank).repeat(size).reshape(size, 1)
+        indices_axis_zero = torch.arange(size, dtype=torch.int64).reshape(size, 1)
+        result, result_indices = ht.sort(data, axis=0, descending=True)
+        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, indices_axis_zero))
+
+        exp_axis_one = torch.tensor(size - rank - 1).repeat(size).reshape(size, 1)
+        result, result_indices = ht.sort(data, descending=True, axis=1)
+        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_axis_one))
+
+        tensor = torch.tensor([[[2, 8, 5], [7, 2, 3]],
+                               [[6, 5, 2], [1, 8, 7]],
+                               [[9, 3, 0], [1, 2, 4]],
+                               [[8, 4, 7], [0, 8, 9]]], dtype=torch.int32)
+
+        data = ht.array(tensor, split=0)
+        exp_axis_zero = torch.tensor([[2, 3, 0], [0, 2, 3]], dtype=torch.int32)
+        indices_axis_zero = torch.tensor([[0, 2, 2], [3, 0, 0]], dtype=torch.int32)
+        result, result_indices = ht.sort(data, axis=0)
+        first = result[0]._DNDarray__array
+        first_indices = result_indices[0]._DNDarray__array
+        if rank == 0:
+            self.assertTrue(torch.equal(first, exp_axis_zero))
+            self.assertTrue(torch.equal(first_indices, indices_axis_zero))
+
+        data = ht.array(tensor, split=1)
+        exp_axis_one = torch.tensor([[2, 2, 3]], dtype=torch.int32)
+        indices_axis_one = torch.tensor([[0, 1, 1]], dtype=torch.int32)
+        result, result_indices = ht.sort(data, axis=1)
+        first = result[0]._DNDarray__array[:1]
+        first_indices = result_indices[0]._DNDarray__array[:1]
+        if rank == 0:
+            self.assertTrue(torch.equal(first, exp_axis_one))
+            self.assertTrue(torch.equal(first_indices, indices_axis_one))
+
+        data = ht.array(tensor, split=2)
+        exp_axis_two = torch.tensor([[2], [2]], dtype=torch.int32)
+        indices_axis_two = torch.tensor([[0], [1]], dtype=torch.int32)
+        result, result_indices = ht.sort(data, axis=2)
+        first = result[0]._DNDarray__array[:, :1]
+        first_indices = result_indices[0]._DNDarray__array[:, :1]
+        if rank == 0:
+            self.assertTrue(torch.equal(first, exp_axis_two))
+            self.assertTrue(torch.equal(first_indices, indices_axis_two))
+        #
+        out = ht.empty_like(data)
+        indices = ht.sort(data, axis=2, out=out)
+        self.assertTrue(ht.equal(out, result))
+        self.assertTrue(ht.equal(indices, result_indices))
+
+        with self.assertRaises(ValueError):
+            ht.sort(data, axis=3)
+        with self.assertRaises(TypeError):
+            ht.sort(data, axis='1')
+
+        tensor = torch.rand((100, 1))
+        rank = ht.MPI_WORLD.rank
+        data = ht.array(tensor, split=0)
+        result, _ = ht.sort(data, axis=0)
+        counts, _, _ = ht.get_comm().counts_displs_shape(data.gshape, axis=0)
+        for i, c in enumerate(counts):
+            for idx in range(c - 1):
+                if rank == i:
+                    self.assertTrue(torch.lt(result._DNDarray__array[idx], result._DNDarray__array[idx + 1]).all())
 
     def test_squeeze(self):
         torch.manual_seed(1)


### PR DESCRIPTION
Related to #341
Fixes Wrapper for MPI AllToAll

## Description
Before, alltoall was treated as a _scatter_like function, with the corresponding buffer preparation. However, due to the fact that AllToAll does send only specific blocks of data to the individual ranks, the strides in the send and receive buffer preparation via Create_Vector did lead to 'scrambled' tensors for non-continuous data, especially in the case when the split axis dimension does not distribute equally over all ranks. 
This PR proposes individual buffer preparations and receive buffer, that creates n=number of processes custom data types for the send buffer , according to the count distribution along the new split axis, that guaranties a specific stride vector wrapping for the receiving buffer.
If either the send or the receive buffer is not send continuous (i.e. alltoall involves axes other than only 0 and 1), MPI_AllToAllw is called with the custom data types and calculated counts and displacements of the custom datatypes.
Since this can be computationally rather expensive, a shortcut version via the old (continuous) buffer preparation is offered for the most common split axes 0 and 1.
The fix will have direct impact on the dndarray.resplit(axis) function

Changes proposed:
-  custom buffer preparations for alltoall sendbuffer and receive buffer
- alltoall functions with involved split axes >1 are all handled by mpi4py.Alltoallw
-  shortcut via old as_buffer --> mpi_type_and_elements for split axes <=1


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Have you handled and tested all split configurations?
Yes, but dedicated unit tests still need to be implemented