### PR TITLE
changed sort to not produce warnings

### DIFF
--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -577,8 +577,8 @@ def sort(a, axis=None, descending=False, out=None):
 
             send_count = scounts[idx_slice].reshape(-1).tolist()
             send_disp = [0] + list(np.cumsum(send_count[:-1]))
-            s_val = torch.tensor(local_sorted[idx_slice])
-            s_ind = torch.tensor(actual_indices[idx_slice], dtype=local_sorted.dtype)
+            s_val = local_sorted[idx_slice].clone().detach()
+            s_ind = actual_indices[idx_slice].clone().detach().to(dtype=local_sorted.dtype)
 
             recv_count = rcounts[idx_slice].reshape(-1).tolist()
             recv_disp = [0] + list(np.cumsum(recv_count[:-1]))

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -577,8 +577,8 @@ def sort(a, axis=None, descending=False, out=None):
 
             send_count = scounts[idx_slice].reshape(-1).tolist()
             send_disp = [0] + list(np.cumsum(send_count[:-1]))
-            s_val = local_sorted[idx_slice].clone().detach()
-            s_ind = actual_indices[idx_slice].clone().detach().to(dtype=local_sorted.dtype)
+            s_val = local_sorted[idx_slice].clone()
+            s_ind = actual_indices[idx_slice].clone().to(dtype=local_sorted.dtype)
 
             recv_count = rcounts[idx_slice].reshape(-1).tolist()
             recv_disp = [0] + list(np.cumsum(recv_count[:-1]))


### PR DESCRIPTION
## Description

The sort function used a torch functionality that produces a warning. Torch proposed a different way which was now implemented.

Fixes: #381

Changes proposed:
- using clone and detach instead of creating a new tensor

## Type of change

Select relevant options.

[x] Bug fix (non-breaking change which fixes an issue)

Are all split configurations tested and accounted for?
[x] yes [ ] no
Does this change require a documentation update outside of the changes proposed?
[ ] yes [x] no
Does this change modify the behaviour of other functions?
[ ] yes [x] no
Are there code practices which require justification?
[ ] yes [x] no
