### PR TITLE
Kmeans/assorted bugs

### DIFF
--- a/heat/ml/cluster/kmeans.py
+++ b/heat/ml/cluster/kmeans.py
@@ -164,7 +164,7 @@ class KMeans:
                     if displ[p] > sample:
                         break
                     proc = p
-                x0 = ht.zeros(X.shape[1], device=X.device, comm=X.comm)
+                x0 = ht.zeros(X.shape[1], dtype=X.dtype, device=X.device, comm=X.comm)
                 if X.comm.rank == proc:
                     idx = sample - displ[proc]
                     x0 = ht.array(X.lloc[idx, :, 0], device=X.device, comm=X.comm)
@@ -190,7 +190,7 @@ class KMeans:
                         if displ[p] > sample:
                             break
                         proc = p
-                    xi = ht.zeros(X.shape[1])
+                    xi = ht.zeros(X.shape[1], dtype=X.dtype)
                     if X.comm.rank == proc:
                         idx = sample - displ[proc]
                         xi = ht.array(X.lloc[idx, :, 0], device=X.device, comm=X.comm)

--- a/heat/ml/cluster/kmeans.py
+++ b/heat/ml/cluster/kmeans.py
@@ -131,7 +131,7 @@ class KMeans:
                     if X.comm.rank == proc:
                         idx = sample - displ[proc]
                         xi = ht.array(X.lloc[idx, :], device=X.device, comm=X.comm)
-                    X.comm.Bcast(xi, root=proc)
+                    xi.comm.Bcast(xi, root=proc)
                     centroids[:, i] = xi
 
             else:
@@ -198,7 +198,7 @@ class KMeans:
             else:
                 raise NotImplementedError("Not implemented for other splitting-axes")
 
-            self._cluster_centers = centroids.T.expand_dims(axis=0)
+            self._cluster_centers = centroids
 
         else:
             raise ValueError(

--- a/heat/ml/cluster/tests/test_kmeans.py
+++ b/heat/ml/cluster/tests/test_kmeans.py
@@ -17,3 +17,10 @@ class TestKMeans(unittest.TestCase):
         # check whether the results are correct
         self.assertIsInstance(kmeans.cluster_centers_, ht.DNDarray)
         self.assertEqual(kmeans.cluster_centers_.shape, (k, iris.shape[1]))
+        # same test with init=kmeans++
+        kmeans = ht.ml.cluster.KMeans(n_clusters=k, init="kmeans++")
+        kmeans.fit(iris)
+
+        # check whether the results are correct
+        self.assertIsInstance(kmeans.cluster_centers_, ht.DNDarray)
+        self.assertEqual(kmeans.cluster_centers_.shape, (k, iris.shape[1]))


### PR DESCRIPTION
## Description

Addressing problems in KMeans(init='kmeans++'). 

- fixed broadcasting of x0, xi in distributed mode
- addressed definition of `KMeans(k, init='kmeans++')._cluster_centers` so that X and KMeans._cluster_centers are broadcastable. 

Fixes: #407, #410 

Changes proposed:
- enforce `x0.dtype =X.dtype`, `xi.dtype =X.dtype`
- set `KMeans(k, init='kmeans++')._cluster_centers = clusters` 
(previously `KMeans(k, init='kmeans++')._cluster_centers = clusters.T.expand_dim(0)`, not consistent with definition of `clusters` in the init='kmeans++' case)


## Type of change

Select relevant options.

[ x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update

Are all split configurations tested and accounted for?
[ x] yes [ ] no
Does this change require a documentation update outside of the changes proposed?
[ ] yes [ x] no
Does this change modify the behaviour of other functions?
[ ] yes [ x] no
Are there code practices which require justification?
[ ] yes [ x] no
