### PR TITLE
Fixes issue #407. Initializing xi to same data type as X.

### DIFF
--- a/heat/ml/cluster/kmeans.py
+++ b/heat/ml/cluster/kmeans.py
@@ -115,7 +115,6 @@ class KMeans:
             centroids = ht.empty(
                 (X.shape[1], self.n_clusters), split=None, device=X.device, comm=X.comm
             )
-
             if (X.split is None) or (X.split == 0):
                 for i in range(self.n_clusters):
                     samplerange = (
@@ -128,7 +127,7 @@ class KMeans:
                         if displ[p] > sample:
                             break
                         proc = p
-                    xi = ht.zeros(X.shape[1])
+                    xi = ht.zeros(X.shape[1], dtype=X.dtype)
                     if X.comm.rank == proc:
                         idx = sample - displ[proc]
                         xi = ht.array(X.lloc[idx, :], device=X.device, comm=X.comm)


### PR DESCRIPTION
## Description


In heat.ml.cluster.KMeans._initialize_cluster_centers():
Bcast(xi, root=proc) was failing because `xi.dtype` was initialized as default (float32). However, if `X.dtype = float64`, xi.dtype is float64 as well, hence the memory allocation mismatch.

Fixes: #407 

Changes proposed:
- Define `xi = ht.zeros(X.shape[1], dtype=X.dtype)`

## Type of change

Select relevant options.

[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update

Are all split configurations tested and accounted for?
[ x] yes [ ] no
Does this change require a documentation update outside of the changes proposed?
[ ] yes [x ] no
Does this change modify the behaviour of other functions?
[ ] yes [ x] no
Are there code practices which require justification?
[ ] yes [ x] no
