### PR TITLE
diag() and diagonal() feature

### DIFF
--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import torch
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -386,19 +386,17 @@ def diag(a, offset=0):
         )
         a = concatenate((a, padding))
         indices_x = torch.arange(0, min(lshape[0], max(gshape[0] - off - offset, 0)))
-        indices_y = indices_x + off + offset
     elif offset < 0:
         padding = factories.empty(
             (abs(offset),), dtype=a.dtype, split=None, device=a.device, comm=a.comm
         )
         a = concatenate((padding, a))
         indices_x = torch.arange(max(0, min(abs(offset) - off, lshape[0])), lshape[0])
-        indices_y = torch.arange(max(0, off + offset), max(0, off + offset + lshape[0]))
     else:
         # Offset = 0 values on main diagonal
         indices_x = torch.arange(0, lshape[0])
-        indices_y = indices_x + off
 
+    indices_y = indices_x + off + offset
     a.balance_()
 
     local = torch.zeros(lshape, dtype=a.dtype.torch_type(), device=a.device.torch_device)

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -381,20 +381,25 @@ def diag(a, offset=0):
 
     # This ensures that the data is on the correct nodes
     if offset > 0:
+        print("first", a.comm)
         padding = factories.empty(
             (offset,), dtype=a.dtype, split=None, device=a.device, comm=a.comm
         )
+        print("padding", padding.comm)
         a = concatenate((a, padding))
         indices_x = torch.arange(0, min(lshape[0], max(gshape[0] - off - offset, 0)))
     elif offset < 0:
+        print("first", a.comm)
         padding = factories.empty(
             (abs(offset),), dtype=a.dtype, split=None, device=a.device, comm=a.comm
         )
+        print("padding", padding.comm)
         a = concatenate((padding, a))
         indices_x = torch.arange(max(0, min(abs(offset) - off, lshape[0])), lshape[0])
     else:
         # Offset = 0 values on main diagonal
         indices_x = torch.arange(0, lshape[0])
+    print("second", a.comm)
 
     indices_y = indices_x + off + offset
     a.balance_()

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -387,6 +387,15 @@ class TestManipulations(BasicTest):
             torch.equal(res[rank, rank]._DNDarray__array, torch.tensor(1, dtype=torch.int32))
         )
 
+    def test_failing(self):
+        self.assert_func_equal(
+            np.arange(23),
+            heat_func=ht.diag,
+            numpy_func=np.diag,
+            heat_args={"offset": 2},
+            numpy_args={"k": 2},
+        )
+
     def test_diagonal(self):
         size = ht.MPI_WORLD.size
         rank = ht.MPI_WORLD.rank

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -395,6 +395,14 @@ class TestManipulations(BasicTest):
             numpy_args={"k": 2},
         )
 
+        self.assert_func_equal(
+            (27,),
+            heat_func=ht.diag,
+            numpy_func=np.diag,
+            heat_args={"offset": -3},
+            numpy_args={"k": -3},
+        )
+
     def test_diagonal(self):
         size = ht.MPI_WORLD.size
         rank = ht.MPI_WORLD.rank

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -388,7 +388,7 @@ class TestManipulations(BasicTest):
         )
 
     def test_failing(self):
-        self.assert_func_equal(
+        self.assert_func_equal_for_tensor(
             np.arange(23),
             heat_func=ht.diag,
             numpy_func=np.diag,

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -387,7 +387,6 @@ class TestManipulations(BasicTest):
             torch.equal(res[rank, rank]._DNDarray__array, torch.tensor(1, dtype=torch.int32))
         )
 
-    def test_failing(self):
         self.assert_func_equal_for_tensor(
             np.arange(23),
             heat_func=ht.diag,


### PR DESCRIPTION
## Description

This PR targets issue #242.

The returned array of `diag()` in case of creating a diagonal array, will be split the same as the input array (`split=None` or `split=0`).

## Type of change

Select relevant options.

- [x] New feature (non-breaking change which adds functionality)

Are all split configurations tested and accounted for?
[x] yes - [ ] no
Does this change require a documentation update outside of the changes proposed?
[ ] yes [x] no
Does this change modify the behaviour of other functions?
[ ] yes [x] no
Are there code practices which require justification?
[ ] yes [x] no
