### PR TITLE
Document installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,18 @@ Project Status
 Goals
 -----
 
-HeAT is a flexible and seamless open-source software for high performance data analytics and machine learning. It provides highly optimized algorithms and data structures for tensor computations using CPUs, GPUs and distributed cluster systems on top of MPI. The goal of HeAT is to fill the gap between data analytics and machine learning libraries with a strong focus on on single-node performance, and traditional high-performance computing (HPC). HeAT's generic Python-first programming interface integrates seamlessly with the existing data science ecosystem and makes it as effortless as using numpy to write scalable scientific and data science applications.
+HeAT is a flexible and seamless open-source software for high performance data
+analytics and machine learning. It provides highly optimized algorithms and data
+structures for tensor computations using CPUs, GPUs and distributed cluster
+systems on top of MPI. The goal of HeAT is to fill the gap between data
+analytics and machine learning libraries with a strong focus on on single-node
+performance, and traditional high-performance computing (HPC). HeAT's generic
+Python-first programming interface integrates seamlessly with the existing data
+science ecosystem and makes it as effortless as using numpy to write scalable
+scientific and data science applications.
 
-HeAT allows you tackle your actual Big Data challenges that go beyond the computational and memory needs of your laptop and desktop.
+HeAT allows you to tackle your actual Big Data challenges that go beyond the
+computational and memory needs of your laptop and desktop.
 
 Features
 --------
@@ -31,7 +40,11 @@ Features
 Getting Started
 ---------------
 
-Check out our Jupyter Notebook [tutorial](https://github.com/helmholtz-analytics/heat/blob/master/scripts/tutorial.ipynb) right here on Github or in the /scripts directory.
+Check out our Jupyter Notebook [tutorial](https://github.com/helmholtz-analytics/heat/blob/master/scripts/tutorial.ipynb)
+right here on Github or in the /scripts directory.
+
+The complete documentation of the latest version is always deployed on
+[Read the Docs](https://heat.readthedocs.io/).
 
 Requirements
 ------------
@@ -48,11 +61,18 @@ Tagged releases are made available on the
 [Python Package Index (PyPI)](https://pypi.org/project/heat/). You can typically
 install the latest version with
 
-> $ pip install heat
+> $ pip install heat[hdf5, netcdf]
+
+where the part in brackets is a list of optional dependencies. You can omit
+it, if you do not need HDF5 or NetCDF support.
 
 If you want to work with the development version, you can checkout the sources using
 
 > $ git clone https://github.com/helmholtz-analytics/heat.git
+
+The installation can then be done from the checked out sources with
+
+> $ pip install .[hdf5, netcdf]
 
 License
 -------

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -14,6 +14,16 @@ Tagged releases of HeAT are made available on the Python Package Index
 
   $ pip install heat
 
+Optionally, you can enable and install HDF5 and/or NetCDF support by adding the
+respective extra requirements::
+
+  $ pip install 'heat[hdf5, netcdf]'
+
 If you want to work with the development version, you can checkout the sources using::
 
   $ git clone https://github.com/helmholtz-analytics/heat.git
+
+This version can then be installed via::
+
+  $ cd heat
+  $ pip install '.[hdf5, netcdf]'


### PR DESCRIPTION
There are several options for installing HeAT, depending on the needs. These are
documented in the README.md and generated documentation now.

Fixes #335

## Description

Changes proposed:
- Documentation update for installation options

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
