### PR TITLE
Limit netCDF4 version to at most 1.5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=["mpi4py>=3.0.0", "numpy>=1.13.0", "torch==1.3.0"],
     extras_require={
         "hdf5": ["h5py>=2.8.0"],
-        "netcdf": ["netCDF4>=1.4.0"],
+        "netcdf": ["netCDF4>=1.4.0,<=1.5.2"],
         "dev": ["pre-commit>=1.18.3"],
     },
 )


### PR DESCRIPTION
Apparently, netCDF4 1.5.3 introduced a problem for us causing the 
problems described in #405.

fixes #405

## Description

Limit netCDF4 version to at most 1.5.2

Fixes: #405 

## Type of change

Select relevant options.

[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update

Are all split configurations tested and accounted for?
[ ] yes [x] no
Does this change require a documentation update outside of the changes proposed?
[ ] yes [x] no
Does this change modify the behaviour of other functions?
[ ] yes [x] no
Are there code practices which require justification?
[ ] yes [x] no
