### PR TITLE
improve GPU support

### DIFF
--- a/heat/core/arithmetics.py
+++ b/heat/core/arithmetics.py
@@ -243,7 +243,9 @@ def diff(a, n=1, axis=-1):
             cr_slice = [slice(None)] * len(a.shape)
             # slice of 1 element in the selected axis for the shape creation
             cr_slice[axis] = 1
-            recv_data = torch.ones(ret.lloc[cr_slice].shape, dtype=ret.dtype.torch_type())
+            recv_data = torch.ones(
+                ret.lloc[cr_slice].shape, dtype=ret.dtype.torch_type(), device=a.device.torch_device
+            )
             rec = ret.comm.Irecv(recv_data, source=rank + 1, tag=rank + 1)
             axis_slice_end = [slice(None)] * len(a.shape)
             # select the last elements in the selected axis

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1427,10 +1427,7 @@ class DNDarray:
                 else:
                     gout = tuple(self.__array[key].shape)
                     if self.split is not None and self.split >= len(gout):
-                        if len(gout) > 0:
-                            new_split = len(gout) - 1 if len(gout) - 1 > 0 else 0
-                        else:
-                            new_split = None
+                        new_split = len(gout) - 1 if len(gout) - 1 >= 0 else 0
                     else:
                         new_split = self.split
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -741,7 +741,7 @@ class DNDarray:
         if rank == rcv_pr:
             shp = list(self.gshape)
             shp[self.split] = send_amt
-            data = torch.zeros(shp, dtype=snd_dtype)
+            data = torch.zeros(shp, dtype=snd_dtype, device=self.device.torch_device)
             self.comm.Recv(data, source=snd_pr, tag=685)
             if snd_pr < rcv_pr:  # data passed from a lower rank (append to top)
                 self.__array = torch.cat((data, self.__array), dim=self.split)

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -116,12 +116,13 @@ def where(cond, x=None, y=None):
         if (isinstance(x, dndarray.DNDarray) and cond.split != x.split) or (
             isinstance(y, dndarray.DNDarray) and cond.split != y.split
         ):
-            raise NotImplementedError("binary op not implemented for different split axes")
+            if len(y.shape) >= 1 and y.shape[0] > 1:
+                raise NotImplementedError("binary op not implemented for different split axes")
     if isinstance(x, (dndarray.DNDarray, int, float)) and isinstance(
         y, (dndarray.DNDarray, int, float)
     ):
-        cond = types.float(cond)
-        return (cond == 0) * y + cond * x
+        cond = types.float(cond, device=cond.device)
+        return types.float(cond == 0, device=cond.device) * y + cond * x
     elif x is None and y is None:
         return nonzero(cond)
     else:

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -106,7 +106,10 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
     """
     if np.isscalar(x):
         try:
-            x = factories.array([float(x)])
+            if isinstance(y, dndarray.DNDarray):
+                x = factories.array([float(x)], device=y.device)
+            else:
+                x = factories.array([float(x)])
         except (ValueError, TypeError):
             raise TypeError("Data type not supported, input was {}".format(type(x)))
 
@@ -117,7 +120,10 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
 
     if np.isscalar(y):
         try:
-            y = factories.array([float(y)])
+            if isinstance(x, dndarray.DNDarray):
+                y = factories.array([float(y)], device=x.device)
+            else:
+                y = factories.array([float(y)])
         except (ValueError, TypeError):
             raise TypeError("Data type not supported, input was {}".format(type(y)))
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -842,10 +842,10 @@ def sort(a, axis=None, descending=False, out=None):
         for idx in np.ndindex(local_sorted.shape[1:]):
             idx_slice = [slice(None)] + [slice(ind, ind + 1) for ind in idx]
 
-            send_count = send_vec.cpu()[idx][rank]
+            send_count = send_vec[idx][rank]
             send_disp = [0] + list(np.cumsum(send_count[:-1]))
 
-            recv_count = send_vec.cpu()[idx][:, rank]
+            recv_count = send_vec[idx][:, rank]
             recv_disp = [0] + list(np.cumsum(recv_count[:-1]))
 
             end = partition_matrix[rank][idx]

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -12,7 +12,7 @@ from . import types
 __all__ = []
 
 
-def binary_get_size_scalar(t1, t2):
+def __binary_get_size_scalar(t1, t2):
     """
     Find the tensor size of the result after performing a binary operation with t1 and t2.
 
@@ -49,9 +49,11 @@ def binary_get_size_scalar(t1, t2):
             raise TypeError("Only numeric scalars are supported, but input was {}".format(type(t2)))
         output_shape = (1,)
         output_split = None
-        output_device = None
+        output_device = t1.device
         output_comm = MPI_WORLD
     elif isinstance(t2, dndarray.DNDarray):
+        if t1.device != t2.device:
+            t1 = t1.gpu()
         output_shape = t2.shape
         output_split = t2.split
         output_device = t2.device
@@ -64,7 +66,7 @@ def binary_get_size_scalar(t1, t2):
     return t1, t2, output_shape, output_split, output_device, output_comm
 
 
-def binary_get_size_tensor(t1, t2):
+def __binary_get_size_tensor(t1, t2):
     """
     Find the tensor size of the result after performing a binary operation with t1 and t2.
 
@@ -91,7 +93,7 @@ def binary_get_size_tensor(t1, t2):
     """
     if np.isscalar(t2):
         try:
-            t2 = factories.array([t2])
+            t2 = factories.array([t2], device=t1.device)
             output_shape = t1.shape
             output_split = t1.split
             output_device = t1.device
@@ -100,6 +102,13 @@ def binary_get_size_tensor(t1, t2):
             raise TypeError("Data type not supported, input was {}".format(type(t2)))
 
     elif isinstance(t2, dndarray.DNDarray):
+        if t1.device != t2.device:
+            raise RuntimeError(
+                "Operands on different device types, inputs were {} and {}".format(
+                    t1.device.device_type, t2.device.device_type
+                )
+            )
+
         if t1.split is None:
             t1 = factories.array(
                 t1, split=t2.split, copy=False, comm=t1.comm, device=t1.device, ndmin=-t2.numdims
@@ -171,8 +180,9 @@ def __binary_bit_op(method, t1, t2):
     result: ht.DNDarray
         A tensor containing the element-wise results of bit-wise operation.
     """
+
     if np.isscalar(t1):
-        t1, t2, output_shape, output_split, output_device, output_comm = binary_get_size_scalar(
+        t1, t2, output_shape, output_split, output_device, output_comm = __binary_get_size_scalar(
             t1, t2
         )
 
@@ -184,7 +194,7 @@ def __binary_bit_op(method, t1, t2):
             )
 
     elif isinstance(t1, dndarray.DNDarray):
-        t1, t2, output_shape, output_split, output_device, output_comm = binary_get_size_tensor(
+        t1, t2, output_shape, output_split, output_device, output_comm = __binary_get_size_tensor(
             t1, t2
         )
 
@@ -225,12 +235,7 @@ def __binary_bit_op(method, t1, t2):
         result = operation(t2._DNDarray__array)
 
     return dndarray.DNDarray(
-        result,
-        output_shape,
-        types.canonical_heat_type(t1.dtype),
-        output_split,
-        output_device,
-        output_comm,
+        result, output_shape, types.heat_type_of(result), output_split, output_device, output_comm
     )
 
 
@@ -257,7 +262,7 @@ def __binary_op(operation, t1, t2):
         A tensor containing the results of element-wise operation.
     """
     if np.isscalar(t1):
-        t1, t2, output_shape, output_split, output_device, output_comm = binary_get_size_scalar(
+        t1, t2, output_shape, output_split, output_device, output_comm = __binary_get_size_scalar(
             t1, t2
         )
 
@@ -265,7 +270,7 @@ def __binary_op(operation, t1, t2):
             t1 = t1.astype(t2.dtype)
 
     elif isinstance(t1, dndarray.DNDarray):
-        t1, t2, output_shape, output_split, output_device, output_comm = binary_get_size_tensor(
+        t1, t2, output_shape, output_split, output_device, output_comm = __binary_get_size_tensor(
             t1, t2
         )
 
@@ -297,12 +302,7 @@ def __binary_op(operation, t1, t2):
         )
 
     return dndarray.DNDarray(
-        result,
-        output_shape,
-        types.canonical_heat_type(t1.dtype),
-        output_split,
-        output_device,
-        output_comm,
+        result, output_shape, types.heat_type_of(result), output_split, output_device, output_comm
     )
 
 

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -125,7 +125,9 @@ def binary_get_size_tensor(t1, t2):
                     "Broadcasting requires transferring data of first operator between MPI ranks!"
                 )
                 if t1.comm.rank > 0:
-                    t1._DNDarray__array = torch.zeros(t1.shape, dtype=t1.dtype.torch_type())
+                    t1._DNDarray__array = torch.zeros(
+                        t1.shape, dtype=t1.dtype.torch_type(), device=t1.device.torch_device
+                    )
                 t1.comm.Bcast(t1)
 
         if t2.split is not None:
@@ -134,7 +136,9 @@ def binary_get_size_tensor(t1, t2):
                     "Broadcasting requires transferring data of second operator between MPI ranks!"
                 )
                 if t2.comm.rank > 0:
-                    t2._DNDarray__array = torch.zeros(t2.shape, dtype=t2.dtype.torch_type())
+                    t2._DNDarray__array = torch.zeros(
+                        t2.shape, dtype=t2.dtype.torch_type(), device=t2.device.torch_device
+                    )
                 t2.comm.Bcast(t2)
 
     else:
@@ -252,7 +256,6 @@ def __binary_op(operation, t1, t2):
     result: ht.DNDarray
         A tensor containing the results of element-wise operation.
     """
-
     if np.isscalar(t1):
         t1, t2, output_shape, output_split, output_device, output_comm = binary_get_size_scalar(
             t1, t2

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -324,7 +324,7 @@ def average(x, axis=None, weights=None, returned=False):
             if weights.gshape[0] != x.gshape[axis]:
                 raise ValueError("Length of weights not compatible with specified axis.")
 
-        wgt = factories.empty_like(weights)
+        wgt = factories.empty_like(weights, device=x.device)
         wgt._DNDarray__array = weights._DNDarray__array
         wgt._DNDarray__split = weights.split
 
@@ -724,8 +724,8 @@ def mean(x, axis=None):
 
         mu_shape = list(mu.shape) if list(mu.shape) else [1]
 
-        mu_tot = factories.zeros(([x.comm.size] + mu_shape))
-        n_tot = factories.zeros(x.comm.size)
+        mu_tot = factories.zeros(([x.comm.size] + mu_shape), device=x.device)
+        n_tot = factories.zeros(x.comm.size, device=x.device)
         mu_tot[x.comm.rank, :] = mu
         n_tot[x.comm.rank] = float(x.lshape[x.split])
         x.comm.Allreduce(MPI.IN_PLACE, mu_tot, MPI.SUM)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -7,12 +7,17 @@ import os
 import heat as ht
 import numpy as np
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestArithmetics(unittest.TestCase):
@@ -21,17 +26,17 @@ class TestArithmetics(unittest.TestCase):
         cls.a_scalar = 2.0
         cls.an_int_scalar = 2
 
-        cls.a_vector = ht.float32([2, 2])
-        cls.another_vector = ht.float32([2, 2, 2])
+        cls.a_vector = ht.float32([2, 2], device=ht_device)
+        cls.another_vector = ht.float32([2, 2, 2], device=ht_device)
 
-        cls.a_tensor = ht.array([[1.0, 2.0], [3.0, 4.0]])
-        cls.another_tensor = ht.array([[2.0, 2.0], [2.0, 2.0]])
+        cls.a_tensor = ht.array([[1.0, 2.0], [3.0, 4.0]], device=ht_device)
+        cls.another_tensor = ht.array([[2.0, 2.0], [2.0, 2.0]], device=ht_device)
         cls.a_split_tensor = cls.another_tensor.copy().resplit_(0)
 
         cls.errorneous_type = (2, 2)
 
     def test_add(self):
-        result = ht.array([[3.0, 4.0], [5.0, 6.0]])
+        result = ht.array([[3.0, 4.0], [5.0, 6.0]], device=ht_device)
 
         self.assertTrue(ht.equal(ht.add(self.a_scalar, self.a_scalar), ht.float32([4.0])))
         self.assertTrue(ht.equal(ht.add(self.a_tensor, self.a_scalar), result))
@@ -49,17 +54,17 @@ class TestArithmetics(unittest.TestCase):
             ht.add("T", "s")
 
     def test_bitwise_and(self):
-        an_int_tensor = ht.array([[1, 2], [3, 4]])
-        an_int_vector = ht.array([2, 2])
-        another_int_vector = ht.array([2, 2, 2, 2])
+        an_int_tensor = ht.array([[1, 2], [3, 4]], device=ht_device)
+        an_int_vector = ht.array([2, 2], device=ht_device)
+        another_int_vector = ht.array([2, 2, 2, 2], device=ht_device)
 
-        int_result = ht.array([[0, 2], [2, 0]])
+        int_result = ht.array([[0, 2], [2, 0]], device=ht_device)
 
-        int16_result = ht.array([[0, 2], [2, 0]], dtype=ht.int16)
+        int16_result = ht.array([[0, 2], [2, 0]], dtype=ht.int16, device=ht_device)
 
-        a_boolean_vector = ht.array([False, True, False, True])
-        another_boolean_vector = ht.array([False, False, True, True])
-        boolean_result = ht.array([False, False, False, True])
+        a_boolean_vector = ht.array([False, True, False, True], device=ht_device)
+        another_boolean_vector = ht.array([False, False, True, True], device=ht_device)
+        boolean_result = ht.array([False, False, False, True], device=ht_device)
 
         self.assertTrue(ht.equal(ht.bitwise_and(an_int_tensor, self.an_int_scalar), int_result))
         self.assertTrue(ht.equal(ht.bitwise_and(an_int_tensor, an_int_vector), int_result))
@@ -93,17 +98,17 @@ class TestArithmetics(unittest.TestCase):
             ht.bitwise_and(1, [2])
 
     def test_bitwise_or(self):
-        an_int_tensor = ht.array([[1, 2], [3, 4]])
-        an_int_vector = ht.array([2, 2])
-        another_int_vector = ht.array([2, 2, 2, 2])
+        an_int_tensor = ht.array([[1, 2], [3, 4]], device=ht_device)
+        an_int_vector = ht.array([2, 2], device=ht_device)
+        another_int_vector = ht.array([2, 2, 2, 2], device=ht_device)
 
-        int_result = ht.array([[3, 2], [3, 6]])
+        int_result = ht.array([[3, 2], [3, 6]], device=ht_device)
 
-        int16_result = ht.array([[0, 2], [2, 0]], dtype=ht.int16)
+        int16_result = ht.array([[0, 2], [2, 0]], dtype=ht.int16, device=ht_device)
 
-        a_boolean_vector = ht.array([False, True, False, True])
-        another_boolean_vector = ht.array([False, False, True, True])
-        boolean_result = ht.array([False, True, True, True])
+        a_boolean_vector = ht.array([False, True, False, True], device=ht_device)
+        another_boolean_vector = ht.array([False, False, True, True], device=ht_device)
+        boolean_result = ht.array([False, True, True, True], device=ht_device)
 
         self.assertTrue(ht.equal(ht.bitwise_or(an_int_tensor, self.an_int_scalar), int_result))
         self.assertTrue(ht.equal(ht.bitwise_or(an_int_tensor, an_int_vector), int_result))
@@ -137,17 +142,17 @@ class TestArithmetics(unittest.TestCase):
             ht.bitwise_or(1, [2])
 
     def test_bitwise_xor(self):
-        an_int_tensor = ht.array([[1, 2], [3, 4]])
-        an_int_vector = ht.array([2, 2])
-        another_int_vector = ht.array([2, 2, 2, 2])
+        an_int_tensor = ht.array([[1, 2], [3, 4]], device=ht_device)
+        an_int_vector = ht.array([2, 2], device=ht_device)
+        another_int_vector = ht.array([2, 2, 2, 2], device=ht_device)
 
-        int_result = ht.array([[3, 0], [1, 6]])
+        int_result = ht.array([[3, 0], [1, 6]], device=ht_device)
 
-        int16_result = ht.array([[0, 2], [2, 0]], dtype=ht.int16)
+        int16_result = ht.array([[0, 2], [2, 0]], dtype=ht.int16, device=ht_device)
 
-        a_boolean_vector = ht.array([False, True, False, True])
-        another_boolean_vector = ht.array([False, False, True, True])
-        boolean_result = ht.array([False, True, True, False])
+        a_boolean_vector = ht.array([False, True, False, True], device=ht_device)
+        another_boolean_vector = ht.array([False, False, True, True], device=ht_device)
+        boolean_result = ht.array([False, True, True, False], device=ht_device)
 
         self.assertTrue(ht.equal(ht.bitwise_xor(an_int_tensor, self.an_int_scalar), int_result))
         self.assertTrue(ht.equal(ht.bitwise_xor(an_int_tensor, an_int_vector), int_result))
@@ -181,7 +186,7 @@ class TestArithmetics(unittest.TestCase):
             ht.bitwise_xor(1, [2])
 
     def test_diff(self):
-        ht_array = ht.random.rand(20, 20, 20, split=None)
+        ht_array = ht.random.rand(20, 20, 20, split=None, device=ht_device)
         arb_slice = [0] * 3
         for dim in range(3):  # loop over 3 dimensions
             arb_slice[dim] = slice(None)
@@ -194,7 +199,7 @@ class TestArithmetics(unittest.TestCase):
                         np_array = ht_array[arb_slice].numpy()
 
                         ht_diff = ht.diff(lp_array, n=nl, axis=ax)
-                        np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
+                        np_diff = ht.array(np.diff(np_array, n=nl, axis=ax), device=ht_device)
 
                         self.assertTrue(ht.equal(ht_diff, np_diff))
                         self.assertEqual(ht_diff.split, sp)
@@ -202,15 +207,15 @@ class TestArithmetics(unittest.TestCase):
 
         np_array = ht_array.numpy()
         ht_diff = ht.diff(ht_array, n=2)
-        np_diff = ht.array(np.diff(np_array, n=2))
+        np_diff = ht.array(np.diff(np_array, n=2), device=ht_device)
         self.assertTrue(ht.equal(ht_diff, np_diff))
         self.assertEqual(ht_diff.split, None)
         self.assertEqual(ht_diff.dtype, ht_array.dtype)
 
-        ht_array = ht.random.rand(20, 20, 20, split=1, dtype=ht.float64)
+        ht_array = ht.random.rand(20, 20, 20, split=1, dtype=ht.float64, device=ht_device)
         np_array = ht_array.copy().numpy()
         ht_diff = ht.diff(ht_array, n=2)
-        np_diff = ht.array(np.diff(np_array, n=2))
+        np_diff = ht.array(np.diff(np_array, n=2), device=ht_device)
         self.assertTrue(ht.equal(ht_diff, np_diff))
         self.assertEqual(ht_diff.split, 1)
         self.assertEqual(ht_diff.dtype, ht_array.dtype)
@@ -224,8 +229,8 @@ class TestArithmetics(unittest.TestCase):
             ht.diff("string", axis=2)
 
     def test_div(self):
-        result = ht.array([[0.5, 1.0], [1.5, 2.0]])
-        commutated_result = ht.array([[2.0, 1.0], [2.0 / 3.0, 0.5]])
+        result = ht.array([[0.5, 1.0], [1.5, 2.0]], device=ht_device)
+        commutated_result = ht.array([[2.0, 1.0], [2.0 / 3.0, 0.5]], device=ht_device)
 
         self.assertTrue(ht.equal(ht.div(self.a_scalar, self.a_scalar), ht.float32([1.0])))
         self.assertTrue(ht.equal(ht.div(self.a_tensor, self.a_scalar), result))
@@ -243,15 +248,15 @@ class TestArithmetics(unittest.TestCase):
             ht.div("T", "s")
 
     def test_fmod(self):
-        result = ht.array([[1.0, 0.0], [1.0, 0.0]])
-        an_int_tensor = ht.array([[5, 3], [4, 1]])
-        integer_result = ht.array([[1, 1], [0, 1]])
-        commutated_result = ht.array([[0.0, 0.0], [2.0, 2.0]])
-        zero_tensor = ht.zeros((2, 2))
+        result = ht.array([[1.0, 0.0], [1.0, 0.0]], device=ht_device)
+        an_int_tensor = ht.array([[5, 3], [4, 1]], device=ht_device)
+        integer_result = ht.array([[1, 1], [0, 1]], device=ht_device)
+        commutated_result = ht.array([[0.0, 0.0], [2.0, 2.0]], device=ht_device)
+        zero_tensor = ht.zeros((2, 2), device=ht_device)
 
-        a_float = ht.array([5.3])
-        another_float = ht.array([1.9])
-        result_float = ht.array([1.5])
+        a_float = ht.array([5.3], device=ht_device)
+        another_float = ht.array([1.9], device=ht_device)
+        result_float = ht.array([1.5], device=ht_device)
 
         self.assertTrue(ht.equal(ht.fmod(self.a_scalar, self.a_scalar), ht.float32([0.0])))
         self.assertTrue(ht.equal(ht.fmod(self.a_tensor, self.a_tensor), zero_tensor))
@@ -272,17 +277,17 @@ class TestArithmetics(unittest.TestCase):
             ht.fmod("T", "s")
 
     def test_mod(self):
-        a_tensor = ht.array([[1, 4], [2, 2]])
-        another_tensor = ht.array([[1, 2], [3, 4]])
-        a_result = ht.array([[0, 0], [2, 2]])
-        another_result = ht.array([[1, 0], [0, 0]])
+        a_tensor = ht.array([[1, 4], [2, 2]], device=ht_device)
+        another_tensor = ht.array([[1, 2], [3, 4]], device=ht_device)
+        a_result = ht.array([[0, 0], [2, 2]], device=ht_device)
+        another_result = ht.array([[1, 0], [0, 0]], device=ht_device)
 
         self.assertTrue(ht.equal(ht.mod(a_tensor, another_tensor), a_result))
         self.assertTrue(ht.equal(ht.mod(a_tensor, self.an_int_scalar), another_result))
         self.assertTrue(ht.equal(ht.mod(self.an_int_scalar, another_tensor), a_result))
 
     def test_mul(self):
-        result = ht.array([[2.0, 4.0], [6.0, 8.0]])
+        result = ht.array([[2.0, 4.0], [6.0, 8.0]], device=ht_device)
 
         self.assertTrue(ht.equal(ht.mul(self.a_scalar, self.a_scalar), ht.array([4.0])))
         self.assertTrue(ht.equal(ht.mul(self.a_tensor, self.a_scalar), result))
@@ -300,8 +305,8 @@ class TestArithmetics(unittest.TestCase):
             ht.mul("T", "s")
 
     def test_pow(self):
-        result = ht.array([[1.0, 4.0], [9.0, 16.0]])
-        commutated_result = ht.array([[2.0, 4.0], [8.0, 16.0]])
+        result = ht.array([[1.0, 4.0], [9.0, 16.0]], device=ht_device)
+        commutated_result = ht.array([[2.0, 4.0], [8.0, 16.0]], device=ht_device)
 
         self.assertTrue(ht.equal(ht.pow(self.a_scalar, self.a_scalar), ht.array([4.0])))
         self.assertTrue(ht.equal(ht.pow(self.a_tensor, self.a_scalar), result))
@@ -322,7 +327,7 @@ class TestArithmetics(unittest.TestCase):
         array_len = 11
 
         # check sum over all float elements of 1d tensor locally
-        shape_noaxis = ht.ones(array_len)
+        shape_noaxis = ht.ones(array_len, device=ht_device)
         no_axis_prod = shape_noaxis.prod()
 
         self.assertIsInstance(no_axis_prod, ht.DNDarray)
@@ -333,12 +338,12 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(no_axis_prod.split, None)
         self.assertEqual(no_axis_prod._DNDarray__array, 1)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.prod(shape_noaxis, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 1)
 
         # check sum over all float elements of split 1d tensor
-        shape_noaxis_split = ht.arange(1, array_len, split=0)
+        shape_noaxis_split = ht.arange(1, array_len, split=0, device=ht_device)
         shape_noaxis_split_prod = shape_noaxis_split.prod()
 
         self.assertIsInstance(shape_noaxis_split_prod, ht.DNDarray)
@@ -349,12 +354,12 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(shape_noaxis_split_prod.split, None)
         self.assertEqual(shape_noaxis_split_prod, 3628800)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.prod(shape_noaxis_split, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 3628800)
 
         # check sum over all float elements of 3d tensor locally
-        shape_noaxis = ht.full((3, 3, 3), 2)
+        shape_noaxis = ht.full((3, 3, 3), 2, device=ht_device)
         no_axis_prod = shape_noaxis.prod()
 
         self.assertIsInstance(no_axis_prod, ht.DNDarray)
@@ -365,12 +370,12 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(no_axis_prod.split, None)
         self.assertEqual(no_axis_prod._DNDarray__array, 134217728)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.prod(shape_noaxis, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 134217728)
 
         # check sum over all float elements of split 3d tensor
-        shape_noaxis_split_axis = ht.full((3, 3, 3), 2, split=0)
+        shape_noaxis_split_axis = ht.full((3, 3, 3), 2, split=0, device=ht_device)
         split_axis_prod = shape_noaxis_split_axis.prod(axis=0)
 
         self.assertIsInstance(split_axis_prod, ht.DNDarray)
@@ -379,12 +384,12 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(split_axis_prod._DNDarray__array.dtype, torch.float32)
         self.assertEqual(split_axis_prod.split, None)
 
-        out_axis = ht.ones((3, 3))
+        out_axis = ht.ones((3, 3), device=ht_device)
         ht.prod(shape_noaxis, axis=0, out=out_axis)
         self.assertTrue((out_axis._DNDarray__array == torch.full((3,), 8, device=device)).all())
 
         # check sum over all float elements of splitted 5d tensor with negative axis
-        shape_noaxis_split_axis_neg = ht.full((1, 2, 3, 4, 5), 2, split=1)
+        shape_noaxis_split_axis_neg = ht.full((1, 2, 3, 4, 5), 2, split=1, device=ht_device)
         shape_noaxis_split_axis_neg_prod = shape_noaxis_split_axis_neg.prod(axis=-2)
 
         self.assertIsInstance(shape_noaxis_split_axis_neg_prod, ht.DNDarray)
@@ -393,13 +398,13 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(shape_noaxis_split_axis_neg_prod._DNDarray__array.dtype, torch.float32)
         self.assertEqual(shape_noaxis_split_axis_neg_prod.split, 1)
 
-        out_noaxis = ht.zeros((1, 2, 3, 5))
+        out_noaxis = ht.zeros((1, 2, 3, 5), device=ht_device)
         ht.prod(shape_noaxis_split_axis_neg, axis=-2, out=out_noaxis)
 
         # check sum over all float elements of splitted 3d tensor with tuple axis
-        shape_split_axis_tuple = ht.ones((3, 4, 5), split=1)
+        shape_split_axis_tuple = ht.ones((3, 4, 5), split=1, device=ht_device)
         shape_split_axis_tuple_prod = shape_split_axis_tuple.prod(axis=(-2, -3))
-        expected_result = ht.ones((5,))
+        expected_result = ht.ones((5,), device=ht_device)
 
         self.assertIsInstance(shape_split_axis_tuple_prod, ht.DNDarray)
         self.assertEqual(shape_split_axis_tuple_prod.shape, (5,))
@@ -410,17 +415,17 @@ class TestArithmetics(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(ValueError):
-            ht.ones(array_len).prod(axis=1)
+            ht.ones(array_len, device=ht_device).prod(axis=1)
         with self.assertRaises(ValueError):
-            ht.ones(array_len).prod(axis=-2)
+            ht.ones(array_len, device=ht_device).prod(axis=-2)
         with self.assertRaises(ValueError):
-            ht.ones((4, 4)).prod(axis=0, out=out_noaxis)
+            ht.ones((4, 4), device=ht_device).prod(axis=0, out=out_noaxis)
         with self.assertRaises(TypeError):
-            ht.ones(array_len).prod(axis="bad_axis_type")
+            ht.ones(array_len, device=ht_device).prod(axis="bad_axis_type")
 
     def test_sub(self):
-        result = ht.array([[-1.0, 0.0], [1.0, 2.0]])
-        minus_result = ht.array([[1.0, 0.0], [-1.0, -2.0]])
+        result = ht.array([[-1.0, 0.0], [1.0, 2.0]], device=ht_device)
+        minus_result = ht.array([[1.0, 0.0], [-1.0, -2.0]], device=ht_device)
 
         self.assertTrue(ht.equal(ht.sub(self.a_scalar, self.a_scalar), ht.array([0.0])))
         self.assertTrue(ht.equal(ht.sub(self.a_tensor, self.a_scalar), result))
@@ -441,7 +446,7 @@ class TestArithmetics(unittest.TestCase):
         array_len = 11
 
         # check sum over all float elements of 1d tensor locally
-        shape_noaxis = ht.ones(array_len)
+        shape_noaxis = ht.ones(array_len, device=ht_device)
         no_axis_sum = shape_noaxis.sum()
 
         self.assertIsInstance(no_axis_sum, ht.DNDarray)
@@ -452,12 +457,12 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(no_axis_sum.split, None)
         self.assertEqual(no_axis_sum._DNDarray__array, array_len)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.sum(shape_noaxis, out=out_noaxis)
         self.assertTrue(out_noaxis._DNDarray__array == shape_noaxis._DNDarray__array.sum())
 
         # check sum over all float elements of split 1d tensor
-        shape_noaxis_split = ht.arange(array_len, split=0)
+        shape_noaxis_split = ht.arange(array_len, split=0, device=ht_device)
         shape_noaxis_split_sum = shape_noaxis_split.sum()
 
         self.assertIsInstance(shape_noaxis_split_sum, ht.DNDarray)
@@ -468,12 +473,12 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(shape_noaxis_split_sum.split, None)
         self.assertEqual(shape_noaxis_split_sum, 55)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.sum(shape_noaxis_split, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 55)
 
         # check sum over all float elements of 3d tensor locally
-        shape_noaxis = ht.ones((3, 3, 3))
+        shape_noaxis = ht.ones((3, 3, 3), device=ht_device)
         no_axis_sum = shape_noaxis.sum()
 
         self.assertIsInstance(no_axis_sum, ht.DNDarray)
@@ -484,12 +489,12 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(no_axis_sum.split, None)
         self.assertEqual(no_axis_sum._DNDarray__array, 27)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.sum(shape_noaxis, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 27)
 
         # check sum over all float elements of split 3d tensor
-        shape_noaxis_split_axis = ht.ones((3, 3, 3), split=0)
+        shape_noaxis_split_axis = ht.ones((3, 3, 3), split=0, device=ht_device)
         split_axis_sum = shape_noaxis_split_axis.sum(axis=0)
 
         self.assertIsInstance(split_axis_sum, ht.DNDarray)
@@ -498,12 +503,12 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(split_axis_sum._DNDarray__array.dtype, torch.float32)
         self.assertEqual(split_axis_sum.split, None)
 
-        out_noaxis = ht.zeros((3, 3))
+        out_noaxis = ht.zeros((3, 3), device=ht_device)
         ht.sum(shape_noaxis, axis=0, out=out_noaxis)
         self.assertTrue((out_noaxis._DNDarray__array == torch.full((3, 3), 3, device=device)).all())
 
         # check sum over all float elements of splitted 5d tensor with negative axis
-        shape_noaxis_split_axis_neg = ht.ones((1, 2, 3, 4, 5), split=1)
+        shape_noaxis_split_axis_neg = ht.ones((1, 2, 3, 4, 5), split=1, device=ht_device)
         shape_noaxis_split_axis_neg_sum = shape_noaxis_split_axis_neg.sum(axis=-2)
 
         self.assertIsInstance(shape_noaxis_split_axis_neg_sum, ht.DNDarray)
@@ -512,13 +517,13 @@ class TestArithmetics(unittest.TestCase):
         self.assertEqual(shape_noaxis_split_axis_neg_sum._DNDarray__array.dtype, torch.float32)
         self.assertEqual(shape_noaxis_split_axis_neg_sum.split, 1)
 
-        out_noaxis = ht.zeros((1, 2, 3, 5))
+        out_noaxis = ht.zeros((1, 2, 3, 5), device=ht_device)
         ht.sum(shape_noaxis_split_axis_neg, axis=-2, out=out_noaxis)
 
         # check sum over all float elements of splitted 3d tensor with tuple axis
-        shape_split_axis_tuple = ht.ones((3, 4, 5), split=1)
+        shape_split_axis_tuple = ht.ones((3, 4, 5), split=1, device=ht_device)
         shape_split_axis_tuple_sum = shape_split_axis_tuple.sum(axis=(-2, -3))
-        expected_result = ht.ones((5,)) * 12.0
+        expected_result = ht.ones((5,), device=ht_device) * 12.0
 
         self.assertIsInstance(shape_split_axis_tuple_sum, ht.DNDarray)
         self.assertEqual(shape_split_axis_tuple_sum.shape, (5,))
@@ -529,13 +534,13 @@ class TestArithmetics(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(ValueError):
-            ht.ones(array_len).sum(axis=1)
+            ht.ones(array_len, device=ht_device).sum(axis=1)
         with self.assertRaises(ValueError):
-            ht.ones(array_len).sum(axis=-2)
+            ht.ones(array_len, device=ht_device).sum(axis=-2)
         with self.assertRaises(ValueError):
-            ht.ones((4, 4)).sum(axis=0, out=out_noaxis)
+            ht.ones((4, 4), device=ht_device).sum(axis=0, out=out_noaxis)
         with self.assertRaises(TypeError):
-            ht.ones(array_len).sum(axis="bad_axis_type")
+            ht.ones(array_len, device=ht_device).sum(axis="bad_axis_type")
 
     def test_right_hand_side_operations(self):
         """
@@ -545,7 +550,7 @@ class TestArithmetics(unittest.TestCase):
         Examples
         --------
         >>> import heat as ht
-        >>> T = ht.float32([[1., 2.], [3., 4.]])
+        >>> T = ht.float32([[1., 2.], [3., 4.]], device=ht_device)
         >>> assert T * 3 == 3 * T
         """
         operators = (
@@ -560,11 +565,11 @@ class TestArithmetics(unittest.TestCase):
             ("__or__", operator.or_, False),
             ("__xor__", operator.xor, False),
         )
-        tensor = ht.float32([[1, 4], [2, 3]])
+        tensor = ht.float32([[1, 4], [2, 3]], device=ht_device)
         num = 3
         for (attr, op, commutative) in operators:
             if attr in ["__and__", "__or__", "__xor__"]:
-                tensor = ht.int64([[1, 4], [2, 3]])
+                tensor = ht.int64([[1, 4], [2, 3]], device=ht_device)
             try:
                 func = tensor.__getattribute__(attr)
             except AttributeError:

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -2,9 +2,17 @@ import operator
 
 import torch
 import unittest
+import os
 
 import heat as ht
 import numpy as np
+
+if os.environ.get("DEVICE") == "gpu":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+else:
+    device = torch.device("cpu")
+    ht.use_device("cpu")
 
 
 class TestArithmetics(unittest.TestCase):
@@ -372,7 +380,7 @@ class TestArithmetics(unittest.TestCase):
 
         out_axis = ht.ones((3, 3))
         ht.prod(shape_noaxis, axis=0, out=out_axis)
-        self.assertTrue((out_axis._DNDarray__array == torch.full((3,), 8)).all())
+        self.assertTrue((out_axis._DNDarray__array == torch.full((3,), 8, device=device)).all())
 
         # check sum over all float elements of splitted 5d tensor with negative axis
         shape_noaxis_split_axis_neg = ht.full((1, 2, 3, 4, 5), 2, split=1)
@@ -491,7 +499,7 @@ class TestArithmetics(unittest.TestCase):
 
         out_noaxis = ht.zeros((3, 3))
         ht.sum(shape_noaxis, axis=0, out=out_noaxis)
-        self.assertTrue((out_noaxis._DNDarray__array == torch.full((3, 3), 3)).all())
+        self.assertTrue((out_noaxis._DNDarray__array == torch.full((3, 3), 3, device=device)).all())
 
         # check sum over all float elements of splitted 5d tensor with negative axis
         shape_noaxis_split_axis_neg = ht.ones((1, 2, 3, 4, 5), split=1)
@@ -538,7 +546,6 @@ class TestArithmetics(unittest.TestCase):
         >>> import heat as ht
         >>> T = ht.float32([[1., 2.], [3., 4.]])
         >>> assert T * 3 == 3 * T
-
         """
         operators = (
             ("__add__", operator.add, True),

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -8,11 +8,11 @@ import heat as ht
 import numpy as np
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestArithmetics(unittest.TestCase):

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -5,11 +5,11 @@ import os
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestCommunication(unittest.TestCase):

--- a/heat/core/tests/test_constants.py
+++ b/heat/core/tests/test_constants.py
@@ -4,12 +4,17 @@ import os
 
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and ht.torch.cuda.is_available():
+    ht.use_device("gpu")
     ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and ht.torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    ht.torch.cuda.set_device(device)
 
 
 class TestConstants(unittest.TestCase):

--- a/heat/core/tests/test_constants.py
+++ b/heat/core/tests/test_constants.py
@@ -4,7 +4,12 @@ import os
 
 import heat as ht
 
-ht.use_device(os.environ.get("DEVICE"))
+if os.environ.get("DEVICE") == "gpu":
+    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+    ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
+else:
+    ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestConstants(unittest.TestCase):

--- a/heat/core/tests/test_constants.py
+++ b/heat/core/tests/test_constants.py
@@ -1,7 +1,10 @@
 import unittest
 import numpy as np
+import os
 
 import heat as ht
+
+ht.use_device(os.environ.get("DEVICE"))
 
 
 class TestConstants(unittest.TestCase):

--- a/heat/core/tests/test_devices.py
+++ b/heat/core/tests/test_devices.py
@@ -1,18 +1,32 @@
 import unittest
-
+import os
 import heat as ht
+
+ht.use_device(os.environ.get("DEVICE"))
 
 
 class TestDevices(unittest.TestCase):
     def test_get_default_device(self):
-        self.assertIs(ht.get_device(), ht.cpu)
+        if os.environ.get("DEVICE") == "gpu":
+            ht.use_device(os.environ.get("DEVICE"))
+            self.assertIs(ht.get_device(), ht.gpu)
+        else:
+            self.assertIs(ht.get_device(), ht.cpu)
 
     def test_sanitize_device(self):
-        self.assertIs(ht.sanitize_device("cpu"), ht.cpu)
-        self.assertIs(ht.sanitize_device("cPu"), ht.cpu)
-        self.assertIs(ht.sanitize_device("  CPU  "), ht.cpu)
-        self.assertIs(ht.sanitize_device(ht.cpu), ht.cpu)
-        self.assertIs(ht.sanitize_device(None), ht.cpu)
+        if os.environ.get("DEVICE") == "gpu":
+            ht.use_device(os.environ.get("DEVICE"))
+            self.assertIs(ht.sanitize_device("gpu"), ht.gpu)
+            self.assertIs(ht.sanitize_device("gPu"), ht.gpu)
+            self.assertIs(ht.sanitize_device("  GPU  "), ht.gpu)
+            self.assertIs(ht.sanitize_device(ht.gpu), ht.gpu)
+            self.assertIs(ht.sanitize_device(None), ht.gpu)
+        else:
+            self.assertIs(ht.sanitize_device("cpu"), ht.cpu)
+            self.assertIs(ht.sanitize_device("cPu"), ht.cpu)
+            self.assertIs(ht.sanitize_device("  CPU  "), ht.cpu)
+            self.assertIs(ht.sanitize_device(ht.cpu), ht.cpu)
+            self.assertIs(ht.sanitize_device(None), ht.cpu)
 
         with self.assertRaises(ValueError):
             self.assertIs(ht.sanitize_device("fpu"), ht.cpu)
@@ -20,12 +34,20 @@ class TestDevices(unittest.TestCase):
             self.assertIs(ht.sanitize_device(1), ht.cpu)
 
     def test_set_default_device(self):
-        ht.use_device("cpu")
-        self.assertIs(ht.get_device(), ht.cpu)
-        ht.use_device(ht.cpu)
-        self.assertIs(ht.get_device(), ht.cpu)
-        ht.use_device(None)
-        self.assertIs(ht.get_device(), ht.cpu)
+        if os.environ.get("DEVICE") == "gpu":
+            ht.use_device("gpu")
+            self.assertIs(ht.get_device(), ht.gpu)
+            ht.use_device(ht.gpu)
+            self.assertIs(ht.get_device(), ht.gpu)
+            ht.use_device(None)
+            self.assertIs(ht.get_device(), ht.gpu)
+        else:
+            ht.use_device("cpu")
+            self.assertIs(ht.get_device(), ht.cpu)
+            ht.use_device(ht.cpu)
+            self.assertIs(ht.get_device(), ht.cpu)
+            ht.use_device(None)
+            self.assertIs(ht.get_device(), ht.cpu)
 
         with self.assertRaises(ValueError):
             ht.use_device("fpu")

--- a/heat/core/tests/test_devices.py
+++ b/heat/core/tests/test_devices.py
@@ -2,12 +2,17 @@ import unittest
 import os
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and ht.torch.cuda.is_available():
+    ht.use_device("gpu")
     ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and ht.torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    ht.torch.cuda.set_device(device)
 
 
 class TestDevices(unittest.TestCase):

--- a/heat/core/tests/test_devices.py
+++ b/heat/core/tests/test_devices.py
@@ -2,7 +2,12 @@ import unittest
 import os
 import heat as ht
 
-ht.use_device(os.environ.get("DEVICE"))
+if os.environ.get("DEVICE") == "gpu":
+    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+    ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
+else:
+    ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestDevices(unittest.TestCase):

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -724,61 +724,66 @@ class TestDNDarray(unittest.TestCase):
 
     def test_stride_and_strides(self):
         # Local, int16, row-major memory layout
-        torch_int16 = torch.arange(6 * 5 * 3 * 4 * 5 * 7, dtype=torch.int16).reshape(
+        torch_int16 = torch.arange(6 * 5 * 3 * 4 * 5 * 7, dtype=torch.int16, device=device).reshape(
             6, 5, 3, 4, 5, 7
         )
-        heat_int16 = ht.array(torch_int16)
-        numpy_int16 = torch_int16.numpy()
+        heat_int16 = ht.array(torch_int16, device=ht_device)
+        numpy_int16 = torch_int16.cpu().numpy()
         self.assertEqual(heat_int16.stride(), torch_int16.stride())
         self.assertEqual(heat_int16.strides, numpy_int16.strides)
+
         # Local, float32, row-major memory layout
-        torch_float32 = torch.arange(6 * 5 * 3 * 4 * 5 * 7, dtype=torch.float32).reshape(
-            6, 5, 3, 4, 5, 7
-        )
-        heat_float32 = ht.array(torch_float32)
-        numpy_float32 = torch_float32.numpy()
+        torch_float32 = torch.arange(
+            6 * 5 * 3 * 4 * 5 * 7, dtype=torch.float32, device=device
+        ).reshape(6, 5, 3, 4, 5, 7)
+        heat_float32 = ht.array(torch_float32, device=ht_device)
+        numpy_float32 = torch_float32.cpu().numpy()
         self.assertEqual(heat_float32.stride(), torch_float32.stride())
         self.assertEqual(heat_float32.strides, numpy_float32.strides)
+
         # Local, float64, column-major memory layout
-        torch_float64 = torch.arange(6 * 5 * 3 * 4 * 5 * 7, dtype=torch.float64).reshape(
-            6, 5, 3, 4, 5, 7
-        )
-        heat_float64_F = ht.array(torch_float64, order="F")
-        numpy_float64_F = np.array(torch_float64.numpy(), order="F")
+        torch_float64 = torch.arange(
+            6 * 5 * 3 * 4 * 5 * 7, dtype=torch.float64, device=device
+        ).reshape(6, 5, 3, 4, 5, 7)
+        heat_float64_F = ht.array(torch_float64, order="F", device=ht_device)
+        numpy_float64_F = np.array(torch_float64.cpu().numpy(), order="F")
         self.assertNotEqual(heat_float64_F.stride(), torch_float64.stride())
         self.assertEqual(heat_float64_F.strides, numpy_float64_F.strides)
+
         # Distributed, int16, row-major memory layout
         size = ht.communication.MPI_WORLD.size
         split = 2
-        torch_int16 = torch.arange(6 * 5 * 3 * size * 4 * 5 * 7, dtype=torch.int16).reshape(
-            6, 5, 3 * size, 4, 5, 7
-        )
-        heat_int16_split = ht.array(torch_int16, split=split)
-        numpy_int16 = torch_int16.numpy()
+        torch_int16 = torch.arange(
+            6 * 5 * 3 * size * 4 * 5 * 7, dtype=torch.int16, device=device
+        ).reshape(6, 5, 3 * size, 4, 5, 7)
+        heat_int16_split = ht.array(torch_int16, split=split, device=ht_device)
+        numpy_int16 = torch_int16.cpu().numpy()
         if size > 1:
             self.assertNotEqual(heat_int16_split.stride(), torch_int16.stride())
         numpy_int16_split_strides = (
             tuple(np.array(numpy_int16.strides[:split]) / size) + numpy_int16.strides[split:]
         )
         self.assertEqual(heat_int16_split.strides, numpy_int16_split_strides)
+
         # Distributed, float32, row-major memory layout
         split = -1
-        torch_float32 = torch.arange(6 * 5 * 3 * 4 * 5 * 7 * size, dtype=torch.float32).reshape(
-            6, 5, 3, 4, 5, 7 * size
-        )
-        heat_float32_split = ht.array(torch_float32, split=split)
-        numpy_float32 = torch_float32.numpy()
+        torch_float32 = torch.arange(
+            6 * 5 * 3 * 4 * 5 * 7 * size, dtype=torch.float32, device=device
+        ).reshape(6, 5, 3, 4, 5, 7 * size)
+        heat_float32_split = ht.array(torch_float32, split=split, device=ht_device)
+        numpy_float32 = torch_float32.cpu().numpy()
         numpy_float32_split_strides = (
             tuple(np.array(numpy_float32.strides[:split]) / size) + numpy_float32.strides[split:]
         )
         self.assertEqual(heat_float32_split.strides, numpy_float32_split_strides)
+
         # Distributed, float64, column-major memory layout
         split = -2
-        torch_float64 = torch.arange(6 * 5 * 3 * 4 * 5 * size * 7, dtype=torch.float64).reshape(
-            6, 5, 3, 4, 5 * size, 7
-        )
-        heat_float64_F_split = ht.array(torch_float64, order="F", split=split)
-        numpy_float64_F = np.array(torch_float64.numpy(), order="F")
+        torch_float64 = torch.arange(
+            6 * 5 * 3 * 4 * 5 * size * 7, dtype=torch.float64, device=device
+        ).reshape(6, 5, 3, 4, 5 * size, 7)
+        heat_float64_F_split = ht.array(torch_float64, order="F", split=split, device=ht_device)
+        numpy_float64_F = np.array(torch_float64.cpu().numpy(), order="F")
         numpy_float64_F_split_strides = numpy_float64_F.strides[: split + 1] + tuple(
             np.array(numpy_float64_F.strides[split + 1 :]) / size
         )

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -5,11 +5,11 @@ import os
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestDNDarray(unittest.TestCase):

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -4,26 +4,31 @@ import unittest
 import os
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestDNDarray(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         N = ht.MPI_WORLD.size
-        cls.reference_tensor = ht.zeros((N, N + 1, 2 * N))
+        cls.reference_tensor = ht.zeros((N, N + 1, 2 * N), device=ht_device)
 
         for n in range(N):
             for m in range(N + 1):
                 cls.reference_tensor[n, m, :] = ht.arange(0, 2 * N) + m * 10 + n * 100
 
     def test_astype(self):
-        data = ht.float32([[1, 2, 3], [4, 5, 6]])
+        data = ht.float32([[1, 2, 3], [4, 5, 6]], device=ht_device)
 
         # check starting invariant
         self.assertEqual(data.dtype, ht.float32)
@@ -43,29 +48,29 @@ class TestDNDarray(unittest.TestCase):
         self.assertIs(as_float64, data)
 
     def test_balance_(self):
-        data = ht.zeros((70, 20), split=0)
+        data = ht.zeros((70, 20), split=0, device=ht_device)
         data = data[:50]
         data.balance_()
         self.assertTrue(data.is_balanced())
 
-        data = ht.zeros((4, 120), split=1)
+        data = ht.zeros((4, 120), split=1, device=ht_device)
         data = data[:, 40:70]
         data.balance_()
         self.assertTrue(data.is_balanced())
 
-        data = ht.zeros((70, 20), split=0, dtype=ht.float64)
+        data = ht.zeros((70, 20), split=0, dtype=ht.float64, device=ht_device)
         data = data[:50]
         data.balance_()
         self.assertTrue(data.is_balanced())
 
-        data = ht.zeros((4, 120), split=1, dtype=ht.int64)
+        data = ht.zeros((4, 120), split=1, dtype=ht.int64, device=ht_device)
         data = data[:, 40:70]
         data.balance_()
         self.assertTrue(data.is_balanced())
 
         data = np.loadtxt("heat/datasets/data/iris.csv", delimiter=";")
-        htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0)
-        self.assertTrue(ht.equal(htdata, ht.array(data, split=0, dtype=ht.float)))
+        htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0, device=ht_device)
+        self.assertTrue(ht.equal(htdata, ht.array(data, split=0, dtype=ht.float, device=ht_device)))
 
         if ht.MPI_WORLD.size > 4:
             rank = ht.MPI_WORLD.rank
@@ -77,134 +82,134 @@ class TestDNDarray(unittest.TestCase):
                 arr = torch.tensor([6, 7, 8, 9])
             else:
                 arr = torch.empty([0], dtype=torch.int64)
-            a = ht.array(arr, is_split=0)
+            a = ht.array(arr, is_split=0, device=ht_device)
             a.balance_()
-            comp = ht.arange(10, split=0)
+            comp = ht.arange(10, split=0, device=ht_device)
 
             self.assertTrue(ht.equal(a, comp))
 
     def test_bool_cast(self):
         # simple scalar tensor
-        a = ht.ones(1)
+        a = ht.ones(1, device=ht_device)
         casted_a = bool(a)
         self.assertEqual(casted_a, True)
         self.assertIsInstance(casted_a, bool)
 
         # multi-dimensional scalar tensor
-        b = ht.zeros((1, 1, 1, 1))
+        b = ht.zeros((1, 1, 1, 1), device=ht_device)
         casted_b = bool(b)
         self.assertEqual(casted_b, False)
         self.assertIsInstance(casted_b, bool)
 
         # split scalar tensor
-        c = ht.full((1,), 5, split=0)
+        c = ht.full((1,), 5, split=0, device=ht_device)
         casted_c = bool(c)
         self.assertEqual(casted_c, True)
         self.assertIsInstance(casted_c, bool)
 
         # exception on non-scalar tensor
         with self.assertRaises(TypeError):
-            bool(ht.empty(1, 2, 1, 1))
+            bool(ht.empty(1, 2, 1, 1, device=ht_device))
         # exception on empty tensor
         with self.assertRaises(TypeError):
-            bool(ht.empty((0, 1, 2)))
+            bool(ht.empty((0, 1, 2), device=ht_device))
         # exception on split tensor, where each chunk has size 1
         if ht.MPI_WORLD.size > 1:
             with self.assertRaises(TypeError):
-                bool(ht.full((ht.MPI_WORLD.size,), 2, split=0))
+                bool(ht.full((ht.MPI_WORLD.size,), 2, split=0, device=ht_device))
 
     def test_complex_cast(self):
         # simple scalar tensor
-        a = ht.ones(1)
+        a = ht.ones(1, device=ht_device)
         casted_a = complex(a)
         self.assertEqual(casted_a, 1 + 0j)
         self.assertIsInstance(casted_a, complex)
 
         # multi-dimensional scalar tensor
-        b = ht.zeros((1, 1, 1, 1))
+        b = ht.zeros((1, 1, 1, 1), device=ht_device)
         casted_b = complex(b)
         self.assertEqual(casted_b, 0 + 0j)
         self.assertIsInstance(casted_b, complex)
 
         # split scalar tensor
-        c = ht.full((1,), 5, split=0)
+        c = ht.full((1,), 5, split=0, device=ht_device)
         casted_c = complex(c)
         self.assertEqual(casted_c, 5 + 0j)
         self.assertIsInstance(casted_c, complex)
 
         # exception on non-scalar tensor
         with self.assertRaises(TypeError):
-            complex(ht.empty(1, 2, 1, 1))
+            complex(ht.empty(1, 2, 1, 1, device=ht_device))
         # exception on empty tensor
         with self.assertRaises(TypeError):
-            complex(ht.empty((0, 1, 2)))
+            complex(ht.empty((0, 1, 2), device=ht_device))
         # exception on split tensor, where each chunk has size 1
         if ht.MPI_WORLD.size > 1:
             with self.assertRaises(TypeError):
-                complex(ht.full((ht.MPI_WORLD.size,), 2, split=0))
+                complex(ht.full((ht.MPI_WORLD.size,), 2, split=0, device=ht_device))
 
     def test_float_cast(self):
         # simple scalar tensor
-        a = ht.ones(1)
+        a = ht.ones(1, device=ht_device)
         casted_a = float(a)
         self.assertEqual(casted_a, 1.0)
         self.assertIsInstance(casted_a, float)
 
         # multi-dimensional scalar tensor
-        b = ht.zeros((1, 1, 1, 1))
+        b = ht.zeros((1, 1, 1, 1), device=ht_device)
         casted_b = float(b)
         self.assertEqual(casted_b, 0.0)
         self.assertIsInstance(casted_b, float)
 
         # split scalar tensor
-        c = ht.full((1,), 5, split=0)
+        c = ht.full((1,), 5, split=0, device=ht_device)
         casted_c = float(c)
         self.assertEqual(casted_c, 5.0)
         self.assertIsInstance(casted_c, float)
 
         # exception on non-scalar tensor
         with self.assertRaises(TypeError):
-            float(ht.empty(1, 2, 1, 1))
+            float(ht.empty(1, 2, 1, 1, device=ht_device))
         # exception on empty tensor
         with self.assertRaises(TypeError):
-            float(ht.empty((0, 1, 2)))
+            float(ht.empty((0, 1, 2), device=ht_device))
         # exception on split tensor, where each chunk has size 1
         if ht.MPI_WORLD.size > 1:
             with self.assertRaises(TypeError):
-                float(ht.full((ht.MPI_WORLD.size,), 2, split=0))
+                float(ht.full((ht.MPI_WORLD.size,), 2, split=0), device=ht_device)
 
     def test_int_cast(self):
         # simple scalar tensor
-        a = ht.ones(1)
+        a = ht.ones(1, device=ht_device)
         casted_a = int(a)
         self.assertEqual(casted_a, 1)
         self.assertIsInstance(casted_a, int)
 
         # multi-dimensional scalar tensor
-        b = ht.zeros((1, 1, 1, 1))
+        b = ht.zeros((1, 1, 1, 1), device=ht_device)
         casted_b = int(b)
         self.assertEqual(casted_b, 0)
         self.assertIsInstance(casted_b, int)
 
         # split scalar tensor
-        c = ht.full((1,), 5, split=0)
+        c = ht.full((1,), 5, split=0, device=ht_device)
         casted_c = int(c)
         self.assertEqual(casted_c, 5)
         self.assertIsInstance(casted_c, int)
 
         # exception on non-scalar tensor
         with self.assertRaises(TypeError):
-            int(ht.empty(1, 2, 1, 1))
+            int(ht.empty(1, 2, 1, 1, device=ht_device))
         # exception on empty tensor
         with self.assertRaises(TypeError):
-            int(ht.empty((0, 1, 2)))
+            int(ht.empty((0, 1, 2), device=ht_device))
         # exception on split tensor, where each chunk has size 1
         if ht.MPI_WORLD.size > 1:
             with self.assertRaises(TypeError):
-                int(ht.full((ht.MPI_WORLD.size,), 2, split=0))
+                int(ht.full((ht.MPI_WORLD.size,), 2, split=0, device=ht_device))
 
     def test_is_balanced(self):
-        data = ht.zeros((70, 20), split=0)
+        data = ht.zeros((70, 20), split=0, device=ht_device)
         if data.comm.size != 1:
             data = data[:50]
             self.assertFalse(data.is_balanced())
@@ -212,38 +217,38 @@ class TestDNDarray(unittest.TestCase):
             self.assertTrue(data.is_balanced())
 
     def test_is_distributed(self):
-        data = ht.zeros((5, 5))
+        data = ht.zeros((5, 5), device=ht_device)
         self.assertFalse(data.is_distributed())
 
-        data = ht.zeros((4, 4), split=0)
+        data = ht.zeros((4, 4), split=0, device=ht_device)
         self.assertTrue(data.comm.size > 1 and data.is_distributed() or not data.is_distributed())
 
     def test_item(self):
-        x = ht.zeros((1,))
+        x = ht.zeros((1,), device=ht_device)
         self.assertEqual(x.item(), 0)
         self.assertEqual(type(x.item()), float)
 
-        x = ht.zeros((1, 2))
+        x = ht.zeros((1, 2), device=ht_device)
         with self.assertRaises(ValueError):
             x.item()
 
     def test_len(self):
         # vector
-        a = ht.zeros((10,))
+        a = ht.zeros((10,), device=ht_device)
         a_length = len(a)
 
         self.assertIsInstance(a_length, int)
         self.assertEqual(a_length, 10)
 
         # matrix
-        b = ht.ones((50, 2))
+        b = ht.ones((50, 2), device=ht_device)
         b_length = len(b)
 
         self.assertIsInstance(b_length, int)
         self.assertEqual(b_length, 50)
 
         # split 5D array
-        c = ht.empty((3, 4, 5, 6, 7), split=-1)
+        c = ht.empty((3, 4, 5, 6, 7), split=-1, device=ht_device)
         c_length = len(c)
 
         self.assertIsInstance(c_length, int)
@@ -251,19 +256,19 @@ class TestDNDarray(unittest.TestCase):
 
     def test_lloc(self):
         # single set
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a.lloc[0, 0] = 1
         self.assertEqual(a._DNDarray__array[0, 0], 1)
         self.assertEqual(a.lloc[0, 0].dtype, torch.float32)
 
         # multiple set
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a.lloc[1:3, 1] = 1
         self.assertTrue(all(a._DNDarray__array[1:3, 1] == 1))
         self.assertEqual(a.lloc[1:3, 1].dtype, torch.float32)
 
         # multiple set with specific indexing
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a.lloc[3:7:2, 2:5:2] = 1
         self.assertTrue(torch.all(a._DNDarray__array[3:7:2, 2:5:2] == 1))
         self.assertEqual(a.lloc[3:7:2, 2:5:2].dtype, torch.float32)
@@ -272,31 +277,31 @@ class TestDNDarray(unittest.TestCase):
         # ToDo: numpy does not work for distributed tensors du to issue#
         # Add additional tests if the issue is solved
         a = np.random.randn(10, 8)
-        b = ht.array(a)
+        b = ht.array(a, device=ht_device)
         self.assertIsInstance(b.numpy(), np.ndarray)
         self.assertEqual(b.numpy().shape, a.shape)
         self.assertEqual(b.numpy().tolist(), b._DNDarray__array.cpu().numpy().tolist())
 
-        a = ht.ones((10, 8), dtype=ht.float32)
+        a = ht.ones((10, 8), dtype=ht.float32, device=ht_device)
         b = np.ones((2, 2)).astype("float32")
         self.assertEqual(a.numpy().dtype, b.dtype)
 
-        a = ht.ones((10, 8), dtype=ht.float64)
+        a = ht.ones((10, 8), dtype=ht.float64, device=ht_device)
         b = np.ones((2, 2)).astype("float64")
         self.assertEqual(a.numpy().dtype, b.dtype)
 
-        a = ht.ones((10, 8), dtype=ht.int32)
+        a = ht.ones((10, 8), dtype=ht.int32, device=ht_device)
         b = np.ones((2, 2)).astype("int32")
         self.assertEqual(a.numpy().dtype, b.dtype)
 
-        a = ht.ones((10, 8), dtype=ht.int64)
+        a = ht.ones((10, 8), dtype=ht.int64, device=ht_device)
         b = np.ones((2, 2)).astype("int64")
         self.assertEqual(a.numpy().dtype, b.dtype)
 
     def test_resplit(self):
         # resplitting with same axis, should leave everything unchanged
         shape = (ht.MPI_WORLD.size, ht.MPI_WORLD.size)
-        data = ht.zeros(shape, split=None)
+        data = ht.zeros(shape, split=None, device=ht_device)
         data.resplit_(None)
 
         self.assertIsInstance(data, ht.DNDarray)
@@ -306,7 +311,7 @@ class TestDNDarray(unittest.TestCase):
 
         # resplitting with same axis, should leave everything unchanged
         shape = (ht.MPI_WORLD.size, ht.MPI_WORLD.size)
-        data = ht.zeros(shape, split=1)
+        data = ht.zeros(shape, split=1, device=ht_device)
         data.resplit_(1)
 
         self.assertIsInstance(data, ht.DNDarray)
@@ -316,7 +321,7 @@ class TestDNDarray(unittest.TestCase):
 
         # splitting an unsplit tensor should result in slicing the tensor locally
         shape = (ht.MPI_WORLD.size, ht.MPI_WORLD.size)
-        data = ht.zeros(shape)
+        data = ht.zeros(shape, device=ht_device)
         data.resplit_(-1)
 
         self.assertIsInstance(data, ht.DNDarray)
@@ -326,7 +331,7 @@ class TestDNDarray(unittest.TestCase):
 
         # unsplitting, aka gathering a tensor
         shape = (ht.MPI_WORLD.size + 1, ht.MPI_WORLD.size)
-        data = ht.ones(shape, split=0)
+        data = ht.ones(shape, split=0, device=ht_device)
         data.resplit_(None)
 
         self.assertIsInstance(data, ht.DNDarray)
@@ -336,7 +341,7 @@ class TestDNDarray(unittest.TestCase):
 
         # assign and entirely new split axis
         shape = (ht.MPI_WORLD.size + 2, ht.MPI_WORLD.size + 1)
-        data = ht.ones(shape, split=0)
+        data = ht.ones(shape, split=0, device=ht_device)
         data.resplit_(1)
 
         self.assertIsInstance(data, ht.DNDarray)
@@ -389,7 +394,7 @@ class TestDNDarray(unittest.TestCase):
         self.assertTrue((a_tensor._DNDarray__array == local_tensor._DNDarray__array).all())
 
         expected = torch.ones((ht.MPI_WORLD.size, 100), dtype=torch.int64, device=device)
-        data = ht.array(expected, split=1)
+        data = ht.array(expected, split=1, device=ht_device)
         data.resplit_(None)
 
         self.assertTrue(torch.equal(data._DNDarray__array, expected))
@@ -399,7 +404,7 @@ class TestDNDarray(unittest.TestCase):
         self.assertEqual(data._DNDarray__array.dtype, expected.dtype)
 
         expected = torch.zeros((100, ht.MPI_WORLD.size), dtype=torch.uint8, device=device)
-        data = ht.array(expected, split=0)
+        data = ht.array(expected, split=0, device=ht_device)
         data.resplit_(None)
 
         self.assertTrue(torch.equal(data._DNDarray__array, expected))
@@ -410,20 +415,20 @@ class TestDNDarray(unittest.TestCase):
 
     def test_setitem_getitem(self):
         # set and get single value
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         # set value on one node
         a[10, 0] = 1
         self.assertEqual(a[10, 0], 1)
         self.assertEqual(a[10, 0].dtype, ht.float32)
 
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a[10] = 1
         b = a[10]
         self.assertTrue((b == 1).all())
         self.assertEqual(b.dtype, ht.float32)
         self.assertEqual(b.gshape, (5,))
 
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a[-1] = 1
         b = a[-1]
         self.assertTrue((b == 1).all())
@@ -431,7 +436,7 @@ class TestDNDarray(unittest.TestCase):
         self.assertEqual(b.gshape, (5,))
 
         # slice in 1st dim only on 1 node
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a[1:4] = 1
         self.assertTrue((a[1:4] == 1).all())
         self.assertEqual(a[1:4].gshape, (3, 5))
@@ -443,7 +448,7 @@ class TestDNDarray(unittest.TestCase):
             else:
                 self.assertEqual(a[1:4].lshape, (0,))
 
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a[1:2] = 1
         self.assertTrue((a[1:2] == 1).all())
         self.assertEqual(a[1:2].gshape, (1, 5))
@@ -456,7 +461,7 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[1:2].lshape, (0,))
 
         # slice in 1st dim only on 1 node w/ singular second dim
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a[1:4, 1] = 1
         b = a[1:4, 1]
         self.assertTrue((b == 1).all())
@@ -470,7 +475,7 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(b.lshape, (0,))
 
         # slice in 1st dim across both nodes (2 node case) w/ singular second dim
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a[1:11, 1] = 1
         self.assertTrue((a[1:11, 1] == 1).all())
         self.assertEqual(a[1:11, 1].gshape, (10,))
@@ -483,7 +488,7 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[1:11, 1].lshape, (6,))
 
         # slice in 1st dim across 1 node (2nd) w/ singular second dim
-        c = ht.zeros((13, 5), split=0)
+        c = ht.zeros((13, 5), split=0, device=ht_device)
         c[8:12, 1] = 1
         b = c[8:12, 1]
         self.assertTrue((b == 1).all())
@@ -497,7 +502,7 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(b.lshape, (0,))
 
         # slice in both directions
-        a = ht.zeros((13, 5), split=0)
+        a = ht.zeros((13, 5), split=0, device=ht_device)
         a[3:13, 2:5:2] = 1
         self.assertTrue((a[3:13, 2:5:2] == 1).all())
         self.assertEqual(a[3:13, 2:5:2].gshape, (10, 2))
@@ -510,21 +515,21 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[3:13, 2:5:2].lshape, (4, 2))
 
         # setting with heat tensor
-        a = ht.zeros((4, 5), split=0)
-        a[1, 0:4] = ht.arange(4)
+        a = ht.zeros((4, 5), split=0, device=ht_device)
+        a[1, 0:4] = ht.arange(4, device=ht_device)
         # if a.comm.size == 2:
         for c, i in enumerate(range(4)):
             self.assertEqual(a[1, c], i)
 
         # setting with torch tensor
-        a = ht.zeros((4, 5), split=0)
+        a = ht.zeros((4, 5), split=0, device=ht_device)
         a[1, 0:4] = torch.arange(4, device=device)
         # if a.comm.size == 2:
         for c, i in enumerate(range(4)):
             self.assertEqual(a[1, c], i)
 
         ###################################################
-        a = ht.zeros((13, 5), split=1)
+        a = ht.zeros((13, 5), split=1, device=ht_device)
         # # set value on one node
         a[10] = 1
         self.assertEqual(a[10].dtype, ht.float32)
@@ -534,14 +539,14 @@ class TestDNDarray(unittest.TestCase):
             if a.comm.rank == 1:
                 self.assertEqual(a[10].lshape, (2,))
 
-        a = ht.zeros((13, 5), split=1)
+        a = ht.zeros((13, 5), split=1, device=ht_device)
         # # set value on one node
         a[10, 0] = 1
         self.assertEqual(a[10, 0], 1)
         self.assertEqual(a[10, 0].dtype, ht.float32)
 
         # slice in 1st dim only on 1 node
-        a = ht.zeros((13, 5), split=1)
+        a = ht.zeros((13, 5), split=1, device=ht_device)
         a[1:4] = 1
         self.assertTrue((a[1:4] == 1).all())
         self.assertEqual(a[1:4].gshape, (3, 5))
@@ -554,7 +559,7 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[1:4].lshape, (3, 2))
 
         # slice in 1st dim only on 1 node w/ singular second dim
-        a = ht.zeros((13, 5), split=1)
+        a = ht.zeros((13, 5), split=1, device=ht_device)
         a[1:4, 1] = 1
         self.assertTrue((a[1:4, 1] == 1).all())
         self.assertEqual(a[1:4, 1].gshape, (3,))
@@ -567,7 +572,7 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[1:4, 1].lshape, (0,))
 
         # slice in 2st dim across both nodes (2 node case) w/ singular fist dim
-        a = ht.zeros((13, 5), split=1)
+        a = ht.zeros((13, 5), split=1, device=ht_device)
         a[11, 1:5] = 1
         self.assertTrue((a[11, 1:5] == 1).all())
         self.assertEqual(a[11, 1:5].gshape, (4,))
@@ -580,7 +585,7 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[11, 1:5].lshape, (2,))
 
         # slice in 1st dim across 1 node (2nd) w/ singular second dim
-        a = ht.zeros((13, 5), split=1)
+        a = ht.zeros((13, 5), split=1, device=ht_device)
         a[8:12, 1] = 1
         self.assertTrue((a[8:12, 1] == 1).all())
         self.assertEqual(a[8:12, 1].gshape, (4,))
@@ -593,7 +598,7 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[8:12, 1].lshape, (0,))
 
         # slice in both directions
-        a = ht.zeros((13, 5), split=1)
+        a = ht.zeros((13, 5), split=1, device=ht_device)
         a[3:13, 2::2] = 1
         self.assertTrue((a[3:13, 2:5:2] == 1).all())
         self.assertEqual(a[3:13, 2:5:2].gshape, (10, 2))
@@ -606,19 +611,19 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[3:13, 2:5:2].lshape, (10, 1))
 
         # setting with heat tensor
-        a = ht.zeros((4, 5), split=1)
-        a[1, 0:4] = ht.arange(4)
+        a = ht.zeros((4, 5), split=1, device=ht_device)
+        a[1, 0:4] = ht.arange(4, device=ht_device)
         for c, i in enumerate(range(4)):
             self.assertEqual(a[1, c], i)
 
         # setting with torch tensor
-        a = ht.zeros((4, 5), split=1)
+        a = ht.zeros((4, 5), split=1, device=ht_device)
         a[1, 0:4] = torch.arange(4, device=device)
         for c, i in enumerate(range(4)):
             self.assertEqual(a[1, c], i)
 
         ####################################################
-        a = ht.zeros((13, 5, 7), split=2)
+        a = ht.zeros((13, 5, 7), split=2, device=ht_device)
         # # set value on one node
         a[10, :, :] = 1
         self.assertEqual(a[10, :, :].dtype, ht.float32)
@@ -629,14 +634,14 @@ class TestDNDarray(unittest.TestCase):
             if a.comm.rank == 1:
                 self.assertEqual(a[10, :, :].lshape, (5, 3))
 
-        a = ht.zeros((13, 5, 8), split=2)
+        a = ht.zeros((13, 5, 8), split=2, device=ht_device)
         # # set value on one node
         a[10, 0, 0] = 1
         self.assertEqual(a[10, 0, 0], 1)
         self.assertEqual(a[10, 0, 0].dtype, ht.float32)
 
         # # slice in 1st dim only on 1 node
-        a = ht.zeros((13, 5, 7), split=2)
+        a = ht.zeros((13, 5, 7), split=2, device=ht_device)
         a[1:4] = 1
         self.assertTrue((a[1:4] == 1).all())
         self.assertEqual(a[1:4].gshape, (3, 5, 7))
@@ -649,7 +654,7 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[1:4].lshape, (3, 5, 3))
 
         # slice in 1st dim only on 1 node w/ singular second dim
-        a = ht.zeros((13, 5, 7), split=2)
+        a = ht.zeros((13, 5, 7), split=2, device=ht_device)
         a[1:4, 1, :] = 1
         self.assertTrue((a[1:4, 1, :] == 1).all())
         self.assertEqual(a[1:4, 1, :].gshape, (3, 7))
@@ -662,14 +667,14 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[1:4, 1, :].lshape, (3, 3))
 
         # slice in both directions
-        a = ht.zeros((13, 5, 7), split=2)
+        a = ht.zeros((13, 5, 7), split=2, device=ht_device)
         a[3:13, 2:5:2, 1:7:3] = 1
         self.assertTrue((a[3:13, 2:5:2, 1:7:3] == 1).all())
         self.assertEqual(a[3:13, 2:5:2, 1:7:3].split, 2)
         self.assertEqual(a[3:13, 2:5:2, 1:7:3].dtype, ht.float32)
         self.assertEqual(a[3:13, 2:5:2, 1:7:3].gshape, (10, 2, 2))
         if a.comm.size == 2:
-            out = ht.ones((4, 5, 5), split=1)
+            out = ht.ones((4, 5, 5), split=1, device=ht_device)
             self.assertEqual(out[0].gshape, (5, 5))
             if a.comm.rank == 1:
                 self.assertEqual(a[3:13, 2:5:2, 1:7:3].lshape, (10, 2, 1))
@@ -678,41 +683,41 @@ class TestDNDarray(unittest.TestCase):
                 self.assertEqual(a[3:13, 2:5:2, 1:7:3].lshape, (10, 2, 1))
                 self.assertEqual(out[0].lshape, (3, 5))
 
-        a = ht.ones((4, 5), split=0).tril()
+        a = ht.ones((4, 5), split=0, device=ht_device).tril()
         a[0] = [6, 6, 6, 6, 6]
         self.assertTrue((a[0] == 6).all())
 
-        a = ht.ones((4, 5), split=0).tril()
+        a = ht.ones((4, 5), split=0, device=ht_device).tril()
         a[0] = (6, 6, 6, 6, 6)
         self.assertTrue((a[0] == 6).all())
 
-        a = ht.ones((4, 5), split=0).tril()
+        a = ht.ones((4, 5), split=0, device=ht_device).tril()
         a[0] = np.array([6, 6, 6, 6, 6])
         self.assertTrue((a[0] == 6).all())
 
-        a = ht.ones((4, 5), split=0).tril()
-        a[0] = ht.array([6, 6, 6, 6, 6])
-        self.assertTrue((a[ht.array((0,))] == 6).all())
+        a = ht.ones((4, 5), split=0, device=ht_device).tril()
+        a[0] = ht.array([6, 6, 6, 6, 6], device=ht_device)
+        self.assertTrue((a[ht.array((0,), device=ht_device)] == 6).all())
 
-        a = ht.ones((4, 5), split=0).tril()
-        a[0] = ht.array([6, 6, 6, 6, 6])
-        self.assertTrue((a[ht.array((0,))] == 6).all())
+        a = ht.ones((4, 5), split=0, device=ht_device).tril()
+        a[0] = ht.array([6, 6, 6, 6, 6], device=ht_device)
+        self.assertTrue((a[ht.array((0,), device=ht_device)] == 6).all())
 
     def test_size_gnumel(self):
-        a = ht.zeros((10, 10, 10), split=None)
+        a = ht.zeros((10, 10, 10), split=None, device=ht_device)
         self.assertEqual(a.size, 10 * 10 * 10)
         self.assertEqual(a.gnumel, 10 * 10 * 10)
 
-        a = ht.zeros((10, 10, 10), split=0)
+        a = ht.zeros((10, 10, 10), split=0, device=ht_device)
         self.assertEqual(a.size, 10 * 10 * 10)
         self.assertEqual(a.gnumel, 10 * 10 * 10)
 
-        a = ht.zeros((10, 10, 10), split=1)
+        a = ht.zeros((10, 10, 10), split=1, device=ht_device)
         self.assertEqual(a.size, 10 * 10 * 10)
         self.assertEqual(a.gnumel, 10 * 10 * 10)
 
-        a = ht.zeros((10, 10, 10), split=2)
+        a = ht.zeros((10, 10, 10), split=2, device=ht_device)
         self.assertEqual(a.size, 10 * 10 * 10)
         self.assertEqual(a.gnumel, 10 * 10 * 10)
 
-        self.assertEqual(ht.array(0).size, 1)
+        self.assertEqual(ht.array(0, device=ht_device).size, 1)

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -4,43 +4,48 @@ import os
 import numpy as np
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestExponential(unittest.TestCase):
     def test_exp(self):
         elements = 10
         tmp = torch.arange(elements, dtype=torch.float64, device=device).exp()
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=ht_device)
 
         # exponential of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_exp = ht.exp(float32_tensor)
         self.assertIsInstance(float32_exp, ht.DNDarray)
         self.assertEqual(float32_exp.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_exp, comparison.astype(ht.float32)))
 
         # exponential of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_exp = ht.exp(float64_tensor)
         self.assertIsInstance(float64_exp, ht.DNDarray)
         self.assertEqual(float64_exp.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_exp, comparison))
 
         # exponential of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_exp = ht.exp(int32_tensor)
         self.assertIsInstance(int32_exp, ht.DNDarray)
         self.assertEqual(int32_exp.dtype, ht.float64)
         self.assertTrue(ht.allclose(int32_exp, comparison))
 
         # exponential of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_exp = int64_tensor.exp()
         self.assertIsInstance(int64_exp, ht.DNDarray)
         self.assertEqual(int64_exp.dtype, ht.float64)
@@ -54,7 +59,7 @@ class TestExponential(unittest.TestCase):
 
         # Tests with split
         expected = torch.arange(10, dtype=torch.float32, device=device).exp()
-        actual = ht.arange(10, split=0, dtype=ht.float32).exp()
+        actual = ht.arange(10, split=0, dtype=ht.float32, device=ht_device).exp()
         self.assertEqual(actual.gshape, tuple(expected.shape))
         self.assertEqual(actual.split, 0)
         actual = actual.resplit_(None)
@@ -65,31 +70,31 @@ class TestExponential(unittest.TestCase):
     def test_expm1(self):
         elements = 10
         tmp = torch.arange(elements, dtype=torch.float64, device=device).expm1()
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=ht_device)
 
         # expm1onential of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_expm1 = ht.expm1(float32_tensor)
         self.assertIsInstance(float32_expm1, ht.DNDarray)
         self.assertEqual(float32_expm1.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_expm1, comparison.astype(ht.float32)))
 
         # expm1onential of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_expm1 = ht.expm1(float64_tensor)
         self.assertIsInstance(float64_expm1, ht.DNDarray)
         self.assertEqual(float64_expm1.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_expm1, comparison))
 
         # expm1onential of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_expm1 = ht.expm1(int32_tensor)
         self.assertIsInstance(int32_expm1, ht.DNDarray)
         self.assertEqual(int32_expm1.dtype, ht.float64)
         self.assertTrue(ht.allclose(int32_expm1, comparison))
 
         # expm1onential of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_expm1 = int64_tensor.expm1()
         self.assertIsInstance(int64_expm1, ht.DNDarray)
         self.assertEqual(int64_expm1.dtype, ht.float64)
@@ -104,10 +109,10 @@ class TestExponential(unittest.TestCase):
     def test_exp2(self):
         elements = 10
         tmp = np.exp2(torch.arange(elements, dtype=torch.float64))
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=ht_device)
 
         # exponential of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_exp2 = ht.exp2(float32_tensor)
         self.assertIsInstance(float32_exp2, ht.DNDarray)
         self.assertEqual(float32_exp2.dtype, ht.float32)
@@ -115,7 +120,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float32_exp2, comparison.astype(ht.float32)))
 
         # exponential of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_exp2 = ht.exp2(float64_tensor)
         self.assertIsInstance(float64_exp2, ht.DNDarray)
         self.assertEqual(float64_exp2.dtype, ht.float64)
@@ -123,7 +128,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float64_exp2, comparison))
 
         # exponential of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_exp2 = ht.exp2(int32_tensor)
         self.assertIsInstance(int32_exp2, ht.DNDarray)
         self.assertEqual(int32_exp2.dtype, ht.float64)
@@ -131,7 +136,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(int32_exp2, comparison))
 
         # exponential of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_exp2 = int64_tensor.exp2()
         self.assertIsInstance(int64_exp2, ht.DNDarray)
         self.assertEqual(int64_exp2.dtype, ht.float64)
@@ -147,10 +152,10 @@ class TestExponential(unittest.TestCase):
     def test_log(self):
         elements = 15
         tmp = torch.arange(1, elements, dtype=torch.float64, device=device).log()
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=ht_device)
 
         # logarithm of float32
-        float32_tensor = ht.arange(1, elements, dtype=ht.float32)
+        float32_tensor = ht.arange(1, elements, dtype=ht.float32, device=ht_device)
         float32_log = ht.log(float32_tensor)
         self.assertIsInstance(float32_log, ht.DNDarray)
         self.assertEqual(float32_log.dtype, ht.float32)
@@ -158,7 +163,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float32_log, comparison.astype(ht.float32)))
 
         # logarithm of float64
-        float64_tensor = ht.arange(1, elements, dtype=ht.float64)
+        float64_tensor = ht.arange(1, elements, dtype=ht.float64, device=ht_device)
         float64_log = ht.log(float64_tensor)
         self.assertIsInstance(float64_log, ht.DNDarray)
         self.assertEqual(float64_log.dtype, ht.float64)
@@ -166,7 +171,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float64_log, comparison))
 
         # logarithm of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(1, elements, dtype=ht.int32)
+        int32_tensor = ht.arange(1, elements, dtype=ht.int32, device=ht_device)
         int32_log = ht.log(int32_tensor)
         self.assertIsInstance(int32_log, ht.DNDarray)
         self.assertEqual(int32_log.dtype, ht.float64)
@@ -174,7 +179,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(int32_log, comparison))
 
         # logarithm of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(1, elements, dtype=ht.int64)
+        int64_tensor = ht.arange(1, elements, dtype=ht.int64, device=ht_device)
         int64_log = int64_tensor.log()
         self.assertIsInstance(int64_log, ht.DNDarray)
         self.assertEqual(int64_log.dtype, ht.float64)
@@ -190,10 +195,10 @@ class TestExponential(unittest.TestCase):
     def test_log2(self):
         elements = 15
         tmp = torch.arange(1, elements, dtype=torch.float64, device=device).log2()
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=ht_device)
 
         # logarithm of float32
-        float32_tensor = ht.arange(1, elements, dtype=ht.float32)
+        float32_tensor = ht.arange(1, elements, dtype=ht.float32, device=ht_device)
         float32_log2 = ht.log2(float32_tensor)
         self.assertIsInstance(float32_log2, ht.DNDarray)
         self.assertEqual(float32_log2.dtype, ht.float32)
@@ -201,7 +206,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float32_log2, comparison.astype(ht.float32)))
 
         # logarithm of float64
-        float64_tensor = ht.arange(1, elements, dtype=ht.float64)
+        float64_tensor = ht.arange(1, elements, dtype=ht.float64, device=ht_device)
         float64_log2 = ht.log2(float64_tensor)
         self.assertIsInstance(float64_log2, ht.DNDarray)
         self.assertEqual(float64_log2.dtype, ht.float64)
@@ -209,7 +214,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float64_log2, comparison))
 
         # logarithm of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(1, elements, dtype=ht.int32)
+        int32_tensor = ht.arange(1, elements, dtype=ht.int32, device=ht_device)
         int32_log2 = ht.log2(int32_tensor)
         self.assertIsInstance(int32_log2, ht.DNDarray)
         self.assertEqual(int32_log2.dtype, ht.float64)
@@ -217,7 +222,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(int32_log2, comparison))
 
         # logarithm of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(1, elements, dtype=ht.int64)
+        int64_tensor = ht.arange(1, elements, dtype=ht.int64, device=ht_device)
         int64_log2 = int64_tensor.log2()
         self.assertIsInstance(int64_log2, ht.DNDarray)
         self.assertEqual(int64_log2.dtype, ht.float64)
@@ -233,10 +238,10 @@ class TestExponential(unittest.TestCase):
     def test_log10(self):
         elements = 15
         tmp = torch.arange(1, elements, dtype=torch.float64, device=device).log10()
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=ht_device)
 
         # logarithm of float32
-        float32_tensor = ht.arange(1, elements, dtype=ht.float32)
+        float32_tensor = ht.arange(1, elements, dtype=ht.float32, device=ht_device)
         float32_log10 = ht.log10(float32_tensor)
         self.assertIsInstance(float32_log10, ht.DNDarray)
         self.assertEqual(float32_log10.dtype, ht.float32)
@@ -244,7 +249,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float32_log10, comparison.astype(ht.float32)))
 
         # logarithm of float64
-        float64_tensor = ht.arange(1, elements, dtype=ht.float64)
+        float64_tensor = ht.arange(1, elements, dtype=ht.float64, device=ht_device)
         float64_log10 = ht.log10(float64_tensor)
         self.assertIsInstance(float64_log10, ht.DNDarray)
         self.assertEqual(float64_log10.dtype, ht.float64)
@@ -252,7 +257,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float64_log10, comparison))
 
         # logarithm of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(1, elements, dtype=ht.int32)
+        int32_tensor = ht.arange(1, elements, dtype=ht.int32, device=ht_device)
         int32_log10 = ht.log10(int32_tensor)
         self.assertIsInstance(int32_log10, ht.DNDarray)
         self.assertEqual(int32_log10.dtype, ht.float64)
@@ -260,7 +265,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(int32_log10, comparison))
 
         # logarithm of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(1, elements, dtype=ht.int64)
+        int64_tensor = ht.arange(1, elements, dtype=ht.int64, device=ht_device)
         int64_log10 = int64_tensor.log10()
         self.assertIsInstance(int64_log10, ht.DNDarray)
         self.assertEqual(int64_log10.dtype, ht.float64)
@@ -276,10 +281,10 @@ class TestExponential(unittest.TestCase):
     def test_log1p(self):
         elements = 15
         tmp = torch.arange(1, elements, dtype=torch.float64, device=device).log1p()
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=ht_device)
 
         # logarithm of float32
-        float32_tensor = ht.arange(1, elements, dtype=ht.float32)
+        float32_tensor = ht.arange(1, elements, dtype=ht.float32, device=ht_device)
         float32_log1p = ht.log1p(float32_tensor)
         self.assertIsInstance(float32_log1p, ht.DNDarray)
         self.assertEqual(float32_log1p.dtype, ht.float32)
@@ -287,7 +292,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float32_log1p, comparison.astype(ht.float32)))
 
         # logarithm of float64
-        float64_tensor = ht.arange(1, elements, dtype=ht.float64)
+        float64_tensor = ht.arange(1, elements, dtype=ht.float64, device=ht_device)
         float64_log1p = ht.log1p(float64_tensor)
         self.assertIsInstance(float64_log1p, ht.DNDarray)
         self.assertEqual(float64_log1p.dtype, ht.float64)
@@ -295,7 +300,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float64_log1p, comparison))
 
         # logarithm of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(1, elements, dtype=ht.int32)
+        int32_tensor = ht.arange(1, elements, dtype=ht.int32, device=ht_device)
         int32_log1p = ht.log1p(int32_tensor)
         self.assertIsInstance(int32_log1p, ht.DNDarray)
         self.assertEqual(int32_log1p.dtype, ht.float64)
@@ -303,7 +308,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(int32_log1p, comparison))
 
         # logarithm of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(1, elements, dtype=ht.int64)
+        int64_tensor = ht.arange(1, elements, dtype=ht.int64, device=ht_device)
         int64_log1p = int64_tensor.log1p()
         self.assertIsInstance(int64_log1p, ht.DNDarray)
         self.assertEqual(int64_log1p.dtype, ht.float64)
@@ -319,10 +324,10 @@ class TestExponential(unittest.TestCase):
     def test_sqrt(self):
         elements = 25
         tmp = torch.arange(elements, dtype=torch.float64, device=device).sqrt()
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=ht_device)
 
         # square roots of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_sqrt = ht.sqrt(float32_tensor)
         self.assertIsInstance(float32_sqrt, ht.DNDarray)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
@@ -330,7 +335,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float32_sqrt, comparison.astype(ht.float32), 1e-06))
 
         # square roots of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_sqrt = ht.sqrt(float64_tensor)
         self.assertIsInstance(float64_sqrt, ht.DNDarray)
         self.assertEqual(float64_sqrt.dtype, ht.float64)
@@ -338,7 +343,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(float64_sqrt, comparison, 1e-06))
 
         # square roots of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_sqrt = ht.sqrt(int32_tensor)
         self.assertIsInstance(int32_sqrt, ht.DNDarray)
         self.assertEqual(int32_sqrt.dtype, ht.float64)
@@ -346,7 +351,7 @@ class TestExponential(unittest.TestCase):
         self.assertTrue(ht.allclose(int32_sqrt, comparison, 1e-06))
 
         # square roots of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_sqrt = int64_tensor.sqrt()
         self.assertIsInstance(int64_sqrt, ht.DNDarray)
         self.assertEqual(int64_sqrt.dtype, ht.float64)
@@ -362,31 +367,31 @@ class TestExponential(unittest.TestCase):
     def test_sqrt_method(self):
         elements = 25
         tmp = torch.arange(elements, dtype=torch.float64, device=device).sqrt()
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=ht_device)
 
         # square roots of float32
-        float32_sqrt = ht.arange(elements, dtype=ht.float32).sqrt()
+        float32_sqrt = ht.arange(elements, dtype=ht.float32, device=ht_device).sqrt()
         self.assertIsInstance(float32_sqrt, ht.DNDarray)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_sqrt, comparison.astype(ht.float32), 1e-05))
 
         # square roots of float64
-        float64_sqrt = ht.arange(elements, dtype=ht.float64).sqrt()
+        float64_sqrt = ht.arange(elements, dtype=ht.float64, device=ht_device).sqrt()
         self.assertIsInstance(float64_sqrt, ht.DNDarray)
         self.assertEqual(float64_sqrt.dtype, ht.float64)
         self.assertEqual(float64_sqrt.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_sqrt, comparison, 1e-05))
 
         # square roots of ints, automatic conversion to intermediate floats
-        int32_sqrt = ht.arange(elements, dtype=ht.int32).sqrt()
+        int32_sqrt = ht.arange(elements, dtype=ht.int32, device=ht_device).sqrt()
         self.assertIsInstance(int32_sqrt, ht.DNDarray)
         self.assertEqual(int32_sqrt.dtype, ht.float64)
         self.assertEqual(int32_sqrt.dtype, ht.float64)
         self.assertTrue(ht.allclose(int32_sqrt, comparison, 1e-05))
 
         # square roots of longs, automatic conversion to intermediate floats
-        int64_sqrt = ht.arange(elements, dtype=ht.int64).sqrt()
+        int64_sqrt = ht.arange(elements, dtype=ht.int64, device=ht_device).sqrt()
         self.assertIsInstance(int64_sqrt, ht.DNDarray)
         self.assertEqual(int64_sqrt.dtype, ht.float64)
         self.assertEqual(int64_sqrt.dtype, ht.float64)
@@ -401,8 +406,8 @@ class TestExponential(unittest.TestCase):
     def test_sqrt_out_of_place(self):
         elements = 30
         output_shape = (3, elements)
-        number_range = ht.arange(elements, dtype=ht.float32)
-        output_buffer = ht.zeros(output_shape, dtype=ht.float32)
+        number_range = ht.arange(elements, dtype=ht.float32, device=ht_device)
+        output_buffer = ht.zeros(output_shape, dtype=ht.float32, device=ht_device)
 
         # square roots
         float32_sqrt = ht.sqrt(number_range, out=output_buffer)

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -1,14 +1,21 @@
 import unittest
 import torch
-
+import os
 import numpy as np
 import heat as ht
+
+if os.environ.get("DEVICE") == "gpu":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+else:
+    device = torch.device("cpu")
+    ht.use_device("cpu")
 
 
 class TestExponential(unittest.TestCase):
     def test_exp(self):
         elements = 10
-        tmp = torch.arange(elements, dtype=torch.float64).exp()
+        tmp = torch.arange(elements, dtype=torch.float64, device=device).exp()
         comparison = ht.array(tmp)
 
         # exponential of float32
@@ -46,7 +53,7 @@ class TestExponential(unittest.TestCase):
             ht.exp("hello world")
 
         # Tests with split
-        expected = torch.arange(10, dtype=torch.float32).exp()
+        expected = torch.arange(10, dtype=torch.float32, device=device).exp()
         actual = ht.arange(10, split=0, dtype=ht.float32).exp()
         self.assertEqual(actual.gshape, tuple(expected.shape))
         self.assertEqual(actual.split, 0)
@@ -57,7 +64,7 @@ class TestExponential(unittest.TestCase):
 
     def test_expm1(self):
         elements = 10
-        tmp = torch.arange(elements, dtype=torch.float64).expm1()
+        tmp = torch.arange(elements, dtype=torch.float64, device=device).expm1()
         comparison = ht.array(tmp)
 
         # expm1onential of float32
@@ -139,7 +146,7 @@ class TestExponential(unittest.TestCase):
 
     def test_log(self):
         elements = 15
-        tmp = torch.arange(1, elements, dtype=torch.float64).log()
+        tmp = torch.arange(1, elements, dtype=torch.float64, device=device).log()
         comparison = ht.array(tmp)
 
         # logarithm of float32
@@ -182,7 +189,7 @@ class TestExponential(unittest.TestCase):
 
     def test_log2(self):
         elements = 15
-        tmp = torch.arange(1, elements, dtype=torch.float64).log2()
+        tmp = torch.arange(1, elements, dtype=torch.float64, device=device).log2()
         comparison = ht.array(tmp)
 
         # logarithm of float32
@@ -225,7 +232,7 @@ class TestExponential(unittest.TestCase):
 
     def test_log10(self):
         elements = 15
-        tmp = torch.arange(1, elements, dtype=torch.float64).log10()
+        tmp = torch.arange(1, elements, dtype=torch.float64, device=device).log10()
         comparison = ht.array(tmp)
 
         # logarithm of float32
@@ -268,7 +275,7 @@ class TestExponential(unittest.TestCase):
 
     def test_log1p(self):
         elements = 15
-        tmp = torch.arange(1, elements, dtype=torch.float64).log1p()
+        tmp = torch.arange(1, elements, dtype=torch.float64, device=device).log1p()
         comparison = ht.array(tmp)
 
         # logarithm of float32
@@ -311,7 +318,7 @@ class TestExponential(unittest.TestCase):
 
     def test_sqrt(self):
         elements = 25
-        tmp = torch.arange(elements, dtype=torch.float64).sqrt()
+        tmp = torch.arange(elements, dtype=torch.float64, device=device).sqrt()
         comparison = ht.array(tmp)
 
         # square roots of float32
@@ -354,7 +361,7 @@ class TestExponential(unittest.TestCase):
 
     def test_sqrt_method(self):
         elements = 25
-        tmp = torch.arange(elements, dtype=torch.float64).sqrt()
+        tmp = torch.arange(elements, dtype=torch.float64, device=device).sqrt()
         comparison = ht.array(tmp)
 
         # square roots of float32
@@ -399,7 +406,7 @@ class TestExponential(unittest.TestCase):
 
         # square roots
         float32_sqrt = ht.sqrt(number_range, out=output_buffer)
-        comparison = torch.arange(elements, dtype=torch.float32).sqrt()
+        comparison = torch.arange(elements, dtype=torch.float32, device=device).sqrt()
 
         # check whether the input range remain unchanged
         self.assertIsInstance(number_range, ht.DNDarray)

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -5,11 +5,11 @@ import numpy as np
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestExponential(unittest.TestCase):

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -3,18 +3,23 @@ import torch
 import os
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestFactories(unittest.TestCase):
     def test_arange(self):
         # testing one positional integer argument
-        one_arg_arange_int = ht.arange(10)
+        one_arg_arange_int = ht.arange(10, device=ht_device)
         self.assertIsInstance(one_arg_arange_int, ht.DNDarray)
         self.assertEqual(one_arg_arange_int.shape, (10,))
         self.assertLessEqual(one_arg_arange_int.lshape[0], 10)
@@ -25,7 +30,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(one_arg_arange_int.sum(), 45)
 
         # testing one positional float argument
-        one_arg_arange_float = ht.arange(10.0)
+        one_arg_arange_float = ht.arange(10.0, device=ht_device)
         self.assertIsInstance(one_arg_arange_float, ht.DNDarray)
         self.assertEqual(one_arg_arange_float.shape, (10,))
         self.assertLessEqual(one_arg_arange_float.lshape[0], 10)
@@ -36,7 +41,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(one_arg_arange_float.sum(), 45.0)
 
         # testing two positional integer arguments
-        two_arg_arange_int = ht.arange(0, 10)
+        two_arg_arange_int = ht.arange(0, 10, device=ht_device)
         self.assertIsInstance(two_arg_arange_int, ht.DNDarray)
         self.assertEqual(two_arg_arange_int.shape, (10,))
         self.assertLessEqual(two_arg_arange_int.lshape[0], 10)
@@ -47,7 +52,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(two_arg_arange_int.sum(), 45)
 
         # testing two positional arguments, one being float
-        two_arg_arange_float = ht.arange(0.0, 10)
+        two_arg_arange_float = ht.arange(0.0, 10, device=ht_device)
         self.assertIsInstance(two_arg_arange_float, ht.DNDarray)
         self.assertEqual(two_arg_arange_float.shape, (10,))
         self.assertLessEqual(two_arg_arange_float.lshape[0], 10)
@@ -58,7 +63,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(two_arg_arange_float.sum(), 45.0)
 
         # testing three positional integer arguments
-        three_arg_arange_int = ht.arange(0, 10, 2)
+        three_arg_arange_int = ht.arange(0, 10, 2, device=ht_device)
         self.assertIsInstance(three_arg_arange_int, ht.DNDarray)
         self.assertEqual(three_arg_arange_int.shape, (5,))
         self.assertLessEqual(three_arg_arange_int.lshape[0], 5)
@@ -69,7 +74,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(three_arg_arange_int.sum(), 20)
 
         # testing three positional arguments, one being float
-        three_arg_arange_float = ht.arange(0, 10, 2.0)
+        three_arg_arange_float = ht.arange(0, 10, 2.0, device=ht_device)
         self.assertIsInstance(three_arg_arange_float, ht.DNDarray)
         self.assertEqual(three_arg_arange_float.shape, (5,))
         self.assertLessEqual(three_arg_arange_float.lshape[0], 5)
@@ -80,7 +85,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(three_arg_arange_float.sum(), 20.0)
 
         # testing splitting
-        three_arg_arange_dtype_float32 = ht.arange(0, 10, 2.0, split=0)
+        three_arg_arange_dtype_float32 = ht.arange(0, 10, 2.0, split=0, device=ht_device)
         self.assertIsInstance(three_arg_arange_dtype_float32, ht.DNDarray)
         self.assertEqual(three_arg_arange_dtype_float32.shape, (5,))
         self.assertLessEqual(three_arg_arange_dtype_float32.lshape[0], 5)
@@ -91,7 +96,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(three_arg_arange_dtype_float32.sum(axis=0, keepdim=True), 20.0)
 
         # testing setting dtype to int16
-        three_arg_arange_dtype_short = ht.arange(0, 10, 2.0, dtype=torch.int16)
+        three_arg_arange_dtype_short = ht.arange(0, 10, 2.0, dtype=torch.int16, device=ht_device)
         self.assertIsInstance(three_arg_arange_dtype_short, ht.DNDarray)
         self.assertEqual(three_arg_arange_dtype_short.shape, (5,))
         self.assertLessEqual(three_arg_arange_dtype_short.lshape[0], 5)
@@ -102,7 +107,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(three_arg_arange_dtype_short.sum(axis=0, keepdim=True), 20)
 
         # testing setting dtype to float64
-        three_arg_arange_dtype_float64 = ht.arange(0, 10, 2, dtype=torch.float64)
+        three_arg_arange_dtype_float64 = ht.arange(0, 10, 2, dtype=torch.float64, device=ht_device)
         self.assertIsInstance(three_arg_arange_dtype_float64, ht.DNDarray)
         self.assertEqual(three_arg_arange_dtype_float64.shape, (5,))
         self.assertLessEqual(three_arg_arange_dtype_float64.lshape[0], 5)
@@ -114,16 +119,16 @@ class TestFactories(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(ValueError):
-            ht.arange(-5, 3, split=1)
+            ht.arange(-5, 3, split=1, device=ht_device)
         with self.assertRaises(TypeError):
-            ht.arange()
+            ht.arange(device=ht_device)
         with self.assertRaises(TypeError):
-            ht.arange(1, 2, 3, 4)
+            ht.arange(1, 2, 3, 4, device=ht_device)
 
     def test_array(self):
         # basic array function, unsplit data
         unsplit_data = [[1, 2, 3], [4, 5, 6]]
-        a = ht.array(unsplit_data)
+        a = ht.array(unsplit_data, device=ht_device)
         self.assertIsInstance(a, ht.DNDarray)
         self.assertEqual(a.dtype, ht.int64)
         self.assertEqual(a.lshape, (2, 3))
@@ -133,7 +138,7 @@ class TestFactories(unittest.TestCase):
 
         # basic array function, unsplit data, different datatype
         tuple_data = ((0, 0), (1, 1))
-        b = ht.array(tuple_data, dtype=ht.int8)
+        b = ht.array(tuple_data, dtype=ht.int8, device=ht_device)
         self.assertIsInstance(b, ht.DNDarray)
         self.assertEqual(b.dtype, ht.int8)
         self.assertEqual(b._DNDarray__array.dtype, torch.int8)
@@ -146,7 +151,7 @@ class TestFactories(unittest.TestCase):
 
         # basic array function, unsplit data, no copy
         torch_tensor = torch.tensor([6, 5, 4, 3, 2, 1], device=device)
-        c = ht.array(torch_tensor, copy=False)
+        c = ht.array(torch_tensor, copy=False, device=ht_device)
         self.assertIsInstance(c, ht.DNDarray)
         self.assertEqual(c.dtype, ht.int64)
         self.assertEqual(c.lshape, (6,))
@@ -157,7 +162,7 @@ class TestFactories(unittest.TestCase):
 
         # basic array function, unsplit data, additional dimensions
         vector_data = [4.0, 5.0, 6.0]
-        d = ht.array(vector_data, ndmin=3)
+        d = ht.array(vector_data, ndmin=3, device=ht_device)
         self.assertIsInstance(d, ht.DNDarray)
         self.assertEqual(d.dtype, ht.float32)
         self.assertEqual(d.lshape, (3, 1, 1))
@@ -169,7 +174,7 @@ class TestFactories(unittest.TestCase):
 
         # basic array function, unsplit data, additional dimensions
         vector_data = [4.0, 5.0, 6.0]
-        d = ht.array(vector_data, ndmin=-3)
+        d = ht.array(vector_data, ndmin=-3, device=ht_device)
         self.assertIsInstance(d, ht.DNDarray)
         self.assertEqual(d.dtype, ht.float32)
         self.assertEqual(d.lshape, (1, 1, 3))
@@ -180,7 +185,9 @@ class TestFactories(unittest.TestCase):
         )
 
         # distributed array, chunk local data (split)
-        tensor_2d = ht.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0]], split=0)
+        tensor_2d = ht.array(
+            [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0]], split=0, device=ht_device
+        )
         self.assertIsInstance(tensor_2d, ht.DNDarray)
         self.assertEqual(tensor_2d.dtype, ht.float32)
         self.assertEqual(tensor_2d.gshape, (3, 3))
@@ -197,7 +204,7 @@ class TestFactories(unittest.TestCase):
             split_data = [[4.0, 5.0, 6.0], [1.0, 2.0, 3.0], [0.0, 0.0, 0.0]]
         else:
             split_data = [[4.0, 5.0, 6.0], [1.0, 2.0, 3.0]]
-        e = ht.array(split_data, ndmin=3, is_split=0)
+        e = ht.array(split_data, ndmin=3, is_split=0, device=ht_device)
 
         self.assertIsInstance(e, ht.DNDarray)
         self.assertEqual(e.dtype, ht.float32)
@@ -221,7 +228,7 @@ class TestFactories(unittest.TestCase):
 
             # this will fail as the shapes do not match
             with self.assertRaises(ValueError):
-                ht.array(split_data, is_split=0)
+                ht.array(split_data, is_split=0, device=ht_device)
 
         # exception distributed shapes do not fit
         if ht.communication.MPI_WORLD.size > 1:
@@ -232,13 +239,13 @@ class TestFactories(unittest.TestCase):
 
             # this will fail as the shapes do not match on a specific axis (here: 0)
             with self.assertRaises(ValueError):
-                ht.array(split_data, is_split=1)
+                ht.array(split_data, is_split=1, device=ht_device)
 
         # check exception on mutually exclusive split and is_split
         with self.assertRaises(ValueError):
-            ht.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]], split=0, is_split=0)
+            ht.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]], split=0, is_split=0, device=ht_device)
 
-        e = ht.array(split_data, ndmin=-3, is_split=1)
+        e = ht.array(split_data, ndmin=-3, is_split=1, device=ht_device)
 
         self.assertIsInstance(e, ht.DNDarray)
         self.assertEqual(e.dtype, ht.float32)
@@ -262,7 +269,7 @@ class TestFactories(unittest.TestCase):
 
             # this will fail as the shapes do not match
             with self.assertRaises(ValueError):
-                ht.array(split_data, is_split=0)
+                ht.array(split_data, is_split=0, device=ht_device)
 
         # exception distributed shapes do not fit
         if ht.communication.MPI_WORLD.size > 1:
@@ -273,37 +280,37 @@ class TestFactories(unittest.TestCase):
 
             # this will fail as the shapes do not match on a specific axis (here: 0)
             with self.assertRaises(ValueError):
-                ht.array(split_data, is_split=1)
+                ht.array(split_data, is_split=1, device=ht_device)
 
         # check exception on mutually exclusive split and is_split
         with self.assertRaises(ValueError):
-            ht.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]], split=1, is_split=1)
+            ht.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]], split=1, is_split=1, device=ht_device)
 
         # non iterable type
         with self.assertRaises(TypeError):
-            ht.array(map)
+            ht.array(map, device=ht_device)
         # iterable, but unsuitable type
         with self.assertRaises(TypeError):
-            ht.array("abc")
+            ht.array("abc", device=ht_device)
         # unknown dtype
         with self.assertRaises(TypeError):
-            ht.array((4,), dtype="a")
+            ht.array((4,), dtype="a", device=ht_device)
         # invalid ndmin
         with self.assertRaises(TypeError):
-            ht.array((4,), ndmin=3.0)
+            ht.array((4,), ndmin=3.0, device=ht_device)
         # invalid split axis type
         with self.assertRaises(TypeError):
-            ht.array((4,), split="a")
+            ht.array((4,), split="a", device=ht_device)
         # invalid split axis value
         with self.assertRaises(ValueError):
-            ht.array((4,), split=3)
+            ht.array((4,), split=3, device=ht_device)
         # invalid communicator
         with self.assertRaises(TypeError):
-            ht.array((4,), comm={})
+            ht.array((4,), comm={}, device=ht_device)
 
     def test_empty(self):
         # scalar input
-        simple_empty_float = ht.empty(3)
+        simple_empty_float = ht.empty(3, device=ht_device)
         self.assertIsInstance(simple_empty_float, ht.DNDarray)
         self.assertEqual(simple_empty_float.shape, (3,))
         self.assertEqual(simple_empty_float.lshape, (3,))
@@ -311,7 +318,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(simple_empty_float.dtype, ht.float32)
 
         # different data type
-        simple_empty_uint = ht.empty(5, dtype=ht.bool)
+        simple_empty_uint = ht.empty(5, dtype=ht.bool, device=ht_device)
         self.assertIsInstance(simple_empty_uint, ht.DNDarray)
         self.assertEqual(simple_empty_uint.shape, (5,))
         self.assertEqual(simple_empty_uint.lshape, (5,))
@@ -319,7 +326,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(simple_empty_uint.dtype, ht.bool)
 
         # multi-dimensional
-        elaborate_empty_int = ht.empty((2, 3), dtype=ht.int32)
+        elaborate_empty_int = ht.empty((2, 3), dtype=ht.int32, device=ht_device)
         self.assertIsInstance(elaborate_empty_int, ht.DNDarray)
         self.assertEqual(elaborate_empty_int.shape, (2, 3))
         self.assertEqual(elaborate_empty_int.lshape, (2, 3))
@@ -327,7 +334,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(elaborate_empty_int.dtype, ht.int32)
 
         # split axis
-        elaborate_empty_split = ht.empty((6, 4), dtype=ht.int32, split=0)
+        elaborate_empty_split = ht.empty((6, 4), dtype=ht.int32, split=0, device=ht_device)
         self.assertIsInstance(elaborate_empty_split, ht.DNDarray)
         self.assertEqual(elaborate_empty_split.shape, (6, 4))
         self.assertLessEqual(elaborate_empty_split.lshape[0], 6)
@@ -337,15 +344,15 @@ class TestFactories(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(TypeError):
-            ht.empty("(2, 3,)", dtype=ht.float64)
+            ht.empty("(2, 3,)", dtype=ht.float64, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.empty((-1, 3), dtype=ht.float64)
+            ht.empty((-1, 3), dtype=ht.float64, device=ht_device)
         with self.assertRaises(TypeError):
-            ht.empty((2, 3), dtype=ht.float64, split="axis")
+            ht.empty((2, 3), dtype=ht.float64, split="axis", device=ht_device)
 
     def test_empty_like(self):
         # scalar
-        like_int = ht.empty_like(3)
+        like_int = ht.empty_like(3, device=ht_device)
         self.assertIsInstance(like_int, ht.DNDarray)
         self.assertEqual(like_int.shape, (1,))
         self.assertEqual(like_int.lshape, (1,))
@@ -353,7 +360,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(like_int.dtype, ht.int32)
 
         # sequence
-        like_str = ht.empty_like("abc")
+        like_str = ht.empty_like("abc", device=ht_device)
         self.assertIsInstance(like_str, ht.DNDarray)
         self.assertEqual(like_str.shape, (3,))
         self.assertEqual(like_str.lshape, (3,))
@@ -361,8 +368,8 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(like_str.dtype, ht.float32)
 
         # elaborate tensor
-        ones = ht.ones((2, 3), dtype=ht.uint8)
-        like_ones = ht.empty_like(ones)
+        ones = ht.ones((2, 3), dtype=ht.uint8, device=ht_device)
+        like_ones = ht.empty_like(ones, device=ht_device)
         self.assertIsInstance(like_ones, ht.DNDarray)
         self.assertEqual(like_ones.shape, (2, 3))
         self.assertEqual(like_ones.lshape, (2, 3))
@@ -370,8 +377,8 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(like_ones.dtype, ht.uint8)
 
         # elaborate tensor with split
-        ones_split = ht.ones((2, 3), dtype=ht.uint8, split=0)
-        like_ones_split = ht.empty_like(ones_split)
+        ones_split = ht.ones((2, 3), dtype=ht.uint8, split=0, device=ht_device)
+        like_ones_split = ht.empty_like(ones_split, device=ht_device)
         self.assertIsInstance(like_ones_split, ht.DNDarray)
         self.assertEqual(like_ones_split.shape, (2, 3))
         self.assertLessEqual(like_ones_split.lshape[0], 2)
@@ -381,9 +388,9 @@ class TestFactories(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(TypeError):
-            ht.empty_like(ones, dtype="abc")
+            ht.empty_like(ones, dtype="abc", device=ht_device)
         with self.assertRaises(TypeError):
-            ht.empty_like(ones, split="axis")
+            ht.empty_like(ones, split="axis", device=ht_device)
 
     def test_eye(self):
         def get_offset(tensor_array):
@@ -395,7 +402,7 @@ class TestFactories(unittest.TestCase):
             return x, y
 
         shape = 5
-        eye = ht.eye(shape, dtype=ht.uint8, split=1)
+        eye = ht.eye(shape, dtype=ht.uint8, split=1, device=ht_device)
         self.assertIsInstance(eye, ht.DNDarray)
         self.assertEqual(eye.dtype, ht.uint8)
         self.assertEqual(eye.shape, (shape, shape))
@@ -411,7 +418,7 @@ class TestFactories(unittest.TestCase):
                 self.assertEqual(eye._DNDarray__array[i][j], expected)
 
         shape = (10, 20)
-        eye = ht.eye(shape, dtype=ht.float32)
+        eye = ht.eye(shape, dtype=ht.float32, device=ht_device)
         self.assertIsInstance(eye, ht.DNDarray)
         self.assertEqual(eye.dtype, ht.float32)
         self.assertEqual(eye.shape, shape)
@@ -427,7 +434,7 @@ class TestFactories(unittest.TestCase):
                 self.assertEqual(eye._DNDarray__array[i][j], expected)
 
         shape = (10,)
-        eye = ht.eye(shape, dtype=ht.int32, split=0)
+        eye = ht.eye(shape, dtype=ht.int32, split=0, device=ht_device)
         self.assertIsInstance(eye, ht.DNDarray)
         self.assertEqual(eye.dtype, ht.int32)
         self.assertEqual(eye.shape, shape * 2)
@@ -444,27 +451,27 @@ class TestFactories(unittest.TestCase):
 
     def test_full(self):
         # simple tensor
-        data = ht.full((10, 2), 4)
+        data = ht.full((10, 2), 4, device=ht_device)
         self.assertIsInstance(data, ht.DNDarray)
         self.assertEqual(data.shape, (10, 2))
         self.assertEqual(data.lshape, (10, 2))
         self.assertEqual(data.dtype, ht.float32)
         self.assertEqual(data._DNDarray__array.dtype, torch.float32)
         self.assertEqual(data.split, None)
-        self.assertTrue(ht.allclose(data, ht.float32(4.0)))
+        self.assertTrue(ht.allclose(data, ht.float32(4.0, device=ht_device)))
 
         # non-standard dtype tensor
-        data = ht.full((10, 2), 4, dtype=ht.int32)
+        data = ht.full((10, 2), 4, dtype=ht.int32, device=ht_device)
         self.assertIsInstance(data, ht.DNDarray)
         self.assertEqual(data.shape, (10, 2))
         self.assertEqual(data.lshape, (10, 2))
         self.assertEqual(data.dtype, ht.int32)
         self.assertEqual(data._DNDarray__array.dtype, torch.int32)
         self.assertEqual(data.split, None)
-        self.assertTrue(ht.allclose(data, ht.int32(4)))
+        self.assertTrue(ht.allclose(data, ht.int32(4, device=ht_device)))
 
         # split tensor
-        data = ht.full((10, 2), 4, split=0)
+        data = ht.full((10, 2), 4, split=0, device=ht_device)
         self.assertIsInstance(data, ht.DNDarray)
         self.assertEqual(data.shape, (10, 2))
         self.assertLessEqual(data.lshape[0], 10)
@@ -472,15 +479,15 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(data.dtype, ht.float32)
         self.assertEqual(data._DNDarray__array.dtype, torch.float32)
         self.assertEqual(data.split, 0)
-        self.assertTrue(ht.allclose(data, ht.float32(4.0)))
+        self.assertTrue(ht.allclose(data, ht.float32(4.0, device=ht_device)))
 
         # exceptions
         with self.assertRaises(TypeError):
-            ht.full("(2, 3,)", 4, dtype=ht.float64)
+            ht.full("(2, 3,)", 4, dtype=ht.float64, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.full((-1, 3), 2, dtype=ht.float64)
+            ht.full((-1, 3), 2, dtype=ht.float64, device=ht_device)
         with self.assertRaises(TypeError):
-            ht.full((2, 3), dtype=ht.float64, split="axis")
+            ht.full((2, 3), dtype=ht.float64, split="axis", device=ht_device)
 
     def test_full_like(self):
         # scalar
@@ -490,7 +497,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(like_int.lshape, (1,))
         self.assertEqual(like_int.split, None)
         self.assertEqual(like_int.dtype, ht.float32)
-        self.assertTrue(ht.allclose(like_int, ht.float32(4)))
+        self.assertTrue(ht.allclose(like_int, ht.float32(4, device=ht_device)))
 
         # sequence
         like_str = ht.full_like("abc", 2)
@@ -499,20 +506,20 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(like_str.lshape, (3,))
         self.assertEqual(like_str.split, None)
         self.assertEqual(like_str.dtype, ht.float32)
-        self.assertTrue(ht.allclose(like_str, ht.float32(2)))
+        self.assertTrue(ht.allclose(like_str, ht.float32(2, device=ht_device)))
 
         # elaborate tensor
-        zeros = ht.zeros((2, 3), dtype=ht.uint8)
+        zeros = ht.zeros((2, 3), dtype=ht.uint8, device=ht_device)
         like_zeros = ht.full_like(zeros, 7)
         self.assertIsInstance(like_zeros, ht.DNDarray)
         self.assertEqual(like_zeros.shape, (2, 3))
         self.assertEqual(like_zeros.lshape, (2, 3))
         self.assertEqual(like_zeros.split, None)
         self.assertEqual(like_zeros.dtype, ht.float32)
-        self.assertTrue(ht.allclose(like_zeros, ht.float32(7)))
+        self.assertTrue(ht.allclose(like_zeros, ht.float32(7, device=ht_device)))
 
         # elaborate tensor with split
-        zeros_split = ht.zeros((2, 3), dtype=ht.uint8, split=0)
+        zeros_split = ht.zeros((2, 3), dtype=ht.uint8, split=0, device=ht_device)
         like_zeros_split = ht.full_like(zeros_split, 6)
         self.assertIsInstance(like_zeros_split, ht.DNDarray)
         self.assertEqual(like_zeros_split.shape, (2, 3))
@@ -520,17 +527,17 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(like_zeros_split.lshape[1], 3)
         self.assertEqual(like_zeros_split.split, 0)
         self.assertEqual(like_zeros_split.dtype, ht.float32)
-        self.assertTrue(ht.allclose(like_zeros_split, ht.float32(6)))
+        self.assertTrue(ht.allclose(like_zeros_split, ht.float32(6, device=ht_device)))
 
         # exceptions
         with self.assertRaises(TypeError):
-            ht.ones_like(zeros, dtype="abc")
+            ht.ones_like(zeros, dtype="abc", device=ht_device)
         with self.assertRaises(TypeError):
-            ht.ones_like(zeros, split="axis")
+            ht.ones_like(zeros, split="axis", device=ht_device)
 
     def test_linspace(self):
         # simple linear space
-        ascending = ht.linspace(-3, 5)
+        ascending = ht.linspace(-3, 5, device=ht_device)
         self.assertIsInstance(ascending, ht.DNDarray)
         self.assertEqual(ascending.shape, (50,))
         self.assertLessEqual(ascending.lshape[0], 50)
@@ -539,7 +546,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(ascending.split, None)
 
         # simple inverse linear space
-        descending = ht.linspace(-5, 3, num=100)
+        descending = ht.linspace(-5, 3, num=100, device=ht_device)
         self.assertIsInstance(descending, ht.DNDarray)
         self.assertEqual(descending.shape, (100,))
         self.assertLessEqual(descending.lshape[0], 100)
@@ -548,7 +555,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(descending.split, None)
 
         # split linear space
-        split = ht.linspace(-5, 3, num=70, split=0)
+        split = ht.linspace(-5, 3, num=70, split=0, device=ht_device)
         self.assertIsInstance(split, ht.DNDarray)
         self.assertEqual(split.shape, (70,))
         self.assertLessEqual(split.lshape[0], 70)
@@ -557,7 +564,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(split.split, 0)
 
         # with casted type
-        casted = ht.linspace(-5, 3, num=70, dtype=ht.uint8, split=0)
+        casted = ht.linspace(-5, 3, num=70, dtype=ht.uint8, split=0, device=ht_device)
         self.assertIsInstance(casted, ht.DNDarray)
         self.assertEqual(casted.shape, (70,))
         self.assertLessEqual(casted.lshape[0], 70)
@@ -566,7 +573,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(casted.split, 0)
 
         # retstep test
-        result = ht.linspace(-5, 3, num=70, retstep=True, dtype=ht.uint8, split=0)
+        result = ht.linspace(-5, 3, num=70, retstep=True, dtype=ht.uint8, split=0, device=ht_device)
         self.assertIsInstance(result, tuple)
         self.assertEqual(len(result), 2)
 
@@ -582,15 +589,15 @@ class TestFactories(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(ValueError):
-            ht.linspace(-5, 3, split=1)
+            ht.linspace(-5, 3, split=1, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.linspace(-5, 3, num=-1)
+            ht.linspace(-5, 3, num=-1, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.linspace(-5, 3, num=0)
+            ht.linspace(-5, 3, num=0, device=ht_device)
 
     def test_logspace(self):
         # simple log space
-        ascending = ht.logspace(-3, 5)
+        ascending = ht.logspace(-3, 5, device=ht_device)
         self.assertIsInstance(ascending, ht.DNDarray)
         self.assertEqual(ascending.shape, (50,))
         self.assertLessEqual(ascending.lshape[0], 50)
@@ -599,7 +606,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(ascending.split, None)
 
         # simple inverse log space
-        descending = ht.logspace(-5, 3, num=100)
+        descending = ht.logspace(-5, 3, num=100, device=ht_device)
         self.assertIsInstance(descending, ht.DNDarray)
         self.assertEqual(descending.shape, (100,))
         self.assertLessEqual(descending.lshape[0], 100)
@@ -608,7 +615,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(descending.split, None)
 
         # split log space
-        split = ht.logspace(-5, 3, num=70, split=0)
+        split = ht.logspace(-5, 3, num=70, split=0, device=ht_device)
         self.assertIsInstance(split, ht.DNDarray)
         self.assertEqual(split.shape, (70,))
         self.assertLessEqual(split.lshape[0], 70)
@@ -617,7 +624,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(split.split, 0)
 
         # with casted type
-        casted = ht.logspace(-5, 3, num=70, dtype=ht.uint8, split=0)
+        casted = ht.logspace(-5, 3, num=70, dtype=ht.uint8, split=0, device=ht_device)
         self.assertIsInstance(casted, ht.DNDarray)
         self.assertEqual(casted.shape, (70,))
         self.assertLessEqual(casted.lshape[0], 70)
@@ -626,7 +633,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(casted.split, 0)
 
         # base test
-        base = ht.logspace(-5, 3, num=70, base=2.0)
+        base = ht.logspace(-5, 3, num=70, base=2.0, device=ht_device)
         self.assertIsInstance(base, ht.DNDarray)
         self.assertEqual(base.shape, (70,))
         self.assertLessEqual(base.lshape[0], 70)
@@ -636,15 +643,15 @@ class TestFactories(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(ValueError):
-            ht.logspace(-5, 3, split=1)
+            ht.logspace(-5, 3, split=1, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.logspace(-5, 3, num=-1)
+            ht.logspace(-5, 3, num=-1, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.logspace(-5, 3, num=0)
+            ht.logspace(-5, 3, num=0, device=ht_device)
 
     def test_ones(self):
         # scalar input
-        simple_ones_float = ht.ones(3)
+        simple_ones_float = ht.ones(3, device=ht_device)
         self.assertIsInstance(simple_ones_float, ht.DNDarray)
         self.assertEqual(simple_ones_float.shape, (3,))
         self.assertEqual(simple_ones_float.lshape, (3,))
@@ -653,7 +660,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((simple_ones_float._DNDarray__array == 1).all().item(), 1)
 
         # different data type
-        simple_ones_uint = ht.ones(5, dtype=ht.bool)
+        simple_ones_uint = ht.ones(5, dtype=ht.bool, device=ht_device)
         self.assertIsInstance(simple_ones_uint, ht.DNDarray)
         self.assertEqual(simple_ones_uint.shape, (5,))
         self.assertEqual(simple_ones_uint.lshape, (5,))
@@ -662,7 +669,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((simple_ones_uint._DNDarray__array == 1).all().item(), 1)
 
         # multi-dimensional
-        elaborate_ones_int = ht.ones((2, 3), dtype=ht.int32)
+        elaborate_ones_int = ht.ones((2, 3), dtype=ht.int32, device=ht_device)
         self.assertIsInstance(elaborate_ones_int, ht.DNDarray)
         self.assertEqual(elaborate_ones_int.shape, (2, 3))
         self.assertEqual(elaborate_ones_int.lshape, (2, 3))
@@ -671,7 +678,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((elaborate_ones_int._DNDarray__array == 1).all().item(), 1)
 
         # split axis
-        elaborate_ones_split = ht.ones((6, 4), dtype=ht.int32, split=0)
+        elaborate_ones_split = ht.ones((6, 4), dtype=ht.int32, split=0, device=ht_device)
         self.assertIsInstance(elaborate_ones_split, ht.DNDarray)
         self.assertEqual(elaborate_ones_split.shape, (6, 4))
         self.assertLessEqual(elaborate_ones_split.lshape[0], 6)
@@ -682,15 +689,15 @@ class TestFactories(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(TypeError):
-            ht.ones("(2, 3,)", dtype=ht.float64)
+            ht.ones("(2, 3,)", dtype=ht.float64, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.ones((-1, 3), dtype=ht.float64)
+            ht.ones((-1, 3), dtype=ht.float64, device=ht_device)
         with self.assertRaises(TypeError):
-            ht.ones((2, 3), dtype=ht.float64, split="axis")
+            ht.ones((2, 3), dtype=ht.float64, split="axis", device=ht_device)
 
     def test_ones_like(self):
         # scalar
-        like_int = ht.ones_like(3)
+        like_int = ht.ones_like(3, device=ht_device)
         self.assertIsInstance(like_int, ht.DNDarray)
         self.assertEqual(like_int.shape, (1,))
         self.assertEqual(like_int.lshape, (1,))
@@ -699,7 +706,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((like_int._DNDarray__array == 1).all().item(), 1)
 
         # sequence
-        like_str = ht.ones_like("abc")
+        like_str = ht.ones_like("abc", device=ht_device)
         self.assertIsInstance(like_str, ht.DNDarray)
         self.assertEqual(like_str.shape, (3,))
         self.assertEqual(like_str.lshape, (3,))
@@ -708,8 +715,8 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((like_str._DNDarray__array == 1).all().item(), 1)
 
         # elaborate tensor
-        zeros = ht.zeros((2, 3), dtype=ht.uint8)
-        like_zeros = ht.ones_like(zeros)
+        zeros = ht.zeros((2, 3), dtype=ht.uint8, device=ht_device)
+        like_zeros = ht.ones_like(zeros, device=ht_device)
         self.assertIsInstance(like_zeros, ht.DNDarray)
         self.assertEqual(like_zeros.shape, (2, 3))
         self.assertEqual(like_zeros.lshape, (2, 3))
@@ -718,8 +725,8 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((like_zeros._DNDarray__array == 1).all().item(), 1)
 
         # elaborate tensor with split
-        zeros_split = ht.zeros((2, 3), dtype=ht.uint8, split=0)
-        like_zeros_split = ht.ones_like(zeros_split)
+        zeros_split = ht.zeros((2, 3), dtype=ht.uint8, split=0, device=ht_device)
+        like_zeros_split = ht.ones_like(zeros_split, device=ht_device)
         self.assertIsInstance(like_zeros_split, ht.DNDarray)
         self.assertEqual(like_zeros_split.shape, (2, 3))
         self.assertLessEqual(like_zeros_split.lshape[0], 2)
@@ -730,13 +737,13 @@ class TestFactories(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(TypeError):
-            ht.ones_like(zeros, dtype="abc")
+            ht.ones_like(zeros, dtype="abc", device=ht_device)
         with self.assertRaises(TypeError):
-            ht.ones_like(zeros, split="axis")
+            ht.ones_like(zeros, split="axis", device=ht_device)
 
     def test_zeros(self):
         # scalar input
-        simple_zeros_float = ht.zeros(3)
+        simple_zeros_float = ht.zeros(3, device=ht_device)
         self.assertIsInstance(simple_zeros_float, ht.DNDarray)
         self.assertEqual(simple_zeros_float.shape, (3,))
         self.assertEqual(simple_zeros_float.lshape, (3,))
@@ -745,7 +752,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((simple_zeros_float._DNDarray__array == 0).all().item(), 1)
 
         # different data type
-        simple_zeros_uint = ht.zeros(5, dtype=ht.bool)
+        simple_zeros_uint = ht.zeros(5, dtype=ht.bool, device=ht_device)
         self.assertIsInstance(simple_zeros_uint, ht.DNDarray)
         self.assertEqual(simple_zeros_uint.shape, (5,))
         self.assertEqual(simple_zeros_uint.lshape, (5,))
@@ -754,7 +761,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((simple_zeros_uint._DNDarray__array == 0).all().item(), 1)
 
         # multi-dimensional
-        elaborate_zeros_int = ht.zeros((2, 3), dtype=ht.int32)
+        elaborate_zeros_int = ht.zeros((2, 3), dtype=ht.int32, device=ht_device)
         self.assertIsInstance(elaborate_zeros_int, ht.DNDarray)
         self.assertEqual(elaborate_zeros_int.shape, (2, 3))
         self.assertEqual(elaborate_zeros_int.lshape, (2, 3))
@@ -763,7 +770,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((elaborate_zeros_int._DNDarray__array == 0).all().item(), 1)
 
         # split axis
-        elaborate_zeros_split = ht.zeros((6, 4), dtype=ht.int32, split=0)
+        elaborate_zeros_split = ht.zeros((6, 4), dtype=ht.int32, split=0, device=ht_device)
         self.assertIsInstance(elaborate_zeros_split, ht.DNDarray)
         self.assertEqual(elaborate_zeros_split.shape, (6, 4))
         self.assertLessEqual(elaborate_zeros_split.lshape[0], 6)
@@ -774,15 +781,15 @@ class TestFactories(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(TypeError):
-            ht.zeros("(2, 3,)", dtype=ht.float64)
+            ht.zeros("(2, 3,)", dtype=ht.float64, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.zeros((-1, 3), dtype=ht.float64)
+            ht.zeros((-1, 3), dtype=ht.float64, device=ht_device)
         with self.assertRaises(TypeError):
-            ht.zeros((2, 3), dtype=ht.float64, split="axis")
+            ht.zeros((2, 3), dtype=ht.float64, split="axis", device=ht_device)
 
     def test_zeros_like(self):
         # scalar
-        like_int = ht.zeros_like(3)
+        like_int = ht.zeros_like(3, device=ht_device)
         self.assertIsInstance(like_int, ht.DNDarray)
         self.assertEqual(like_int.shape, (1,))
         self.assertEqual(like_int.lshape, (1,))
@@ -791,7 +798,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((like_int._DNDarray__array == 0).all().item(), 1)
 
         # sequence
-        like_str = ht.zeros_like("abc")
+        like_str = ht.zeros_like("abc", device=ht_device)
         self.assertIsInstance(like_str, ht.DNDarray)
         self.assertEqual(like_str.shape, (3,))
         self.assertEqual(like_str.lshape, (3,))
@@ -800,8 +807,8 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((like_str._DNDarray__array == 0).all().item(), 1)
 
         # elaborate tensor
-        ones = ht.ones((2, 3), dtype=ht.uint8)
-        like_ones = ht.zeros_like(ones)
+        ones = ht.ones((2, 3), dtype=ht.uint8, device=ht_device)
+        like_ones = ht.zeros_like(ones, device=ht_device)
         self.assertIsInstance(like_ones, ht.DNDarray)
         self.assertEqual(like_ones.shape, (2, 3))
         self.assertEqual(like_ones.lshape, (2, 3))
@@ -810,8 +817,8 @@ class TestFactories(unittest.TestCase):
         self.assertEqual((like_ones._DNDarray__array == 0).all().item(), 1)
 
         # elaborate tensor with split
-        ones_split = ht.ones((2, 3), dtype=ht.uint8, split=0)
-        like_ones_split = ht.zeros_like(ones_split)
+        ones_split = ht.ones((2, 3), dtype=ht.uint8, split=0, device=ht_device)
+        like_ones_split = ht.zeros_like(ones_split, device=ht_device)
         self.assertIsInstance(like_ones_split, ht.DNDarray)
         self.assertEqual(like_ones_split.shape, (2, 3))
         self.assertLessEqual(like_ones_split.lshape[0], 2)
@@ -822,6 +829,6 @@ class TestFactories(unittest.TestCase):
 
         # exceptions
         with self.assertRaises(TypeError):
-            ht.zeros_like(ones, dtype="abc")
+            ht.zeros_like(ones, dtype="abc", device=ht_device)
         with self.assertRaises(TypeError):
-            ht.zeros_like(ones, split="axis")
+            ht.zeros_like(ones, split="axis", device=ht_device)

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -4,11 +4,11 @@ import os
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestFactories(unittest.TestCase):

--- a/heat/core/tests/test_indexing.py
+++ b/heat/core/tests/test_indexing.py
@@ -1,6 +1,14 @@
 import unittest
-
+import os
 import heat as ht
+import torch
+
+if os.environ.get("DEVICE") == "gpu":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+else:
+    device = torch.device("cpu")
+    ht.use_device("cpu")
 
 
 class TestIndexing(unittest.TestCase):

--- a/heat/core/tests/test_indexing.py
+++ b/heat/core/tests/test_indexing.py
@@ -3,19 +3,24 @@ import os
 import heat as ht
 import torch
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestIndexing(unittest.TestCase):
     def test_nonzero(self):
         # cases to test:
         # not split
-        a = ht.array([[1, 2, 3], [4, 5, 2], [7, 8, 9]], split=None)
+        a = ht.array([[1, 2, 3], [4, 5, 2], [7, 8, 9]], split=None, device=ht_device)
         cond = a > 3
         nz = ht.nonzero(cond)
         self.assertEqual(nz.gshape, (5, 2))
@@ -23,7 +28,7 @@ class TestIndexing(unittest.TestCase):
         self.assertEqual(nz.split, None)
 
         # split
-        a = ht.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], split=1)
+        a = ht.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], split=1, device=ht_device)
         cond = a > 3
         nz = cond.nonzero()
         self.assertEqual(nz.gshape, (6, 2))
@@ -35,14 +40,14 @@ class TestIndexing(unittest.TestCase):
     def test_where(self):
         # cases to test
         # no x and y
-        a = ht.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], split=None)
+        a = ht.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], split=None, device=ht_device)
         cond = a > 3
         wh = ht.where(cond)
         self.assertEqual(wh.gshape, (6, 2))
         self.assertEqual(wh.dtype, ht.int64)
         self.assertEqual(wh.split, None)
         # split
-        a = ht.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], split=1)
+        a = ht.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], split=1, device=ht_device)
         cond = a > 3
         wh = ht.where(cond)
         self.assertEqual(wh.gshape, (6, 2))
@@ -50,28 +55,40 @@ class TestIndexing(unittest.TestCase):
         self.assertEqual(wh.split, 0)
 
         # not split cond
-        a = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, 4.0], [0.0, 3.0, 6.0]], split=None)
-        res = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=None)
+        a = ht.array(
+            [[0.0, 1.0, 2.0], [0.0, 2.0, 4.0], [0.0, 3.0, 6.0]], split=None, device=ht_device
+        )
+        res = ht.array(
+            [[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=None, device=ht_device
+        )
         wh = ht.where(a < 4.0, a, -1.0)
         self.assertTrue(
-            ht.equal(a[ht.nonzero(a < 4)], ht.array([0.0, 1.0, 2.0, 0.0, 2.0, 0.0, 3.0]))
+            ht.equal(
+                a[ht.nonzero(a < 4)],
+                ht.array([0.0, 1.0, 2.0, 0.0, 2.0, 0.0, 3.0], device=ht_device),
+            )
         )
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))
         self.assertEqual(wh.dtype, ht.float)
 
         # split cond
-        a = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, 4.0], [0.0, 3.0, 6.0]], split=0)
-        res = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=0)
+        a = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, 4.0], [0.0, 3.0, 6.0]], split=0, device=ht_device)
+        res = ht.array(
+            [[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=0, device=ht_device
+        )
         wh = ht.where(a < 4.0, a, -1)
+        print(wh._DNDarray__array.dtype)
         self.assertTrue(ht.all(wh[ht.nonzero(a >= 4)], -1))
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))
         self.assertEqual(wh.dtype, ht.float)
         self.assertEqual(wh.split, 0)
 
-        a = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, 4.0], [0.0, 3.0, 6.0]], split=1)
-        res = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=1)
+        a = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, 4.0], [0.0, 3.0, 6.0]], split=1, device=ht_device)
+        res = ht.array(
+            [[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=1, device=ht_device
+        )
         wh = ht.where(a < 4.0, a, -1)
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))
@@ -82,4 +99,8 @@ class TestIndexing(unittest.TestCase):
             ht.where(cond, a)
 
         with self.assertRaises(NotImplementedError):
-            ht.where(cond, ht.ones((3, 3), split=0), ht.ones((3, 3), split=1))
+            ht.where(
+                cond,
+                ht.ones((3, 3), split=0, device=ht_device),
+                ht.ones((3, 3), split=1, device=ht_device),
+            )

--- a/heat/core/tests/test_indexing.py
+++ b/heat/core/tests/test_indexing.py
@@ -4,11 +4,11 @@ import heat as ht
 import torch
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestIndexing(unittest.TestCase):

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -6,12 +6,17 @@ import unittest
 
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestIO(unittest.TestCase):
@@ -53,7 +58,7 @@ class TestIO(unittest.TestCase):
     def test_load(self):
         # HDF5
         if ht.io.supports_hdf5():
-            iris = ht.load(self.HDF5_PATH, dataset="data")
+            iris = ht.load(self.HDF5_PATH, dataset="data", device=ht_device)
             self.assertIsInstance(iris, ht.DNDarray)
             # shape invariant
             self.assertEqual(iris.shape, self.IRIS.shape)
@@ -65,11 +70,11 @@ class TestIO(unittest.TestCase):
             self.assertTrue((self.IRIS == iris._DNDarray__array).all())
         else:
             with self.assertRaises(ValueError):
-                _ = ht.load(self.HDF5_PATH, dataset=self.HDF5_DATASET)
+                _ = ht.load(self.HDF5_PATH, dataset=self.HDF5_DATASET, device=ht_device)
 
         # netCDF
         if ht.io.supports_netcdf():
-            iris = ht.load(self.NETCDF_PATH, variable=self.NETCDF_VARIABLE)
+            iris = ht.load(self.NETCDF_PATH, variable=self.NETCDF_VARIABLE, device=ht_device)
             self.assertIsInstance(iris, ht.DNDarray)
             # shape invariant
             self.assertEqual(iris.shape, self.IRIS.shape)
@@ -81,7 +86,7 @@ class TestIO(unittest.TestCase):
             self.assertTrue((self.IRIS == iris._DNDarray__array).all())
         else:
             with self.assertRaises(ValueError):
-                _ = ht.load(self.NETCDF_PATH, variable=self.NETCDF_VARIABLE)
+                _ = ht.load(self.NETCDF_PATH, variable=self.NETCDF_VARIABLE, device=ht_device)
 
     def test_load_csv(self):
         csv_file_length = 150
@@ -89,13 +94,13 @@ class TestIO(unittest.TestCase):
         first_value = torch.tensor([5.1, 3.5, 1.4, 0.2], dtype=torch.float32, device=device)
         tenth_value = torch.tensor([4.9, 3.1, 1.5, 0.1], dtype=torch.float32, device=device)
 
-        a = ht.load_csv(self.CSV_PATH, sep=";")
+        a = ht.load_csv(self.CSV_PATH, sep=";", device=ht_device)
         self.assertEqual(len(a), csv_file_length)
         self.assertEqual(a.shape, (csv_file_length, csv_file_cols))
         self.assertTrue(torch.equal(a._DNDarray__array[0], first_value))
         self.assertTrue(torch.equal(a._DNDarray__array[9], tenth_value))
 
-        a = ht.load_csv(self.CSV_PATH, sep=";", split=0)
+        a = ht.load_csv(self.CSV_PATH, sep=";", split=0, device=ht_device)
         rank = a.comm.Get_rank()
         expected_gshape = (csv_file_length, csv_file_cols)
         self.assertEqual(a.gshape, expected_gshape)
@@ -107,7 +112,9 @@ class TestIO(unittest.TestCase):
         if rank == 0:
             self.assertTrue(torch.equal(a._DNDarray__array[0], first_value))
 
-        a = ht.load_csv(self.CSV_PATH, sep=";", header_lines=9, dtype=ht.float32, split=0)
+        a = ht.load_csv(
+            self.CSV_PATH, sep=";", header_lines=9, dtype=ht.float32, split=0, device=ht_device
+        )
         expected_gshape = (csv_file_length - 9, csv_file_cols)
         counts, _, _ = a.comm.counts_displs_shape(expected_gshape, 0)
         expected_lshape = (counts[rank], csv_file_cols)
@@ -118,52 +125,54 @@ class TestIO(unittest.TestCase):
         if rank == 0:
             self.assertTrue(torch.equal(a._DNDarray__array[0], tenth_value))
 
-        a = ht.load_csv(self.CSV_PATH, sep=";", split=1)
+        a = ht.load_csv(self.CSV_PATH, sep=";", split=1, device=ht_device)
         self.assertEqual(a.shape, (csv_file_length, csv_file_cols))
         self.assertEqual(a.lshape[0], csv_file_length)
 
-        a = ht.load_csv(self.CSV_PATH, sep=";", split=0)
-        b = ht.load(self.CSV_PATH, sep=";", split=0)
+        a = ht.load_csv(self.CSV_PATH, sep=";", split=0, device=ht_device)
+        b = ht.load(self.CSV_PATH, sep=";", split=0, device=ht_device)
         self.assertTrue(ht.equal(a, b))
 
         # Test for csv where header is longer then the first process`s share of lines
-        a = ht.load_csv(self.CSV_PATH, sep=";", header_lines=100, split=0)
+        a = ht.load_csv(self.CSV_PATH, sep=";", header_lines=100, split=0, device=ht_device)
         self.assertEqual(a.shape, (50, 4))
 
         with self.assertRaises(TypeError):
-            ht.load_csv(12314)
+            ht.load_csv(12314, device=ht_device)
         with self.assertRaises(TypeError):
-            ht.load_csv(self.CSV_PATH, sep=11)
+            ht.load_csv(self.CSV_PATH, sep=11, device=ht_device)
         with self.assertRaises(TypeError):
-            ht.load_csv(self.CSV_PATH, header_lines="3", sep=";", split=0)
+            ht.load_csv(self.CSV_PATH, header_lines="3", sep=";", split=0, device=ht_device)
 
     def test_load_exception(self):
         # correct extension, file does not exist
         if ht.io.supports_hdf5():
             with self.assertRaises(IOError):
-                ht.load("foo.h5", "data")
+                ht.load("foo.h5", "data", device=ht_device)
         else:
             with self.assertRaises(ValueError):
-                ht.load("foo.h5", "data")
+                ht.load("foo.h5", "data", device=ht_device)
 
         if ht.io.supports_netcdf():
             with self.assertRaises(IOError):
-                ht.load("foo.nc", "data")
+                ht.load("foo.nc", "data", device=ht_device)
         else:
             with self.assertRaises(ValueError):
-                ht.load("foo.nc", "data")
+                ht.load("foo.nc", "data", device=ht_device)
 
         # unknown file extension
         with self.assertRaises(ValueError):
-            ht.load(os.path.join(os.getcwd(), "heat/datasets/data/iris.json"), "data")
+            ht.load(
+                os.path.join(os.getcwd(), "heat/datasets/data/iris.json"), "data", device=ht_device
+            )
         with self.assertRaises(ValueError):
-            ht.load("iris", "data")
+            ht.load("iris", "data", device=ht_device)
 
     # catch-all save
     def test_save(self):
         if ht.io.supports_hdf5():
             # local range
-            local_range = ht.arange(100)
+            local_range = ht.arange(100, device=ht_device)
             local_range.save(self.HDF5_OUT_PATH, self.HDF5_DATASET)
             if local_range.comm.rank == 0:
                 with ht.io.h5py.File(self.HDF5_OUT_PATH, "r") as handle:
@@ -173,7 +182,7 @@ class TestIO(unittest.TestCase):
                 self.assertTrue((local_range._DNDarray__array == comparison).all())
 
             # split range
-            split_range = ht.arange(100, split=0)
+            split_range = ht.arange(100, split=0, device=ht_device)
             split_range.save(self.HDF5_OUT_PATH, self.HDF5_DATASET)
             if split_range.comm.rank == 0:
                 with ht.io.h5py.File(self.HDF5_OUT_PATH, "r") as handle:
@@ -184,7 +193,7 @@ class TestIO(unittest.TestCase):
 
         if ht.io.supports_netcdf():
             # local range
-            local_range = ht.arange(100)
+            local_range = ht.arange(100, device=ht_device)
             local_range.save(self.NETCDF_OUT_PATH, self.NETCDF_VARIABLE)
             if local_range.comm.rank == 0:
                 with ht.io.nc.Dataset(self.NETCDF_OUT_PATH, "r") as handle:
@@ -194,7 +203,7 @@ class TestIO(unittest.TestCase):
                 self.assertTrue((local_range._DNDarray__array == comparison).all())
 
             # split range
-            split_range = ht.arange(100, split=0)
+            split_range = ht.arange(100, split=0, device=ht_device)
             split_range.save(self.NETCDF_OUT_PATH, self.NETCDF_VARIABLE)
             if split_range.comm.rank == 0:
                 with ht.io.nc.Dataset(self.NETCDF_OUT_PATH, "r") as handle:
@@ -204,7 +213,7 @@ class TestIO(unittest.TestCase):
                 self.assertTrue((local_range._DNDarray__array == comparison).all())
 
     def test_save_exception(self):
-        data = ht.arange(1)
+        data = ht.arange(1, device=ht_device)
 
         if ht.io.supports_hdf5():
             with self.assertRaises(TypeError):
@@ -234,7 +243,7 @@ class TestIO(unittest.TestCase):
             return
 
         # default parameters
-        iris = ht.load_hdf5(self.HDF5_PATH, self.HDF5_DATASET)
+        iris = ht.load_hdf5(self.HDF5_PATH, self.HDF5_DATASET, device=ht_device)
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.float32)
@@ -242,7 +251,7 @@ class TestIO(unittest.TestCase):
         self.assertTrue((self.IRIS == iris._DNDarray__array).all())
 
         # positive split axis
-        iris = ht.load_hdf5(self.HDF5_PATH, self.HDF5_DATASET, split=0)
+        iris = ht.load_hdf5(self.HDF5_PATH, self.HDF5_DATASET, split=0, device=ht_device)
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.float32)
@@ -260,7 +269,7 @@ class TestIO(unittest.TestCase):
         self.assertLessEqual(lshape[1], self.IRIS.shape[1])
 
         # different data type
-        iris = ht.load_hdf5(self.HDF5_PATH, self.HDF5_DATASET, dtype=ht.int8)
+        iris = ht.load_hdf5(self.HDF5_PATH, self.HDF5_DATASET, dtype=ht.int8, device=ht_device)
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.int8)
@@ -273,17 +282,17 @@ class TestIO(unittest.TestCase):
 
         # improper argument types
         with self.assertRaises(TypeError):
-            ht.load_hdf5(1, "data")
+            ht.load_hdf5(1, "data", device=ht_device)
         with self.assertRaises(TypeError):
-            ht.load_hdf5("iris.h5", 1)
+            ht.load_hdf5("iris.h5", 1, device=ht_device)
         with self.assertRaises(TypeError):
-            ht.load_hdf5("iris.h5", dataset="data", split=1.0)
+            ht.load_hdf5("iris.h5", dataset="data", split=1.0, device=ht_device)
 
         # file or dataset does not exist
         with self.assertRaises(IOError):
-            ht.load_hdf5("foo.h5", dataset="data")
+            ht.load_hdf5("foo.h5", dataset="data", device=ht_device)
         with self.assertRaises(IOError):
-            ht.load_hdf5("iris.h5", dataset="foo")
+            ht.load_hdf5("iris.h5", dataset="foo", device=ht_device)
 
     def test_save_hdf5(self):
         # HDF5 support is optional
@@ -291,7 +300,7 @@ class TestIO(unittest.TestCase):
             return
 
         # local unsplit data
-        local_data = ht.arange(100)
+        local_data = ht.arange(100, device=ht_device)
         ht.save_hdf5(local_data, self.HDF5_OUT_PATH, self.HDF5_DATASET)
         if local_data.comm.rank == 0:
             with ht.io.h5py.File(self.HDF5_OUT_PATH, "r") as handle:
@@ -301,7 +310,7 @@ class TestIO(unittest.TestCase):
             self.assertTrue((local_data._DNDarray__array == comparison).all())
 
         # distributed data range
-        split_data = ht.arange(100, split=0)
+        split_data = ht.arange(100, split=0, device=ht_device)
         ht.save_hdf5(split_data, self.HDF5_OUT_PATH, self.HDF5_DATASET)
         if split_data.comm.rank == 0:
             with ht.io.h5py.File(self.HDF5_OUT_PATH, "r") as handle:
@@ -316,7 +325,7 @@ class TestIO(unittest.TestCase):
             return
 
         # dummy data
-        data = ht.arange(1)
+        data = ht.arange(1, device=ht_device)
 
         with self.assertRaises(TypeError):
             ht.save_hdf5(1, self.HDF5_OUT_PATH, self.HDF5_DATASET)
@@ -331,7 +340,7 @@ class TestIO(unittest.TestCase):
             return
 
         # default parameters
-        iris = ht.load_netcdf(self.NETCDF_PATH, self.NETCDF_VARIABLE)
+        iris = ht.load_netcdf(self.NETCDF_PATH, self.NETCDF_VARIABLE, device=ht_device)
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.float32)
@@ -339,7 +348,7 @@ class TestIO(unittest.TestCase):
         self.assertTrue((self.IRIS == iris._DNDarray__array).all())
 
         # positive split axis
-        iris = ht.load_netcdf(self.NETCDF_PATH, self.NETCDF_VARIABLE, split=0)
+        iris = ht.load_netcdf(self.NETCDF_PATH, self.NETCDF_VARIABLE, split=0, device=ht_device)
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.float32)
@@ -357,7 +366,9 @@ class TestIO(unittest.TestCase):
         self.assertLessEqual(lshape[1], self.IRIS.shape[1])
 
         # different data type
-        iris = ht.load_netcdf(self.NETCDF_PATH, self.NETCDF_VARIABLE, dtype=ht.int8)
+        iris = ht.load_netcdf(
+            self.NETCDF_PATH, self.NETCDF_VARIABLE, dtype=ht.int8, device=ht_device
+        )
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.int8)
@@ -370,17 +381,17 @@ class TestIO(unittest.TestCase):
 
         # improper argument types
         with self.assertRaises(TypeError):
-            ht.load_netcdf(1, "data")
+            ht.load_netcdf(1, "data", device=ht_device)
         with self.assertRaises(TypeError):
-            ht.load_netcdf("iris.nc", variable=1)
+            ht.load_netcdf("iris.nc", variable=1, device=ht_device)
         with self.assertRaises(TypeError):
-            ht.load_netcdf("iris.nc", variable="data", split=1.0)
+            ht.load_netcdf("iris.nc", variable="data", split=1.0, device=ht_device)
 
         # file or variable does not exist
         with self.assertRaises(IOError):
-            ht.load_netcdf("foo.nc", variable="data")
+            ht.load_netcdf("foo.nc", variable="data", device=ht_device)
         with self.assertRaises(IOError):
-            ht.load_netcdf("iris.nc", variable="foo")
+            ht.load_netcdf("iris.nc", variable="foo", device=ht_device)
 
     def test_save_netcdf(self):
         # netcdf support is optional
@@ -388,7 +399,7 @@ class TestIO(unittest.TestCase):
             return
 
         # local unsplit data
-        local_data = ht.arange(100)
+        local_data = ht.arange(100, device=ht_device)
         ht.save_netcdf(local_data, self.NETCDF_OUT_PATH, self.NETCDF_VARIABLE)
         if local_data.comm.rank == 0:
             with ht.io.nc.Dataset(self.NETCDF_OUT_PATH, "r") as handle:
@@ -398,7 +409,7 @@ class TestIO(unittest.TestCase):
             self.assertTrue((local_data._DNDarray__array == comparison).all())
 
         # distributed data range
-        split_data = ht.arange(100, split=0)
+        split_data = ht.arange(100, split=0, device=ht_device)
         ht.save_netcdf(split_data, self.NETCDF_OUT_PATH, self.NETCDF_VARIABLE)
         if split_data.comm.rank == 0:
             with ht.io.nc.Dataset(self.NETCDF_OUT_PATH, "r") as handle:
@@ -413,7 +424,7 @@ class TestIO(unittest.TestCase):
             return
 
         # dummy data
-        data = ht.arange(1)
+        data = ht.arange(1, device=ht_device)
 
         with self.assertRaises(TypeError):
             ht.save_netcdf(1, self.NETCDF_PATH, self.NETCDF_VARIABLE)

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -7,11 +7,11 @@ import unittest
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestIO(unittest.TestCase):

--- a/heat/core/tests/test_linalg.py
+++ b/heat/core/tests/test_linalg.py
@@ -5,11 +5,11 @@ import heat as ht
 import numpy as np
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestLinalg(unittest.TestCase):

--- a/heat/core/tests/test_linalg.py
+++ b/heat/core/tests/test_linalg.py
@@ -4,12 +4,17 @@ import os
 import heat as ht
 import numpy as np
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestLinalg(unittest.TestCase):
@@ -20,50 +25,50 @@ class TestLinalg(unittest.TestCase):
         data3d = np.ones((10, 10, 10))
         data1d = np.arange(10)
 
-        a1d = ht.array(data1d, dtype=ht.float32, split=0)
-        b1d = ht.array(data1d, dtype=ht.float32, split=0)
+        a1d = ht.array(data1d, dtype=ht.float32, split=0, device=ht_device)
+        b1d = ht.array(data1d, dtype=ht.float32, split=0, device=ht_device)
 
         # 2 1D arrays,
         self.assertEqual(ht.dot(a1d, b1d), np.dot(data1d, data1d))
         ret = []
         self.assertEqual(ht.dot(a1d, b1d, out=ret), np.dot(data1d, data1d))
 
-        a1d = ht.array(data1d, dtype=ht.float32, split=None)
-        b1d = ht.array(data1d, dtype=ht.float32, split=0)
+        a1d = ht.array(data1d, dtype=ht.float32, split=None, device=ht_device)
+        b1d = ht.array(data1d, dtype=ht.float32, split=0, device=ht_device)
         # 2 1D arrays,
         self.assertEqual(ht.dot(a1d, b1d), np.dot(data1d, data1d))
 
-        a2d = ht.array(data2d, split=1)
-        b2d = ht.array(data2d, split=1)
+        a2d = ht.array(data2d, split=1, device=ht_device)
+        b2d = ht.array(data2d, split=1, device=ht_device)
         # 2 2D arrays,
-        res = ht.dot(a2d, b2d) - ht.array(np.dot(data2d, data2d))
-        self.assertEqual(ht.equal(res, ht.zeros(res.shape)), 1)
-        ret = ht.array(data2d, split=1)
+        res = ht.dot(a2d, b2d) - ht.array(np.dot(data2d, data2d), device=ht_device)
+        self.assertEqual(ht.equal(res, ht.zeros(res.shape, device=ht_device)), 1)
+        ret = ht.array(data2d, split=1, device=ht_device)
         ht.dot(a2d, b2d, out=ret)
         # print(ht.dot(a2d, b2d, out=ret))
-        res = ret - ht.array(np.dot(data2d, data2d))
-        self.assertEqual(ht.equal(res, ht.zeros(res.shape)), 1)
+        res = ret - ht.array(np.dot(data2d, data2d), device=ht_device)
+        self.assertEqual(ht.equal(res, ht.zeros(res.shape, device=ht_device)), 1)
 
         const1 = 5
         const2 = 6
         # a is const,
-        res = ht.dot(const1, b2d) - ht.array(np.dot(const1, data2d))
+        res = ht.dot(const1, b2d) - ht.array(np.dot(const1, data2d), device=ht_device)
         ret = 0
         ht.dot(const1, b2d, out=ret)
-        self.assertEqual(ht.equal(res, ht.zeros(res.shape)), 1)
+        self.assertEqual(ht.equal(res, ht.zeros(res.shape, device=ht_device)), 1)
 
         # b is const,
-        res = ht.dot(a2d, const2) - ht.array(np.dot(data2d, const2))
-        self.assertEqual(ht.equal(res, ht.zeros(res.shape)), 1)
+        res = ht.dot(a2d, const2) - ht.array(np.dot(data2d, const2), device=ht_device)
+        self.assertEqual(ht.equal(res, ht.zeros(res.shape, device=ht_device)), 1)
         # a and b and const
         self.assertEqual(ht.dot(const2, const1), 5 * 6)
 
         with self.assertRaises(NotImplementedError):
-            ht.dot(ht.array(data3d), ht.array(data1d))
+            ht.dot(ht.array(data3d, device=ht_device), ht.array(data1d, device=ht_device))
 
     def test_matmul(self):
         with self.assertRaises(ValueError):
-            ht.matmul(ht.ones((25, 25)), ht.ones((42, 42)))
+            ht.matmul(ht.ones((25, 25), device=ht_device), ht.ones((42, 42), device=ht_device))
 
         # cases to test:
         n, m = 21, 31
@@ -76,15 +81,15 @@ class TestLinalg(unittest.TestCase):
         b_torch[:, 0] = torch.arange(1, j + 1, device=device)
 
         # splits None None
-        a = ht.ones((n, m), split=None)
-        b = ht.ones((j, k), split=None)
-        a[0] = ht.arange(1, m + 1)
-        a[:, -1] = ht.arange(1, n + 1)
-        b[0] = ht.arange(1, k + 1)
-        b[:, 0] = ht.arange(1, j + 1)
+        a = ht.ones((n, m), split=None, device=ht_device)
+        b = ht.ones((j, k), split=None, device=ht_device)
+        a[0] = ht.arange(1, m + 1, device=ht_device)
+        a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+        b[0] = ht.arange(1, k + 1, device=ht_device)
+        b[:, 0] = ht.arange(1, j + 1, device=ht_device)
         ret00 = ht.matmul(a, b)
 
-        self.assertEqual(ht.all(ret00 == ht.array(a_torch @ b_torch)), 1)
+        self.assertEqual(ht.all(ret00 == ht.array(a_torch @ b_torch, device=ht_device)), 1)
         self.assertIsInstance(ret00, ht.DNDarray)
         self.assertEqual(ret00.shape, (n, k))
         self.assertEqual(ret00.dtype, ht.float)
@@ -92,15 +97,15 @@ class TestLinalg(unittest.TestCase):
 
         if a.comm.size > 1:
             # splits 00
-            a = ht.ones((n, m), split=0, dtype=ht.float64)
-            b = ht.ones((j, k), split=0)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((n, m), split=0, dtype=ht.float64, device=ht_device)
+            b = ht.ones((j, k), split=0, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = a @ b
 
-            ret_comp00 = ht.array(a_torch @ b_torch, split=0)
+            ret_comp00 = ht.array(a_torch @ b_torch, split=0, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp00))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -108,15 +113,15 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 00 (numpy)
-            a = ht.array(np.ones((n, m)), split=0)
-            b = ht.array(np.ones((j, k)), split=0)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.array(np.ones((n, m)), split=0, device=ht_device)
+            b = ht.array(np.ones((j, k)), split=0, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = a @ b
 
-            ret_comp00 = ht.array(a_torch @ b_torch, split=0)
+            ret_comp00 = ht.array(a_torch @ b_torch, split=0, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp00))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -124,15 +129,15 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 01
-            a = ht.ones((n, m), split=0)
-            b = ht.ones((j, k), split=1, dtype=ht.float64)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((n, m), split=0, device=ht_device)
+            b = ht.ones((j, k), split=1, dtype=ht.float64, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp01 = ht.array(a_torch @ b_torch, split=0)
+            ret_comp01 = ht.array(a_torch @ b_torch, split=0, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp01))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -140,15 +145,15 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 10
-            a = ht.ones((n, m), split=1)
-            b = ht.ones((j, k), split=0)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((n, m), split=1, device=ht_device)
+            b = ht.ones((j, k), split=0, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp10 = ht.array(a_torch @ b_torch, split=1)
+            ret_comp10 = ht.array(a_torch @ b_torch, split=1, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp10))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -156,15 +161,15 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 1)
 
             # splits 11
-            a = ht.ones((n, m), split=1)
-            b = ht.ones((j, k), split=1)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((n, m), split=1, device=ht_device)
+            b = ht.ones((j, k), split=1, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp11 = ht.array(a_torch @ b_torch, split=1)
+            ret_comp11 = ht.array(a_torch @ b_torch, split=1, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp11))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -172,15 +177,15 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 1)
 
             # splits 11 (torch)
-            a = ht.array(torch.ones((n, m), device=device), split=1)
-            b = ht.array(torch.ones((j, k), device=device), split=1)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.array(torch.ones((n, m), device=device), split=1, device=ht_device)
+            b = ht.array(torch.ones((j, k), device=device), split=1, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp11 = ht.array(a_torch @ b_torch, split=1)
+            ret_comp11 = ht.array(a_torch @ b_torch, split=1, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp11))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -188,15 +193,15 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 1)
 
             # splits 0 None
-            a = ht.ones((n, m), split=0)
-            b = ht.ones((j, k), split=None)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((n, m), split=0, device=ht_device)
+            b = ht.ones((j, k), split=None, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp0 = ht.array(a_torch @ b_torch, split=0)
+            ret_comp0 = ht.array(a_torch @ b_torch, split=0, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp0))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -204,15 +209,15 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 1 None
-            a = ht.ones((n, m), split=1)
-            b = ht.ones((j, k), split=None)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((n, m), split=1, device=ht_device)
+            b = ht.ones((j, k), split=None, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp1 = ht.array(a_torch @ b_torch, split=1)
+            ret_comp1 = ht.array(a_torch @ b_torch, split=1, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp1))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -220,15 +225,15 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 1)
 
             # splits None 0
-            a = ht.ones((n, m), split=None)
-            b = ht.ones((j, k), split=0)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((n, m), split=None, device=ht_device)
+            b = ht.ones((j, k), split=0, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array(a_torch @ b_torch, split=0)
+            ret_comp = ht.array(a_torch @ b_torch, split=0, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -236,15 +241,15 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits None 1
-            a = ht.ones((n, m), split=None)
-            b = ht.ones((j, k), split=1)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((n, m), split=None, device=ht_device)
+            b = ht.ones((j, k), split=1, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array(a_torch @ b_torch, split=1)
+            ret_comp = ht.array(a_torch @ b_torch, split=1, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n, k))
@@ -258,13 +263,13 @@ class TestLinalg(unittest.TestCase):
             b_torch[0] = torch.arange(1, k + 1, device=device)
             b_torch[:, 0] = torch.arange(1, j + 1, device=device)
             # splits None None
-            a = ht.ones((m), split=None)
-            b = ht.ones((j, k), split=None)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((m), split=None, device=ht_device)
+            b = ht.ones((j, k), split=None, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array(a_torch @ b_torch, split=None)
+            ret_comp = ht.array(a_torch @ b_torch, split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (k,))
@@ -272,13 +277,13 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, None)
 
             # splits None 0
-            a = ht.ones((m), split=None)
-            b = ht.ones((j, k), split=0)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((m), split=None, device=ht_device)
+            b = ht.ones((j, k), split=0, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array(a_torch @ b_torch, split=None)
+            ret_comp = ht.array(a_torch @ b_torch, split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (k,))
@@ -286,12 +291,12 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits None 1
-            a = ht.ones((m), split=None)
-            b = ht.ones((j, k), split=1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((m), split=None, device=ht_device)
+            b = ht.ones((j, k), split=1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
-            ret_comp = ht.array(a_torch @ b_torch, split=0)
+            ret_comp = ht.array(a_torch @ b_torch, split=0, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (k,))
@@ -299,13 +304,13 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 0 None
-            a = ht.ones((m), split=None)
-            b = ht.ones((j, k), split=0)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((m), split=None, device=ht_device)
+            b = ht.ones((j, k), split=0, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array(a_torch @ b_torch, split=None)
+            ret_comp = ht.array(a_torch @ b_torch, split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (k,))
@@ -313,13 +318,13 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 0 0
-            a = ht.ones((m), split=0)
-            b = ht.ones((j, k), split=0)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((m), split=0, device=ht_device)
+            b = ht.ones((j, k), split=0, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array(a_torch @ b_torch, split=None)
+            ret_comp = ht.array(a_torch @ b_torch, split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (k,))
@@ -327,13 +332,13 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 0 1
-            a = ht.ones((m), split=0)
-            b = ht.ones((j, k), split=1)
-            b[0] = ht.arange(1, k + 1)
-            b[:, 0] = ht.arange(1, j + 1)
+            a = ht.ones((m), split=0, device=ht_device)
+            b = ht.ones((j, k), split=1, device=ht_device)
+            b[0] = ht.arange(1, k + 1, device=ht_device)
+            b[:, 0] = ht.arange(1, j + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array(a_torch @ b_torch, split=None)
+            ret_comp = ht.array(a_torch @ b_torch, split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (k,))
@@ -346,13 +351,13 @@ class TestLinalg(unittest.TestCase):
             a_torch[:, -1] = torch.arange(1, n + 1, device=device)
             b_torch = torch.ones((j), device=device)
             # splits None None
-            a = ht.ones((n, m), split=None)
-            b = ht.ones((j), split=None)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
+            a = ht.ones((n, m), split=None, device=ht_device)
+            b = ht.ones((j), split=None, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array(a_torch @ b_torch, split=None)
+            ret_comp = ht.array(a_torch @ b_torch, split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n,))
@@ -360,13 +365,13 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, None)
 
             # splits 0 None
-            a = ht.ones((n, m), split=0)
-            b = ht.ones((j), split=None)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
+            a = ht.ones((n, m), split=0, device=ht_device)
+            b = ht.ones((j), split=None, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            ret_comp = ht.array((a_torch @ b_torch), split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n,))
@@ -374,13 +379,13 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 1 None
-            a = ht.ones((n, m), split=1)
-            b = ht.ones((j), split=None)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
+            a = ht.ones((n, m), split=1, device=ht_device)
+            b = ht.ones((j), split=None, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            ret_comp = ht.array((a_torch @ b_torch), split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n,))
@@ -388,13 +393,13 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits None 0
-            a = ht.ones((n, m), split=None)
-            b = ht.ones((j), split=0)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
+            a = ht.ones((n, m), split=None, device=ht_device)
+            b = ht.ones((j), split=0, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            ret_comp = ht.array((a_torch @ b_torch), split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n,))
@@ -402,13 +407,13 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 0 0
-            a = ht.ones((n, m), split=0)
-            b = ht.ones((j), split=0)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
+            a = ht.ones((n, m), split=0, device=ht_device)
+            b = ht.ones((j), split=0, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            ret_comp = ht.array((a_torch @ b_torch), split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n,))
@@ -416,13 +421,13 @@ class TestLinalg(unittest.TestCase):
             self.assertEqual(ret00.split, 0)
 
             # splits 1 0
-            a = ht.ones((n, m), split=1)
-            b = ht.ones((j), split=0)
-            a[0] = ht.arange(1, m + 1)
-            a[:, -1] = ht.arange(1, n + 1)
+            a = ht.ones((n, m), split=1, device=ht_device)
+            b = ht.ones((j), split=0, device=ht_device)
+            a[0] = ht.arange(1, m + 1, device=ht_device)
+            a[:, -1] = ht.arange(1, n + 1, device=ht_device)
             ret00 = ht.matmul(a, b)
 
-            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            ret_comp = ht.array((a_torch @ b_torch), split=None, device=ht_device)
             self.assertTrue(ht.equal(ret00, ret_comp))
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n,))
@@ -431,7 +436,7 @@ class TestLinalg(unittest.TestCase):
 
     def test_transpose(self):
         # vector transpose, not distributed
-        vector = ht.arange(10)
+        vector = ht.arange(10, device=ht_device)
         vector_t = vector.T
         self.assertIsInstance(vector_t, ht.DNDarray)
         self.assertEqual(vector_t.dtype, ht.int32)
@@ -439,7 +444,7 @@ class TestLinalg(unittest.TestCase):
         self.assertEqual(vector_t.shape, (10,))
 
         # simple matrix transpose, not distributed
-        simple_matrix = ht.zeros((2, 4))
+        simple_matrix = ht.zeros((2, 4), device=ht_device)
         simple_matrix_t = simple_matrix.transpose()
         self.assertIsInstance(simple_matrix_t, ht.DNDarray)
         self.assertEqual(simple_matrix_t.dtype, ht.float32)
@@ -448,7 +453,7 @@ class TestLinalg(unittest.TestCase):
         self.assertEqual(simple_matrix_t._DNDarray__array.shape, (4, 2))
 
         # 4D array, not distributed, with given axis
-        array_4d = ht.zeros((2, 3, 4, 5))
+        array_4d = ht.zeros((2, 3, 4, 5), device=ht_device)
         array_4d_t = ht.transpose(array_4d, axes=(-1, 0, 2, 1))
         self.assertIsInstance(array_4d_t, ht.DNDarray)
         self.assertEqual(array_4d_t.dtype, ht.float32)
@@ -457,7 +462,7 @@ class TestLinalg(unittest.TestCase):
         self.assertEqual(array_4d_t._DNDarray__array.shape, (5, 2, 4, 3))
 
         # vector transpose, distributed
-        vector_split = ht.arange(10, split=0)
+        vector_split = ht.arange(10, split=0, device=ht_device)
         vector_split_t = vector_split.T
         self.assertIsInstance(vector_split_t, ht.DNDarray)
         self.assertEqual(vector_split_t.dtype, ht.int32)
@@ -466,7 +471,7 @@ class TestLinalg(unittest.TestCase):
         self.assertLessEqual(vector_split_t.lshape[0], 10)
 
         # matrix transpose, distributed
-        matrix_split = ht.ones((10, 20), split=1)
+        matrix_split = ht.ones((10, 20), split=1, device=ht_device)
         matrix_split_t = matrix_split.transpose()
         self.assertIsInstance(matrix_split_t, ht.DNDarray)
         self.assertEqual(matrix_split_t.dtype, ht.float32)
@@ -476,7 +481,7 @@ class TestLinalg(unittest.TestCase):
         self.assertEqual(matrix_split_t.lshape[1], 10)
 
         # 4D array, distributed
-        array_4d_split = ht.ones((3, 4, 5, 6), split=3)
+        array_4d_split = ht.ones((3, 4, 5, 6), split=3, device=ht_device)
         array_4d_split_t = ht.transpose(array_4d_split, axes=(1, 0, 3, 2))
         self.assertIsInstance(array_4d_t, ht.DNDarray)
         self.assertEqual(array_4d_split_t.dtype, ht.float32)
@@ -492,18 +497,18 @@ class TestLinalg(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.transpose(1)
         with self.assertRaises(ValueError):
-            ht.transpose(ht.zeros((2, 3)), axes=1.0)
+            ht.transpose(ht.zeros((2, 3), device=ht_device), axes=1.0)
         with self.assertRaises(ValueError):
-            ht.transpose(ht.zeros((2, 3)), axes=(-1,))
+            ht.transpose(ht.zeros((2, 3), device=ht_device), axes=(-1,))
         with self.assertRaises(TypeError):
-            ht.zeros((2, 3)).transpose(axes="01")
+            ht.zeros((2, 3), device=ht_device).transpose(axes="01")
         with self.assertRaises(TypeError):
-            ht.zeros((2, 3)).transpose(axes=(0, 1.0))
+            ht.zeros((2, 3), device=ht_device).transpose(axes=(0, 1.0))
         with self.assertRaises((ValueError, IndexError)):
-            ht.zeros((2, 3)).transpose(axes=(0, 3))
+            ht.zeros((2, 3), device=ht_device).transpose(axes=(0, 3))
 
     def test_tril(self):
-        local_ones = ht.ones((5,))
+        local_ones = ht.ones((5,), device=ht_device)
 
         # 1D case, no offset, data is not split, module-level call
         result = ht.tril(local_ones)
@@ -532,7 +537,7 @@ class TestLinalg(unittest.TestCase):
         self.assertEqual(result.split, None)
         self.assertTrue((result._DNDarray__array == comparison).all())
 
-        local_ones = ht.ones((4, 5))
+        local_ones = ht.ones((4, 5), device=ht_device)
 
         # 2D case, no offset, data is not split, method
         result = local_ones.tril()
@@ -561,7 +566,7 @@ class TestLinalg(unittest.TestCase):
         self.assertEqual(result.split, None)
         self.assertTrue((result._DNDarray__array == comparison).all())
 
-        local_ones = ht.ones((3, 4, 5, 6))
+        local_ones = ht.ones((3, 4, 5, 6), device=ht_device)
 
         # 2D+ case, no offset, data is not split, module-level call
         result = local_ones.tril()
@@ -596,7 +601,7 @@ class TestLinalg(unittest.TestCase):
             for j in range(4):
                 self.assertTrue((result._DNDarray__array[i, j] == comparison).all())
 
-        distributed_ones = ht.ones((5,), split=0)
+        distributed_ones = ht.ones((5,), split=0, device=ht_device)
 
         # 1D case, no offset, data is split, method
         result = distributed_ones.tril()
@@ -637,7 +642,7 @@ class TestLinalg(unittest.TestCase):
         if result.comm.rank == result.shape[0] - 1:
             self.assertTrue(result._DNDarray__array[0, -1] == 0)
 
-        distributed_ones = ht.ones((4, 5), split=0)
+        distributed_ones = ht.ones((4, 5), split=0, device=ht_device)
 
         # 2D case, no offset, data is horizontally split, method
         result = distributed_ones.tril()
@@ -678,7 +683,7 @@ class TestLinalg(unittest.TestCase):
         if result.comm.rank == result.shape[0] - 1:
             self.assertTrue(result._DNDarray__array[-1, 0] == 1)
 
-        distributed_ones = ht.ones((4, 5), split=1)
+        distributed_ones = ht.ones((4, 5), split=1, device=ht_device)
 
         # 2D case, no offset, data is vertically split, method
         result = distributed_ones.tril()
@@ -720,7 +725,7 @@ class TestLinalg(unittest.TestCase):
             self.assertTrue(result._DNDarray__array[0, -1] == 0)
 
     def test_triu(self):
-        local_ones = ht.ones((5,))
+        local_ones = ht.ones((5,), device=ht_device)
 
         # 1D case, no offset, data is not split, module-level call
         result = ht.triu(local_ones)
@@ -749,7 +754,7 @@ class TestLinalg(unittest.TestCase):
         self.assertEqual(result.split, None)
         self.assertTrue((result._DNDarray__array == comparison).all())
 
-        local_ones = ht.ones((4, 5))
+        local_ones = ht.ones((4, 5), device=ht_device)
 
         # 2D case, no offset, data is not split, method
         result = local_ones.triu()
@@ -778,7 +783,7 @@ class TestLinalg(unittest.TestCase):
         self.assertEqual(result.split, None)
         self.assertTrue((result._DNDarray__array == comparison).all())
 
-        local_ones = ht.ones((3, 4, 5, 6))
+        local_ones = ht.ones((3, 4, 5, 6), device=ht_device)
 
         # 2D+ case, no offset, data is not split, module-level call
         result = local_ones.triu()
@@ -813,7 +818,7 @@ class TestLinalg(unittest.TestCase):
             for j in range(4):
                 self.assertTrue((result._DNDarray__array[i, j] == comparison).all())
 
-        distributed_ones = ht.ones((5,), split=0)
+        distributed_ones = ht.ones((5,), split=0, device=ht_device)
 
         # 1D case, no offset, data is split, method
         result = distributed_ones.triu()
@@ -854,7 +859,7 @@ class TestLinalg(unittest.TestCase):
         if result.comm.rank == result.shape[0] - 1:
             self.assertTrue(result._DNDarray__array[0, -1] == 1)
 
-        distributed_ones = ht.ones((4, 5), split=0)
+        distributed_ones = ht.ones((4, 5), split=0, device=ht_device)
 
         # 2D case, no offset, data is horizontally split, method
         result = distributed_ones.triu()
@@ -895,7 +900,7 @@ class TestLinalg(unittest.TestCase):
         if result.comm.rank == result.shape[0] - 1:
             self.assertTrue(result._DNDarray__array[-1, 0] == 0)
 
-        distributed_ones = ht.ones((4, 5), split=1)
+        distributed_ones = ht.ones((4, 5), split=1, device=ht_device)
 
         # 2D case, no offset, data is vertically split, method
         result = distributed_ones.triu()

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -3,12 +3,17 @@ import unittest
 import os
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestLogical(unittest.TestCase):
@@ -16,7 +21,7 @@ class TestLogical(unittest.TestCase):
         array_len = 9
 
         # check all over all float elements of 1d tensor locally
-        ones_noaxis = ht.ones(array_len)
+        ones_noaxis = ht.ones(array_len, device=ht_device)
         x = (ones_noaxis == 1).all()
 
         self.assertIsInstance(x, ht.DNDarray)
@@ -27,12 +32,12 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(x.split, None)
         self.assertEqual(x._DNDarray__array, 1)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.all(ones_noaxis, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 1)
 
         # check all over all float elements of split 1d tensor
-        ones_noaxis_split = ht.ones(array_len, split=0)
+        ones_noaxis_split = ht.ones(array_len, split=0, device=ht_device)
         floats_is_one = ones_noaxis_split.all()
 
         self.assertIsInstance(floats_is_one, ht.DNDarray)
@@ -43,12 +48,12 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(floats_is_one.split, None)
         self.assertEqual(floats_is_one._DNDarray__array, 1)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.all(ones_noaxis_split, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 1)
 
         # check all over all integer elements of 1d tensor locally
-        ones_noaxis_int = ht.ones(array_len).astype(ht.int)
+        ones_noaxis_int = ht.ones(array_len, device=ht_device).astype(ht.int)
         int_is_one = ones_noaxis_int.all()
 
         self.assertIsInstance(int_is_one, ht.DNDarray)
@@ -59,12 +64,12 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(int_is_one.split, None)
         self.assertEqual(int_is_one._DNDarray__array, 1)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.all(ones_noaxis_int, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 1)
 
         # check all over all integer elements of split 1d tensor
-        ones_noaxis_split_int = ht.ones(array_len, split=0).astype(ht.int)
+        ones_noaxis_split_int = ht.ones(array_len, split=0, device=ht_device).astype(ht.int)
         split_int_is_one = ones_noaxis_split_int.all()
 
         self.assertIsInstance(split_int_is_one, ht.DNDarray)
@@ -75,12 +80,12 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(split_int_is_one.split, None)
         self.assertEqual(split_int_is_one._DNDarray__array, 1)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.all(ones_noaxis_split_int, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 1)
 
         # check all over all float elements of 3d tensor locally
-        ones_noaxis_volume = ht.ones((3, 3, 3))
+        ones_noaxis_volume = ht.ones((3, 3, 3), device=ht_device)
         volume_is_one = ones_noaxis_volume.all()
 
         self.assertIsInstance(volume_is_one, ht.DNDarray)
@@ -91,12 +96,12 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(volume_is_one.split, None)
         self.assertEqual(volume_is_one._DNDarray__array, 1)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.all(ones_noaxis_volume, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 1)
 
         # check sequence is not all one
-        sequence = ht.arange(array_len)
+        sequence = ht.arange(array_len, device=ht_device)
         sequence_is_one = sequence.all()
 
         self.assertIsInstance(sequence_is_one, ht.DNDarray)
@@ -107,12 +112,12 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(sequence_is_one.split, None)
         self.assertEqual(sequence_is_one._DNDarray__array, 0)
 
-        out_noaxis = ht.zeros((1,))
+        out_noaxis = ht.zeros((1,), device=ht_device)
         ht.all(sequence, out=out_noaxis)
         self.assertEqual(out_noaxis._DNDarray__array, 0)
 
         # check all over all float elements of split 3d tensor
-        ones_noaxis_split_axis = ht.ones((3, 3, 3), split=0)
+        ones_noaxis_split_axis = ht.ones((3, 3, 3), split=0, device=ht_device)
         float_volume_is_one = ones_noaxis_split_axis.all(axis=0)
 
         self.assertIsInstance(float_volume_is_one, ht.DNDarray)
@@ -121,11 +126,11 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(float_volume_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(float_volume_is_one.split, None)
 
-        out_noaxis = ht.zeros((3, 3))
+        out_noaxis = ht.zeros((3, 3), device=ht_device)
         ht.all(ones_noaxis_split_axis, axis=0, out=out_noaxis)
 
         # check all over all float elements of split 3d tensor with tuple axis
-        ones_noaxis_split_axis = ht.ones((3, 3, 3), split=0)
+        ones_noaxis_split_axis = ht.ones((3, 3, 3), split=0, device=ht_device)
         float_volume_is_one = ones_noaxis_split_axis.all(axis=(0, 1))
 
         self.assertIsInstance(float_volume_is_one, ht.DNDarray)
@@ -135,7 +140,7 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(float_volume_is_one.split, None)
 
         # check all over all float elements of split 5d tensor with negative axis
-        ones_noaxis_split_axis_neg = ht.zeros((1, 2, 3, 4, 5), split=1)
+        ones_noaxis_split_axis_neg = ht.zeros((1, 2, 3, 4, 5), split=1, device=ht_device)
         float_5d_is_one = ones_noaxis_split_axis_neg.all(axis=-2)
 
         self.assertIsInstance(float_5d_is_one, ht.DNDarray)
@@ -144,25 +149,25 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(float_5d_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(float_5d_is_one.split, 1)
 
-        out_noaxis = ht.zeros((1, 2, 3, 5))
+        out_noaxis = ht.zeros((1, 2, 3, 5), device=ht_device)
         ht.all(ones_noaxis_split_axis_neg, axis=-2, out=out_noaxis)
 
         # exceptions
         with self.assertRaises(ValueError):
-            ht.ones(array_len).all(axis=1)
+            ht.ones(array_len, device=ht_device).all(axis=1)
         with self.assertRaises(ValueError):
-            ht.ones(array_len).all(axis=-2)
+            ht.ones(array_len, device=ht_device).all(axis=-2)
         with self.assertRaises(ValueError):
-            ht.ones((4, 4)).all(axis=0, out=out_noaxis)
+            ht.ones((4, 4), device=ht_device).all(axis=0, out=out_noaxis)
         with self.assertRaises(TypeError):
-            ht.ones(array_len).all(axis="bad_axis_type")
+            ht.ones(array_len, device=ht_device).all(axis="bad_axis_type")
 
     def test_allclose(self):
-        a = ht.float32([[2, 2], [2, 2]])
-        b = ht.float32([[2.00005, 2.00005], [2.00005, 2.00005]])
-        c = ht.zeros((4, 6), split=0)
-        d = ht.zeros((4, 6), split=1)
-        e = ht.zeros((4, 6))
+        a = ht.float32([[2, 2], [2, 2]], device=ht_device)
+        b = ht.float32([[2.00005, 2.00005], [2.00005, 2.00005]], device=ht_device)
+        c = ht.zeros((4, 6), split=0, device=ht_device)
+        d = ht.zeros((4, 6), split=1, device=ht_device)
+        e = ht.zeros((4, 6), device=ht_device)
 
         self.assertFalse(ht.allclose(a, b))
         self.assertTrue(ht.allclose(a, b, atol=1e-04))
@@ -183,27 +188,27 @@ class TestLogical(unittest.TestCase):
 
     def test_any(self):
         # float values, minor axis
-        x = ht.float32([[2.7, 0, 0], [0, 0, 0], [0, 0.3, 0]])
+        x = ht.float32([[2.7, 0, 0], [0, 0, 0], [0, 0.3, 0]], device=ht_device)
         any_tensor = x.any(axis=1)
-        res = ht.uint8([1, 0, 1])
+        res = ht.uint8([1, 0, 1], device=ht_device)
         self.assertIsInstance(any_tensor, ht.DNDarray)
         self.assertEqual(any_tensor.shape, (3,))
         self.assertEqual(any_tensor.dtype, ht.bool)
         self.assertTrue(ht.equal(any_tensor, res))
 
         # integer values, major axis, output tensor
-        any_tensor = ht.zeros((2,))
-        x = ht.int32([[0, 0], [0, 0], [0, 1]])
+        any_tensor = ht.zeros((2,), device=ht_device)
+        x = ht.int32([[0, 0], [0, 0], [0, 1]], device=ht_device)
         ht.any(x, axis=0, out=any_tensor)
-        res = ht.uint8([0, 1])
+        res = ht.uint8([0, 1], device=ht_device)
         self.assertIsInstance(any_tensor, ht.DNDarray)
         self.assertEqual(any_tensor.shape, (2,))
         self.assertEqual(any_tensor.dtype, ht.bool)
         self.assertTrue(ht.equal(any_tensor, res))
 
         # float values, no axis
-        x = ht.float64([[0, 0, 0], [0, 0, 0]])
-        res = ht.zeros(1, dtype=ht.uint8)
+        x = ht.float64([[0, 0, 0], [0, 0, 0]], device=ht_device)
+        res = ht.zeros(1, dtype=ht.uint8, device=ht_device)
         any_tensor = ht.any(x)
         self.assertIsInstance(any_tensor, ht.DNDarray)
         self.assertEqual(any_tensor.shape, (1,))
@@ -211,9 +216,9 @@ class TestLogical(unittest.TestCase):
         self.assertTrue(ht.equal(any_tensor, res))
 
         # split tensor, along axis
-        x = ht.arange(10, split=0)
+        x = ht.arange(10, split=0, device=ht_device)
         any_tensor = ht.any(x, axis=0)
-        res = ht.uint8([1])
+        res = ht.uint8([1], device=ht_device)
         self.assertIsInstance(any_tensor, ht.DNDarray)
         self.assertEqual(any_tensor.shape, (1,))
         self.assertEqual(any_tensor.dtype, ht.bool)

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -4,11 +4,11 @@ import os
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestLogical(unittest.TestCase):

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -1,7 +1,14 @@
 import torch
 import unittest
-
+import os
 import heat as ht
+
+if os.environ.get("DEVICE") == "gpu":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+else:
+    device = torch.device("cpu")
+    ht.use_device("cpu")
 
 
 class TestLogical(unittest.TestCase):

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -5,11 +5,11 @@ import numpy as np
 import os
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestManipulations(unittest.TestCase):

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -4,12 +4,17 @@ import heat as ht
 import numpy as np
 import os
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestManipulations(unittest.TestCase):
@@ -18,8 +23,8 @@ class TestManipulations(unittest.TestCase):
         # Matrices / Vectors
         # s0    s1  axis
         # None None 0
-        x = ht.zeros((16, 15), split=None)
-        y = ht.ones((16, 15), split=None)
+        x = ht.zeros((16, 15), split=None, device=ht_device)
+        y = ht.ones((16, 15), split=None, device=ht_device)
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32, 15))
         self.assertEqual(res.dtype, ht.float)
@@ -41,8 +46,8 @@ class TestManipulations(unittest.TestCase):
 
         # =============================================
         # None 0 0
-        x = ht.zeros((16, 15), split=None)
-        y = ht.ones((16, 15), split=0)
+        x = ht.zeros((16, 15), split=None, device=ht_device)
+        y = ht.ones((16, 15), split=0, device=ht_device)
         res = ht.concatenate((x, y), axis=0)
 
         self.assertEqual(res.gshape, (32, 15))
@@ -64,8 +69,8 @@ class TestManipulations(unittest.TestCase):
         self.assertEqual(res.lshape, tuple(lshape))
         # =============================================
         # None 1 1
-        x = ht.zeros((16, 15), split=None)
-        y = ht.ones((16, 15), split=1)
+        x = ht.zeros((16, 15), split=None, device=ht_device)
+        y = ht.ones((16, 15), split=1, device=ht_device)
         res = ht.concatenate((x, y), axis=1)
         self.assertEqual(res.gshape, (16, 30))
         self.assertEqual(res.dtype, ht.float)
@@ -76,8 +81,8 @@ class TestManipulations(unittest.TestCase):
         self.assertEqual(res.lshape, tuple(lshape))
         #
         # None 1 0
-        x = ht.zeros((16, 15), split=None)
-        y = ht.ones((16, 15), split=1)
+        x = ht.zeros((16, 15), split=None, device=ht_device)
+        y = ht.ones((16, 15), split=1, device=ht_device)
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32, 15))
         self.assertEqual(res.dtype, ht.float)
@@ -89,8 +94,8 @@ class TestManipulations(unittest.TestCase):
 
         # # =============================================
         # # 0 None 0
-        x = ht.zeros((16, 15), split=0)
-        y = ht.ones((16, 15), split=None)
+        x = ht.zeros((16, 15), split=0, device=ht_device)
+        y = ht.ones((16, 15), split=None, device=ht_device)
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32, 15))
         self.assertEqual(res.dtype, ht.float)
@@ -111,8 +116,8 @@ class TestManipulations(unittest.TestCase):
 
         # =============================================
         # 1 None 0
-        x = ht.zeros((16, 15), split=1)
-        y = ht.ones((16, 15), split=None)
+        x = ht.zeros((16, 15), split=1, device=ht_device)
+        y = ht.ones((16, 15), split=None, device=ht_device)
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32, 15))
         self.assertEqual(res.dtype, ht.float)
@@ -132,8 +137,8 @@ class TestManipulations(unittest.TestCase):
         self.assertEqual(res.lshape, tuple(lshape))
 
         # =============================================
-        x = ht.zeros((16, 15), split=0)
-        y = ht.ones((16, 15), split=0)
+        x = ht.zeros((16, 15), split=0, device=ht_device)
+        y = ht.ones((16, 15), split=0, device=ht_device)
         # # 0 0 0
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32, 15))
@@ -154,8 +159,8 @@ class TestManipulations(unittest.TestCase):
         self.assertEqual(res.lshape, tuple(lshape))
 
         # =============================================
-        x = ht.zeros((16, 15), split=1)
-        y = ht.ones((16, 15), split=1)
+        x = ht.zeros((16, 15), split=1, device=ht_device)
+        y = ht.ones((16, 15), split=1, device=ht_device)
         # 1 1 0
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32, 15))
@@ -176,8 +181,8 @@ class TestManipulations(unittest.TestCase):
         self.assertEqual(res.lshape, tuple(lshape))
 
         # =============================================
-        x = ht.zeros((16, 15, 14), split=2)
-        y = ht.ones((16, 15, 14), split=2)
+        x = ht.zeros((16, 15, 14), split=2, device=ht_device)
+        y = ht.ones((16, 15, 14), split=2, device=ht_device)
         # 2 2 0
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32, 15, 14))
@@ -207,7 +212,7 @@ class TestManipulations(unittest.TestCase):
         self.assertEqual(res.lshape, tuple(lshape))
         #
         # =============================================
-        y = ht.ones((16, 15, 14), split=None)
+        y = ht.ones((16, 15, 14), split=None, device=ht_device)
         # 2 None 1
         res = ht.concatenate((x, y), axis=1)
         self.assertEqual(res.gshape, (16, 30, 14))
@@ -237,8 +242,8 @@ class TestManipulations(unittest.TestCase):
         self.assertEqual(res.lshape, tuple(lshape))
 
         # =============================================
-        x = ht.zeros((16, 15, 14), split=None)
-        y = ht.ones((16, 15, 14), split=2)
+        x = ht.zeros((16, 15, 14), split=None, device=ht_device)
+        y = ht.ones((16, 15, 14), split=2, device=ht_device)
         # None 2 0
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32, 15, 14))
@@ -249,8 +254,8 @@ class TestManipulations(unittest.TestCase):
             lshape[i] = chk[i].stop - chk[i].start
         self.assertEqual(res.lshape, tuple(lshape))
 
-        x = ht.zeros((16, 15, 14), split=None)
-        y = ht.ones((16, 15, 14), split=2)
+        x = ht.zeros((16, 15, 14), split=None, device=ht_device)
+        y = ht.ones((16, 15, 14), split=2, device=ht_device)
         # None 2 0
         res = ht.concatenate((x, y, y), axis=0)
         self.assertEqual(res.gshape, (32 + 16, 15, 14))
@@ -273,13 +278,13 @@ class TestManipulations(unittest.TestCase):
 
         # vectors
         # None None 0
-        x = ht.zeros((16,), split=None)
-        y = ht.ones((16,), split=None)
+        x = ht.zeros((16,), split=None, device=ht_device)
+        y = ht.ones((16,), split=None, device=ht_device)
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32,))
         self.assertEqual(res.dtype, ht.float)
         # None 0 0
-        y = ht.ones((16,), split=0)
+        y = ht.ones((16,), split=0, device=ht_device)
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32,))
         self.assertEqual(res.dtype, ht.float)
@@ -289,7 +294,7 @@ class TestManipulations(unittest.TestCase):
         self.assertEqual(res.lshape, tuple(lshape))
 
         # 0 0 0
-        x = ht.ones((16,), split=0, dtype=ht.float64)
+        x = ht.ones((16,), split=0, dtype=ht.float64, device=ht_device)
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32,))
         self.assertEqual(res.dtype, ht.float64)
@@ -298,8 +303,8 @@ class TestManipulations(unittest.TestCase):
         lshape[0] = chk[0].stop - chk[0].start
         self.assertEqual(res.lshape, tuple(lshape))
         # 0 None 0
-        x = ht.ones((16,), split=0)
-        y = ht.ones((16,), split=None, dtype=ht.int64)
+        x = ht.ones((16,), split=0, device=ht_device)
+        y = ht.ones((16,), split=None, dtype=ht.int64, device=ht_device)
         res = ht.concatenate((x, y), axis=0)
         self.assertEqual(res.gshape, (32,))
         self.assertEqual(res.dtype, ht.float64)
@@ -310,7 +315,9 @@ class TestManipulations(unittest.TestCase):
 
         # test raises
         with self.assertRaises(ValueError):
-            ht.concatenate((ht.zeros((6, 3, 5)), ht.zeros((4, 5, 1))))
+            ht.concatenate(
+                (ht.zeros((6, 3, 5), device=ht_device), ht.zeros((4, 5, 1), device=ht_device))
+            )
         with self.assertRaises(TypeError):
             ht.concatenate((x, "5"))
         with self.assertRaises(TypeError):
@@ -318,15 +325,23 @@ class TestManipulations(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.concatenate((x, x), axis=x)
         with self.assertRaises(RuntimeError):
-            ht.concatenate((x, ht.zeros((2, 2))), axis=0)
+            ht.concatenate((x, ht.zeros((2, 2), device=ht_device)), axis=0)
         with self.assertRaises(ValueError):
-            ht.concatenate((ht.zeros((12, 12)), ht.zeros((2, 2))), axis=0)
+            ht.concatenate(
+                (ht.zeros((12, 12), device=ht_device), ht.zeros((2, 2), device=ht_device)), axis=0
+            )
         with self.assertRaises(RuntimeError):
-            ht.concatenate((ht.zeros((2, 2), split=0), ht.zeros((2, 2), split=1)), axis=0)
+            ht.concatenate(
+                (
+                    ht.zeros((2, 2), split=0, device=ht_device),
+                    ht.zeros((2, 2), split=1, device=ht_device),
+                ),
+                axis=0,
+            )
 
     def test_expand_dims(self):
         # vector data
-        a = ht.arange(10)
+        a = ht.arange(10, device=ht_device)
         b = ht.expand_dims(a, 0)
 
         self.assertIsInstance(b, ht.DNDarray)
@@ -341,7 +356,7 @@ class TestManipulations(unittest.TestCase):
         self.assertIs(b.split, None)
 
         # vector data with out-of-bounds axis
-        a = ht.arange(12)
+        a = ht.arange(12, device=ht_device)
         b = a.expand_dims(1)
 
         self.assertIsInstance(b, ht.DNDarray)
@@ -356,7 +371,7 @@ class TestManipulations(unittest.TestCase):
         self.assertIs(b.split, None)
 
         # volume with intermediate axis
-        a = ht.empty((3, 4, 5))
+        a = ht.empty((3, 4, 5), device=ht_device)
         b = a.expand_dims(1)
 
         self.assertIsInstance(b, ht.DNDarray)
@@ -375,7 +390,7 @@ class TestManipulations(unittest.TestCase):
         self.assertIs(b.split, None)
 
         # volume with negative axis
-        a = ht.empty((3, 4, 5))
+        a = ht.empty((3, 4, 5), device=ht_device)
         b = a.expand_dims(-4)
 
         self.assertIsInstance(b, ht.DNDarray)
@@ -394,7 +409,7 @@ class TestManipulations(unittest.TestCase):
         self.assertIs(b.split, None)
 
         # split volume with negative axis expansion after the split
-        a = ht.empty((3, 4, 5), split=1)
+        a = ht.empty((3, 4, 5), split=1, device=ht_device)
         b = a.expand_dims(-2)
 
         self.assertIsInstance(b, ht.DNDarray)
@@ -413,7 +428,7 @@ class TestManipulations(unittest.TestCase):
         self.assertIs(b.split, 1)
 
         # split volume with negative axis expansion before the split
-        a = ht.empty((3, 4, 5), split=2)
+        a = ht.empty((3, 4, 5), split=2, device=ht_device)
         b = a.expand_dims(-3)
 
         self.assertIsInstance(b, ht.DNDarray)
@@ -435,59 +450,59 @@ class TestManipulations(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.expand_dims("(3, 4, 5,)", 1)
         with self.assertRaises(TypeError):
-            ht.empty((3, 4, 5)).expand_dims("1")
+            ht.empty((3, 4, 5), device=ht_device).expand_dims("1")
         with self.assertRaises(ValueError):
-            ht.empty((3, 4, 5)).expand_dims(4)
+            ht.empty((3, 4, 5), device=ht_device).expand_dims(4)
         with self.assertRaises(ValueError):
-            ht.empty((3, 4, 5)).expand_dims(-5)
+            ht.empty((3, 4, 5), device=ht_device).expand_dims(-5)
 
     def test_hstack(self):
         # cases to test:
         # MM===================================
         # NN,
-        a = ht.ones((10, 12), split=None)
-        b = ht.ones((10, 12), split=None)
+        a = ht.ones((10, 12), split=None, device=ht_device)
+        b = ht.ones((10, 12), split=None, device=ht_device)
         res = ht.hstack((a, b))
         self.assertEqual(res.shape, (10, 24))
         # 11,
-        a = ht.ones((10, 12), split=1)
-        b = ht.ones((10, 12), split=1)
+        a = ht.ones((10, 12), split=1, device=ht_device)
+        b = ht.ones((10, 12), split=1, device=ht_device)
         res = ht.hstack((a, b))
         self.assertEqual(res.shape, (10, 24))
 
         # VM===================================
         # NN,
-        a = ht.ones((12,), split=None)
-        b = ht.ones((12, 10), split=None)
+        a = ht.ones((12,), split=None, device=ht_device)
+        b = ht.ones((12, 10), split=None, device=ht_device)
         res = ht.hstack((a, b))
         self.assertEqual(res.shape, (12, 11))
         # 00
-        a = ht.ones((12,), split=0)
-        b = ht.ones((12, 10), split=0)
+        a = ht.ones((12,), split=0, device=ht_device)
+        b = ht.ones((12, 10), split=0, device=ht_device)
         res = ht.hstack((a, b))
         self.assertEqual(res.shape, (12, 11))
 
         # MV===================================
         # NN,
-        a = ht.ones((12, 10), split=None)
-        b = ht.ones((12,), split=None)
+        a = ht.ones((12, 10), split=None, device=ht_device)
+        b = ht.ones((12,), split=None, device=ht_device)
         res = ht.hstack((a, b))
         self.assertEqual(res.shape, (12, 11))
         # 00
-        a = ht.ones((12, 10), split=0)
-        b = ht.ones((12,), split=0)
+        a = ht.ones((12, 10), split=0, device=ht_device)
+        b = ht.ones((12,), split=0, device=ht_device)
         res = ht.hstack((a, b))
         self.assertEqual(res.shape, (12, 11))
 
         # VV===================================
         # NN,
-        a = ht.ones((12,), split=None)
-        b = ht.ones((12,), split=None)
+        a = ht.ones((12,), split=None, device=ht_device)
+        b = ht.ones((12,), split=None, device=ht_device)
         res = ht.hstack((a, b))
         self.assertEqual(res.shape, (24,))
         # 00
-        a = ht.ones((12,), split=0)
-        b = ht.ones((12,), split=0)
+        a = ht.ones((12,), split=0, device=ht_device)
+        b = ht.ones((12,), split=0, device=ht_device)
         res = ht.hstack((a, b))
         self.assertEqual(res.shape, (24,))
 
@@ -496,7 +511,7 @@ class TestManipulations(unittest.TestCase):
         rank = ht.MPI_WORLD.rank
         tensor = torch.arange(size, device=device).repeat(size).reshape(size, size)
 
-        data = ht.array(tensor, split=None)
+        data = ht.array(tensor, split=None, device=ht_device)
         result, result_indices = ht.sort(data, axis=0, descending=True)
         expected, exp_indices = torch.sort(tensor, dim=0, descending=True)
         self.assertTrue(torch.equal(result._DNDarray__array, expected))
@@ -507,7 +522,7 @@ class TestManipulations(unittest.TestCase):
         self.assertTrue(torch.equal(result._DNDarray__array, expected))
         self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
 
-        data = ht.array(tensor, split=0)
+        data = ht.array(tensor, split=0, device=ht_device)
 
         exp_axis_zero = torch.arange(size, device=device).reshape(1, size)
         exp_indices = torch.tensor([[rank] * size], device=device)
@@ -527,7 +542,7 @@ class TestManipulations(unittest.TestCase):
         self.assertTrue(ht.equal(result1[0], result2[0]))
         self.assertTrue(ht.equal(result1[1], result2[1]))
 
-        data = ht.array(tensor, split=1)
+        data = ht.array(tensor, split=1, device=ht_device)
 
         exp_axis_zero = torch.tensor(rank, device=device).repeat(size).reshape(size, 1)
         indices_axis_zero = torch.arange(size, dtype=torch.int64, device=device).reshape(size, 1)
@@ -553,7 +568,7 @@ class TestManipulations(unittest.TestCase):
             device=device,
         )
 
-        data = ht.array(tensor, split=0)
+        data = ht.array(tensor, split=0, device=ht_device)
         exp_axis_zero = torch.tensor([[2, 3, 0], [0, 2, 3]], dtype=torch.int32, device=device)
         if torch.cuda.is_available() and data.device == ht.gpu and size < 4:
             indices_axis_zero = torch.tensor(
@@ -570,7 +585,7 @@ class TestManipulations(unittest.TestCase):
             self.assertTrue(torch.equal(first, exp_axis_zero))
             self.assertTrue(torch.equal(first_indices, indices_axis_zero))
 
-        data = ht.array(tensor, split=1)
+        data = ht.array(tensor, split=1, device=ht_device)
         exp_axis_one = torch.tensor([[2, 2, 3]], dtype=torch.int32, device=device)
         indices_axis_one = torch.tensor([[0, 1, 1]], dtype=torch.int32, device=device)
         result, result_indices = ht.sort(data, axis=1)
@@ -580,7 +595,7 @@ class TestManipulations(unittest.TestCase):
             self.assertTrue(torch.equal(first, exp_axis_one))
             self.assertTrue(torch.equal(first_indices, indices_axis_one))
 
-        data = ht.array(tensor, split=2)
+        data = ht.array(tensor, split=2, device=ht_device)
         exp_axis_two = torch.tensor([[2], [2]], dtype=torch.int32, device=device)
         indices_axis_two = torch.tensor([[0], [1]], dtype=torch.int32, device=device)
         result, result_indices = ht.sort(data, axis=2)
@@ -590,7 +605,7 @@ class TestManipulations(unittest.TestCase):
             self.assertTrue(torch.equal(first, exp_axis_two))
             self.assertTrue(torch.equal(first_indices, indices_axis_two))
         #
-        out = ht.empty_like(data)
+        out = ht.empty_like(data, device=ht_device)
         indices = ht.sort(data, axis=2, out=out)
         self.assertTrue(ht.equal(out, result))
         self.assertTrue(ht.equal(indices, result_indices))
@@ -601,7 +616,7 @@ class TestManipulations(unittest.TestCase):
             ht.sort(data, axis="1")
 
         rank = ht.MPI_WORLD.rank
-        data = ht.random.randn(100, 1, split=0)
+        data = ht.random.randn(100, 1, split=0, device=ht_device)
         result, _ = ht.sort(data, axis=0)
         counts, _, _ = ht.get_comm().counts_displs_shape(data.gshape, axis=0)
         for i, c in enumerate(counts):
@@ -615,7 +630,7 @@ class TestManipulations(unittest.TestCase):
 
     def test_squeeze(self):
         torch.manual_seed(1)
-        data = ht.random.randn(1, 4, 5, 1)
+        data = ht.random.randn(1, 4, 5, 1, device=ht_device)
 
         # 4D local tensor, no axis
         result = ht.squeeze(data)
@@ -672,7 +687,7 @@ class TestManipulations(unittest.TestCase):
 
         # 3D split tensor, across the axis
         size = ht.MPI_WORLD.size * 2
-        data = ht.triu(ht.ones((1, size, size), split=1), k=1)
+        data = ht.triu(ht.ones((1, size, size), split=1, device=ht_device), k=1)
 
         result = ht.squeeze(data, axis=0)
         self.assertIsInstance(result, ht.DNDarray)
@@ -697,39 +712,39 @@ class TestManipulations(unittest.TestCase):
         size = ht.MPI_WORLD.size
         rank = ht.MPI_WORLD.rank
         torch_array = torch.arange(size, dtype=torch.int32, device=device).expand(size, size)
-        split_zero = ht.array(torch_array, split=0)
+        split_zero = ht.array(torch_array, split=0, device=ht_device)
 
-        exp_axis_none = ht.array([rank], dtype=ht.int32)
+        exp_axis_none = ht.array([rank], dtype=ht.int32, device=ht_device)
         res = split_zero.unique(sorted=True)
         self.assertTrue((res._DNDarray__array == exp_axis_none._DNDarray__array).all())
 
-        exp_axis_zero = ht.arange(size, dtype=ht.int32).expand_dims(0)
+        exp_axis_zero = ht.arange(size, dtype=ht.int32, device=ht_device).expand_dims(0)
         res = ht.unique(split_zero, sorted=True, axis=0)
         self.assertTrue((res._DNDarray__array == exp_axis_zero._DNDarray__array).all())
 
-        exp_axis_one = ht.array([rank], dtype=ht.int32).expand_dims(0)
-        split_zero_transposed = ht.array(torch_array.transpose(0, 1), split=0)
+        exp_axis_one = ht.array([rank], dtype=ht.int32, device=ht_device).expand_dims(0)
+        split_zero_transposed = ht.array(torch_array.transpose(0, 1), split=0, device=ht_device)
         res = ht.unique(split_zero_transposed, sorted=False, axis=1)
         self.assertTrue((res._DNDarray__array == exp_axis_one._DNDarray__array).all())
 
-        split_one = ht.array(torch_array, dtype=ht.int32, split=1)
+        split_one = ht.array(torch_array, dtype=ht.int32, split=1, device=ht_device)
 
-        exp_axis_none = ht.arange(size, dtype=ht.int32)
+        exp_axis_none = ht.arange(size, dtype=ht.int32, device=ht_device)
         res = ht.unique(split_one, sorted=True)
         self.assertTrue((res._DNDarray__array == exp_axis_none._DNDarray__array).all())
 
-        exp_axis_zero = ht.array([rank], dtype=ht.int32).expand_dims(0)
+        exp_axis_zero = ht.array([rank], dtype=ht.int32, device=ht_device).expand_dims(0)
         res = ht.unique(split_one, sorted=False, axis=0)
         self.assertTrue((res._DNDarray__array == exp_axis_zero._DNDarray__array).all())
 
-        exp_axis_one = ht.array([rank] * size, dtype=ht.int32).expand_dims(1)
+        exp_axis_one = ht.array([rank] * size, dtype=ht.int32, device=ht_device).expand_dims(1)
         res = ht.unique(split_one, sorted=True, axis=1)
         self.assertTrue((res._DNDarray__array == exp_axis_one._DNDarray__array).all())
 
         torch_array = torch.tensor(
             [[1, 2], [2, 3], [1, 2], [2, 3], [1, 2]], dtype=torch.int32, device=device
         )
-        data = ht.array(torch_array, split=0)
+        data = ht.array(torch_array, split=0, device=ht_device)
 
         res, inv = ht.unique(data, return_inverse=True, axis=0)
         _, exp_inv = torch_array.unique(dim=0, return_inverse=True, sorted=True)
@@ -746,18 +761,18 @@ class TestManipulations(unittest.TestCase):
         )
         exp_res, exp_inv = torch_array.unique(return_inverse=True, sorted=True)
 
-        data_split_none = ht.array(torch_array)
+        data_split_none = ht.array(torch_array, device=ht_device)
         res, inv = ht.unique(data_split_none, return_inverse=True, sorted=True)
         self.assertTrue(torch.equal(inv, exp_inv.to(dtype=inv.dtype)))
 
-        data_split_zero = ht.array(torch_array, split=0)
+        data_split_zero = ht.array(torch_array, split=0, device=ht_device)
         res, inv = ht.unique(data_split_zero, return_inverse=True, sorted=True)
         self.assertTrue(torch.equal(inv, exp_inv.to(dtype=inv.dtype)))
 
     def test_resplit(self):
         # resplitting with same axis, should leave everything unchanged
         shape = (ht.MPI_WORLD.size, ht.MPI_WORLD.size)
-        data = ht.zeros(shape, split=None)
+        data = ht.zeros(shape, split=None, device=ht_device)
         data2 = ht.resplit(data, None)
 
         self.assertIsInstance(data2, ht.DNDarray)
@@ -767,7 +782,7 @@ class TestManipulations(unittest.TestCase):
 
         # resplitting with same axis, should leave everything unchanged
         shape = (ht.MPI_WORLD.size, ht.MPI_WORLD.size)
-        data = ht.zeros(shape, split=1)
+        data = ht.zeros(shape, split=1, device=ht_device)
         data2 = ht.resplit(data, 1)
 
         self.assertIsInstance(data2, ht.DNDarray)
@@ -777,7 +792,7 @@ class TestManipulations(unittest.TestCase):
 
         # splitting an unsplit tensor should result in slicing the tensor locally
         shape = (ht.MPI_WORLD.size, ht.MPI_WORLD.size)
-        data = ht.zeros(shape)
+        data = ht.zeros(shape, device=ht_device)
         data2 = ht.resplit(data, 1)
 
         self.assertIsInstance(data2, ht.DNDarray)
@@ -787,7 +802,7 @@ class TestManipulations(unittest.TestCase):
 
         # unsplitting, aka gathering a tensor
         shape = (ht.MPI_WORLD.size + 1, ht.MPI_WORLD.size)
-        data = ht.ones(shape, split=0)
+        data = ht.ones(shape, split=0, device=ht_device)
         data2 = ht.resplit(data, None)
 
         self.assertIsInstance(data2, ht.DNDarray)
@@ -797,7 +812,7 @@ class TestManipulations(unittest.TestCase):
 
         # assign and entirely new split axis
         shape = (ht.MPI_WORLD.size + 2, ht.MPI_WORLD.size + 1)
-        data = ht.ones(shape, split=0)
+        data = ht.ones(shape, split=0, device=ht_device)
         data2 = ht.resplit(data, 1)
 
         self.assertIsInstance(data2, ht.DNDarray)
@@ -857,48 +872,48 @@ class TestManipulations(unittest.TestCase):
         # cases to test:
         # MM===================================
         # NN,
-        a = ht.ones((10, 12), split=None)
-        b = ht.ones((10, 12), split=None)
+        a = ht.ones((10, 12), split=None, device=ht_device)
+        b = ht.ones((10, 12), split=None, device=ht_device)
         res = ht.vstack((a, b))
         self.assertEqual(res.shape, (20, 12))
         # 11,
-        a = ht.ones((10, 12), split=1)
-        b = ht.ones((10, 12), split=1)
+        a = ht.ones((10, 12), split=1, device=ht_device)
+        b = ht.ones((10, 12), split=1, device=ht_device)
         res = ht.vstack((a, b))
         self.assertEqual(res.shape, (20, 12))
 
         # VM===================================
         # NN,
-        a = ht.ones((10,), split=None)
-        b = ht.ones((12, 10), split=None)
+        a = ht.ones((10,), split=None, device=ht_device)
+        b = ht.ones((12, 10), split=None, device=ht_device)
         res = ht.vstack((a, b))
         self.assertEqual(res.shape, (13, 10))
         # 00
-        a = ht.ones((10,), split=0)
-        b = ht.ones((12, 10), split=0)
+        a = ht.ones((10,), split=0, device=ht_device)
+        b = ht.ones((12, 10), split=0, device=ht_device)
         res = ht.vstack((a, b))
         self.assertEqual(res.shape, (13, 10))
 
         # MV===================================
         # NN,
-        a = ht.ones((12, 10), split=None)
-        b = ht.ones((10,), split=None)
+        a = ht.ones((12, 10), split=None, device=ht_device)
+        b = ht.ones((10,), split=None, device=ht_device)
         res = ht.vstack((a, b))
         self.assertEqual(res.shape, (13, 10))
         # 00
-        a = ht.ones((12, 10), split=0)
-        b = ht.ones((10,), split=0)
+        a = ht.ones((12, 10), split=0, device=ht_device)
+        b = ht.ones((10,), split=0, device=ht_device)
         res = ht.vstack((a, b))
         self.assertEqual(res.shape, (13, 10))
 
         # VV===================================
         # NN,
-        a = ht.ones((12,), split=None)
-        b = ht.ones((12,), split=None)
+        a = ht.ones((12,), split=None, device=ht_device)
+        b = ht.ones((12,), split=None, device=ht_device)
         res = ht.vstack((a, b))
         self.assertEqual(res.shape, (2, 12))
         # 00
-        a = ht.ones((12,), split=0)
-        b = ht.ones((12,), split=0)
+        a = ht.ones((12,), split=0, device=ht_device)
+        b = ht.ones((12,), split=0, device=ht_device)
         res = ht.vstack((a, b))
         self.assertEqual(res.shape, (2, 12))

--- a/heat/core/tests/test_memory.py
+++ b/heat/core/tests/test_memory.py
@@ -1,6 +1,8 @@
 import unittest
-
+import os
 import heat as ht
+
+ht.use_device(os.environ.get("DEVICE"))
 
 
 class TestMemory(unittest.TestCase):

--- a/heat/core/tests/test_memory.py
+++ b/heat/core/tests/test_memory.py
@@ -35,15 +35,15 @@ class TestMemory(BasicTest):
 
     def test_sanitize_memory_layout(self):
         # non distributed, 2D
-        a_torch = torch.arange(12).reshape(4, 3)
-        a_heat_C = ht.array(a_torch)
-        a_heat_F = ht.array(a_torch, order="F")
+        a_torch = torch.arange(12, device=device).reshape(4, 3)
+        a_heat_C = ht.array(a_torch, device=ht_device)
+        a_heat_F = ht.array(a_torch, order="F", device=ht_device)
         self.assertTrue_memory_layout(a_heat_C, "C")
         self.assertTrue_memory_layout(a_heat_F, "F")
         # non distributed, 5D
-        a_torch_5d = torch.arange(4 * 3 * 5 * 2 * 1).reshape(4, 3, 1, 2, 5)
-        a_heat_5d_C = ht.array(a_torch_5d)
-        a_heat_5d_F = ht.array(a_torch_5d, order="F")
+        a_torch_5d = torch.arange(4 * 3 * 5 * 2 * 1, device=device).reshape(4, 3, 1, 2, 5)
+        a_heat_5d_C = ht.array(a_torch_5d, device=ht_device)
+        a_heat_5d_F = ht.array(a_torch_5d, order="F", device=ht_device)
         self.assertTrue_memory_layout(a_heat_5d_C, "C")
         self.assertTrue_memory_layout(a_heat_5d_F, "F")
         a_heat_5d_F_sum = a_heat_5d_F.sum(-2)
@@ -51,34 +51,36 @@ class TestMemory(BasicTest):
         self.assert_array_equal(a_heat_5d_F_sum, a_torch_5d_sum)
         # distributed, split, 2D
         size = ht.communication.MPI_WORLD.size
-        a_torch_2d = torch.arange(4 * size * 3 * size).reshape(4 * size, 3 * size)
-        a_heat_2d_C_split = ht.array(a_torch_2d, split=0)
-        a_heat_2d_F_split = ht.array(a_torch_2d, split=1, order="F")
+        a_torch_2d = torch.arange(4 * size * 3 * size, device=device).reshape(4 * size, 3 * size)
+        a_heat_2d_C_split = ht.array(a_torch_2d, split=0, device=ht_device)
+        a_heat_2d_F_split = ht.array(a_torch_2d, split=1, order="F", device=ht_device)
         self.assertTrue_memory_layout(a_heat_2d_C_split, "C")
         self.assertTrue_memory_layout(a_heat_2d_F_split, "F")
         a_heat_2d_F_split_sum = a_heat_2d_F_split.sum(1)
         a_torch_2d_sum = a_torch_2d.sum(1)
         self.assert_array_equal(a_heat_2d_F_split_sum, a_torch_2d_sum)
         # distributed, split, 5D
-        a_torch_5d = torch.arange(4 * 3 * 5 * 2 * size * 7).reshape(4, 3, 7, 2 * size, 5)
-        a_heat_5d_C_split = ht.array(a_torch_5d, split=-2)
-        a_heat_5d_F_split = ht.array(a_torch_5d, split=-2, order="F")
+        a_torch_5d = torch.arange(4 * 3 * 5 * 2 * size * 7, device=device).reshape(
+            4, 3, 7, 2 * size, 5
+        )
+        a_heat_5d_C_split = ht.array(a_torch_5d, split=-2, device=ht_device)
+        a_heat_5d_F_split = ht.array(a_torch_5d, split=-2, order="F", device=ht_device)
         self.assertTrue_memory_layout(a_heat_5d_C_split, "C")
         self.assertTrue_memory_layout(a_heat_5d_F_split, "F")
         a_heat_5d_F_split_sum = a_heat_5d_F_split.sum(-2)
         a_torch_5d_sum = a_torch_5d.sum(-2)
         self.assert_array_equal(a_heat_5d_F_split_sum, a_torch_5d_sum)
         # distributed, is_split, 2D
-        a_heat_2d_C_issplit = ht.array(a_torch_2d, is_split=0)
-        a_heat_2d_F_issplit = ht.array(a_torch_2d, is_split=1, order="F")
+        a_heat_2d_C_issplit = ht.array(a_torch_2d, is_split=0, device=ht_device)
+        a_heat_2d_F_issplit = ht.array(a_torch_2d, is_split=1, order="F", device=ht_device)
         self.assertTrue_memory_layout(a_heat_2d_C_issplit, "C")
         self.assertTrue_memory_layout(a_heat_2d_F_issplit, "F")
         a_heat_2d_F_issplit_sum = a_heat_2d_F_issplit.sum(1)
         a_torch_2d_sum = a_torch_2d.sum(1) * size
         self.assert_array_equal(a_heat_2d_F_issplit_sum, a_torch_2d_sum)
         # distributed, is_split, 5D
-        a_heat_5d_C_issplit = ht.array(a_torch_5d, is_split=-2)
-        a_heat_5d_F_issplit = ht.array(a_torch_5d, is_split=-2, order="F")
+        a_heat_5d_C_issplit = ht.array(a_torch_5d, is_split=-2, device=ht_device)
+        a_heat_5d_F_issplit = ht.array(a_torch_5d, is_split=-2, order="F", device=ht_device)
         self.assertTrue_memory_layout(a_heat_5d_C_issplit, "C")
         self.assertTrue_memory_layout(a_heat_5d_F_issplit, "F")
         a_heat_5d_F_issplit_sum = a_heat_5d_F_issplit.sum(-2)

--- a/heat/core/tests/test_memory.py
+++ b/heat/core/tests/test_memory.py
@@ -2,7 +2,12 @@ import unittest
 import os
 import heat as ht
 
-ht.use_device(os.environ.get("DEVICE"))
+if os.environ.get("DEVICE") == "gpu":
+    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+    ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
+else:
+    ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestMemory(unittest.TestCase):

--- a/heat/core/tests/test_memory.py
+++ b/heat/core/tests/test_memory.py
@@ -2,17 +2,22 @@ import unittest
 import os
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and ht.torch.cuda.is_available():
+    ht.use_device("gpu")
     ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and ht.torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    ht.torch.cuda.set_device(device)
 
 
 class TestMemory(unittest.TestCase):
     def test_copy(self):
-        tensor = ht.ones(5)
+        tensor = ht.ones(5, device=ht_device)
         copied = tensor.copy()
 
         # test identity inequality and value equality

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -1,7 +1,14 @@
 import unittest
 import torch
-
+import os
 import heat as ht
+
+if os.environ.get("DEVICE") == "gpu":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+else:
+    device = torch.device("cpu")
+    ht.use_device("cpu")
 
 
 class TestOperations(unittest.TestCase):

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -3,123 +3,131 @@ import torch
 import os
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestOperations(unittest.TestCase):
     def test___binary_op_broadcast(self):
 
         # broadcast without split
-        left_tensor = ht.ones((4, 1))
-        right_tensor = ht.ones((1, 2))
+        left_tensor = ht.ones((4, 1), device=ht_device)
+        right_tensor = ht.ones((1, 2), device=ht_device)
         result = left_tensor + right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor + left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with split=0 for both operants
-        left_tensor = ht.ones((4, 1), split=0)
-        right_tensor = ht.ones((1, 2), split=0)
+        left_tensor = ht.ones((4, 1), split=0, device=ht_device)
+        right_tensor = ht.ones((1, 2), split=0, device=ht_device)
         result = left_tensor + right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor + left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with split=1 for both operants
-        left_tensor = ht.ones((4, 1), split=1)
-        right_tensor = ht.ones((1, 2), split=1)
+        left_tensor = ht.ones((4, 1), split=1, device=ht_device)
+        right_tensor = ht.ones((1, 2), split=1, device=ht_device)
         result = left_tensor + right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor + left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with split=1 for second operant
-        left_tensor = ht.ones((4, 1))
-        right_tensor = ht.ones((1, 2), split=1)
+        left_tensor = ht.ones((4, 1), device=ht_device)
+        right_tensor = ht.ones((1, 2), split=1, device=ht_device)
         result = left_tensor - right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor + left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with split=0 for first operant
-        left_tensor = ht.ones((4, 1), split=0)
-        right_tensor = ht.ones((1, 2))
+        left_tensor = ht.ones((4, 1), split=0, device=ht_device)
+        right_tensor = ht.ones((1, 2), device=ht_device)
         result = left_tensor - right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor + left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with unequal dimensions and one splitted tensor
-        left_tensor = ht.ones((2, 4, 1), split=0)
-        right_tensor = ht.ones((1, 2))
+        left_tensor = ht.ones((2, 4, 1), split=0, device=ht_device)
+        right_tensor = ht.ones((1, 2), device=ht_device)
         result = left_tensor + right_tensor
         self.assertEqual(result.shape, (2, 4, 2))
         result = right_tensor - left_tensor
         self.assertEqual(result.shape, (2, 4, 2))
 
         # broadcast with unequal dimensions and two splitted tensors
-        left_tensor = ht.ones((4, 1, 3, 1, 2), split=0, dtype=torch.uint8)
-        right_tensor = ht.ones((1, 3, 1), split=0, dtype=torch.uint8)
+        left_tensor = ht.ones((4, 1, 3, 1, 2), split=0, dtype=torch.uint8, device=ht_device)
+        right_tensor = ht.ones((1, 3, 1), split=0, dtype=torch.uint8, device=ht_device)
         result = left_tensor + right_tensor
         self.assertEqual(result.shape, (4, 1, 3, 3, 2))
         result = right_tensor + left_tensor
         self.assertEqual(result.shape, (4, 1, 3, 3, 2))
 
         with self.assertRaises(TypeError):
-            ht.add(ht.ones((1, 2)), "wrong type")
+            ht.add(ht.ones((1, 2), device=ht_device), "wrong type")
         with self.assertRaises(NotImplementedError):
-            ht.add(ht.ones((1, 2), split=0), ht.ones((1, 2), split=1))
+            ht.add(
+                ht.ones((1, 2), split=0, device=ht_device),
+                ht.ones((1, 2), split=1, device=ht_device),
+            )
 
     def test___binary_bit_op_broadcast(self):
 
         # broadcast without split
-        left_tensor = ht.ones((4, 1), dtype=ht.int32)
-        right_tensor = ht.ones((1, 2), dtype=ht.int32)
+        left_tensor = ht.ones((4, 1), dtype=ht.int32, device=ht_device)
+        right_tensor = ht.ones((1, 2), dtype=ht.int32, device=ht_device)
         result = left_tensor & right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor & left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with split=0 for both operants
-        left_tensor = ht.ones((4, 1), split=0, dtype=ht.int32)
-        right_tensor = ht.ones((1, 2), split=0, dtype=ht.int32)
+        left_tensor = ht.ones((4, 1), split=0, dtype=ht.int32, device=ht_device)
+        right_tensor = ht.ones((1, 2), split=0, dtype=ht.int32, device=ht_device)
         result = left_tensor | right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor | left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with split=1 for both operants
-        left_tensor = ht.ones((4, 1), split=1, dtype=ht.int32)
-        right_tensor = ht.ones((1, 2), split=1, dtype=ht.int32)
+        left_tensor = ht.ones((4, 1), split=1, dtype=ht.int32, device=ht_device)
+        right_tensor = ht.ones((1, 2), split=1, dtype=ht.int32, device=ht_device)
         result = left_tensor ^ right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor ^ left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with split=1 for second operant
-        left_tensor = ht.ones((4, 1), dtype=ht.int32)
-        right_tensor = ht.ones((1, 2), split=1, dtype=ht.int32)
+        left_tensor = ht.ones((4, 1), dtype=ht.int32, device=ht_device)
+        right_tensor = ht.ones((1, 2), split=1, dtype=ht.int32, device=ht_device)
         result = left_tensor & right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor & left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with split=0 for first operant
-        left_tensor = ht.ones((4, 1), split=0, dtype=ht.int32)
-        right_tensor = ht.ones((1, 2), dtype=ht.int32)
+        left_tensor = ht.ones((4, 1), split=0, dtype=ht.int32, device=ht_device)
+        right_tensor = ht.ones((1, 2), dtype=ht.int32, device=ht_device)
         result = left_tensor | right_tensor
         self.assertEqual(result.shape, (4, 2))
         result = right_tensor | left_tensor
         self.assertEqual(result.shape, (4, 2))
 
         # broadcast with unequal dimensions and one splitted tensor
-        left_tensor = ht.ones((2, 4, 1), split=0, dtype=ht.int32)
-        right_tensor = ht.ones((1, 2), dtype=ht.int32)
+        left_tensor = ht.ones((2, 4, 1), split=0, dtype=ht.int32, device=ht_device)
+        right_tensor = ht.ones((1, 2), dtype=ht.int32, device=ht_device)
         result = left_tensor ^ right_tensor
         self.assertEqual(result.shape, (2, 4, 2))
         result = right_tensor ^ left_tensor
@@ -127,21 +135,24 @@ class TestOperations(unittest.TestCase):
 
         # broadcast with unequal dimensions, a scalar, and one splitted tensor
         left_scalar = ht.np.int32(1)
-        right_tensor = ht.ones((1, 2), split=0, dtype=ht.int32)
+        right_tensor = ht.ones((1, 2), split=0, dtype=ht.int32, device=ht_device)
         result = ht.bitwise_or(left_scalar, right_tensor)
         self.assertEqual(result.shape, (1, 2))
         result = right_tensor | left_scalar
         self.assertEqual(result.shape, (1, 2))
 
         # broadcast with unequal dimensions and two splitted tensors
-        left_tensor = ht.ones((4, 1, 3, 1, 2), split=0, dtype=torch.uint8)
-        right_tensor = ht.ones((1, 3, 1), split=0, dtype=torch.uint8)
+        left_tensor = ht.ones((4, 1, 3, 1, 2), split=0, dtype=torch.uint8, device=ht_device)
+        right_tensor = ht.ones((1, 3, 1), split=0, dtype=torch.uint8, device=ht_device)
         result = left_tensor & right_tensor
         self.assertEqual(result.shape, (4, 1, 3, 3, 2))
         result = right_tensor & left_tensor
         self.assertEqual(result.shape, (4, 1, 3, 3, 2))
 
         with self.assertRaises(TypeError):
-            ht.add(ht.ones((1, 2)), "wrong type")
+            ht.bitwise_and(ht.ones((1, 2), device=ht_device), "wrong type")
         with self.assertRaises(NotImplementedError):
-            ht.add(ht.ones((1, 2), split=0), ht.ones((1, 2), split=1))
+            ht.bitwise_or(
+                ht.ones((1, 2), split=0, device=ht_device),
+                ht.ones((1, 2), split=1, device=ht_device),
+            )

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -4,11 +4,11 @@ import os
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestOperations(unittest.TestCase):

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -6,7 +6,12 @@ import torch
 import heat as ht
 import numpy as np
 
-ht.use_device(os.environ.get("DEVICE"))
+if os.environ.get("DEVICE") == "gpu":
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
+else:
+    ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestRandom(unittest.TestCase):

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -6,12 +6,17 @@ import torch
 import heat as ht
 import numpy as np
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestRandom(unittest.TestCase):
@@ -21,20 +26,22 @@ class TestRandom(unittest.TestCase):
         # Resetting seed works
         seed = 12345
         ht.random.seed(seed)
-        a = ht.random.rand(2, 5, 7, 3, split=0, comm=ht.MPI_WORLD)
+        a = ht.random.rand(2, 5, 7, 3, split=0, comm=ht.MPI_WORLD, device=ht_device)
         self.assertEqual(a.dtype, ht.float64)
         self.assertEqual(a._DNDarray__array.dtype, torch.float64)
-        b = ht.random.rand(2, 5, 7, 3, split=0, comm=ht.MPI_WORLD)
+        b = ht.random.rand(2, 5, 7, 3, split=0, comm=ht.MPI_WORLD, device=ht_device)
         self.assertFalse(ht.equal(a, b))
         ht.random.seed(seed)
-        c = ht.random.rand(2, 5, 7, 3, dtype=ht.float64, split=0, comm=ht.MPI_WORLD)
+        c = ht.random.rand(
+            2, 5, 7, 3, dtype=ht.float64, split=0, comm=ht.MPI_WORLD, device=ht_device
+        )
         self.assertTrue(ht.equal(a, c))
 
         # Random numbers with overflow
         ht.random.set_state(("Threefry", seed, 0xFFFFFFFFFFFFFFF0))
-        a = ht.random.rand(2, 3, 4, 5, split=0, comm=ht.MPI_WORLD)
+        a = ht.random.rand(2, 3, 4, 5, split=0, comm=ht.MPI_WORLD, device=ht_device)
         ht.random.set_state(("Threefry", seed, 0x10000000000000000))
-        b = ht.random.rand(2, 44, split=0, comm=ht.MPI_WORLD)
+        b = ht.random.rand(2, 44, split=0, comm=ht.MPI_WORLD, device=ht_device)
         a = a.numpy().flatten()
         b = b.numpy().flatten()
         self.assertEqual(a.dtype, np.float64)
@@ -43,54 +50,54 @@ class TestRandom(unittest.TestCase):
         # Check that random numbers don't repeat after first overflow
         seed = 12345
         ht.random.set_state(("Threefry", seed, 0x10000000000000000))
-        a = ht.random.rand(2, 44)
+        a = ht.random.rand(2, 44, device=ht_device)
         ht.random.seed(seed)
-        b = ht.random.rand(2, 44)
+        b = ht.random.rand(2, 44, device=ht_device)
         self.assertFalse(ht.equal(a, b))
 
         # Check that we start from beginning after 128 bit overflow
         ht.random.seed(seed)
-        a = ht.random.rand(2, 34, split=0)
+        a = ht.random.rand(2, 34, split=0, device=ht_device)
         ht.random.set_state(("Threefry", seed, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0))
-        b = ht.random.rand(2, 50, split=0)
+        b = ht.random.rand(2, 50, split=0, device=ht_device)
         a = a.numpy().flatten()
         b = b.numpy().flatten()
         self.assertTrue(np.array_equal(a, b[32:]))
 
         # different split axis with resetting seed
         ht.random.seed(seed)
-        a = ht.random.rand(3, 5, 2, 9, split=3, comm=ht.MPI_WORLD)
+        a = ht.random.rand(3, 5, 2, 9, split=3, comm=ht.MPI_WORLD, device=ht_device)
         ht.random.seed(seed)
-        c = ht.random.rand(3, 5, 2, 9, split=3, comm=ht.MPI_WORLD)
+        c = ht.random.rand(3, 5, 2, 9, split=3, comm=ht.MPI_WORLD, device=ht_device)
         self.assertTrue(ht.equal(a, c))
 
         # Random values are in correct order
         ht.random.seed(seed)
-        a = ht.random.rand(2, 50, split=0)
+        a = ht.random.rand(2, 50, split=0, device=ht_device)
         ht.random.seed(seed)
-        b = ht.random.rand(100, split=None)
+        b = ht.random.rand(100, split=None, device=ht_device)
         a = a.numpy().flatten()
         b = b._DNDarray__array.cpu().numpy()
         self.assertTrue(np.array_equal(a, b))
 
         # On different shape and split the same random values are used
         ht.random.seed(seed)
-        a = ht.random.rand(3, 5, 2, 9, split=3, comm=ht.MPI_WORLD)
+        a = ht.random.rand(3, 5, 2, 9, split=3, comm=ht.MPI_WORLD, device=ht_device)
         ht.random.seed(seed)
-        b = ht.random.rand(30, 9, split=1, comm=ht.MPI_WORLD)
+        b = ht.random.rand(30, 9, split=1, comm=ht.MPI_WORLD, device=ht_device)
         a = np.sort(a.numpy().flatten())
         b = np.sort(b.numpy().flatten())
         self.assertTrue(np.array_equal(a, b))
 
         # One large array does not have two similar values
-        a = ht.random.rand(11, 15, 3, 7, split=2, comm=ht.MPI_WORLD)
+        a = ht.random.rand(11, 15, 3, 7, split=2, comm=ht.MPI_WORLD, device=ht_device)
         a = a.numpy()
         _, counts = np.unique(a, return_counts=True)
         # Assert that no value appears more than once
         self.assertTrue((counts == 1).all())
 
         # Two large arrays that were created after each other don't share any values
-        b = ht.random.rand(14, 7, 3, 12, 18, 42, split=5, comm=ht.MPI_WORLD)
+        b = ht.random.rand(14, 7, 3, 12, 18, 42, split=5, comm=ht.MPI_WORLD, device=ht_device)
         c = np.concatenate((a.flatten(), b.numpy().flatten()))
         _, counts = np.unique(c, return_counts=True)
         self.assertTrue((counts == 1).all())
@@ -106,35 +113,39 @@ class TestRandom(unittest.TestCase):
 
         # No arguments work correctly
         ht.random.seed(seed)
-        a = ht.random.rand()
+        a = ht.random.rand(device=ht_device)
         ht.random.seed(seed)
-        b = ht.random.rand(1)
+        b = ht.random.rand(1, device=ht_device)
         self.assertTrue(ht.equal(a, b))
 
         # To big arrays cant be created
         with self.assertRaises(ValueError):
-            ht.random.randn(0xFFFFFFFFFFFFFFFF * 2 + 1, comm=ht.MPI_WORLD)
+            ht.random.randn(0xFFFFFFFFFFFFFFFF * 2 + 1, comm=ht.MPI_WORLD, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.random.rand(3, 2, -2, 5, split=1, comm=ht.MPI_WORLD)
+            ht.random.rand(3, 2, -2, 5, split=1, comm=ht.MPI_WORLD, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.random.randn(12, 43, dtype=ht.int32, split=0, comm=ht.MPI_WORLD)
+            ht.random.randn(12, 43, dtype=ht.int32, split=0, comm=ht.MPI_WORLD, device=ht_device)
 
         # 32 Bit tests
         ht.random.seed(9876)
         shape = (13, 43, 13, 23)
-        a = ht.random.rand(*shape, dtype=ht.float32, split=0, comm=ht.MPI_WORLD)
+        a = ht.random.rand(*shape, dtype=ht.float32, split=0, comm=ht.MPI_WORLD, device=ht_device)
         self.assertEqual(a.dtype, ht.float32)
         self.assertEqual(a._DNDarray__array.dtype, torch.float32)
 
         ht.random.seed(9876)
-        b = ht.random.rand(np.prod(shape), dtype=ht.float32, comm=ht.MPI_WORLD)
+        b = ht.random.rand(np.prod(shape), dtype=ht.float32, comm=ht.MPI_WORLD, device=ht_device)
         a = a.numpy().flatten()
         b = b._DNDarray__array.cpu().numpy()
         self.assertTrue(np.array_equal(a, b))
         self.assertEqual(a.dtype, np.float32)
 
-        a = ht.random.rand(21, 16, 17, 21, dtype=ht.float32, split=2, comm=ht.MPI_WORLD)
-        b = ht.random.rand(15, 11, 19, 31, dtype=ht.float32, split=0, comm=ht.MPI_WORLD)
+        a = ht.random.rand(
+            21, 16, 17, 21, dtype=ht.float32, split=2, comm=ht.MPI_WORLD, device=ht_device
+        )
+        b = ht.random.rand(
+            15, 11, 19, 31, dtype=ht.float32, split=0, comm=ht.MPI_WORLD, device=ht_device
+        )
         a = a.numpy().flatten()
         b = b.numpy().flatten()
         c = np.concatenate((a, b))
@@ -149,20 +160,26 @@ class TestRandom(unittest.TestCase):
         self.assertTrue(((0 <= c) & (c < 1)).all())
 
         ht.random.seed(11111)
-        a = ht.random.rand(12, 32, 44, split=1, dtype=ht.float32, comm=ht.MPI_WORLD).numpy()
+        a = ht.random.rand(
+            12, 32, 44, split=1, dtype=ht.float32, comm=ht.MPI_WORLD, device=ht_device
+        ).numpy()
         # Overflow reached
         ht.random.set_state(("Threefry", 11111, 0x10000000000000000))
-        b = ht.random.rand(12, 32, 44, split=1, dtype=ht.float32, comm=ht.MPI_WORLD).numpy()
+        b = ht.random.rand(
+            12, 32, 44, split=1, dtype=ht.float32, comm=ht.MPI_WORLD, device=ht_device
+        ).numpy()
         self.assertTrue(np.array_equal(a, b))
 
         ht.random.set_state(("Threefry", 11111, 0x100000000))
-        c = ht.random.rand(12, 32, 44, split=1, dtype=ht.float32, comm=ht.MPI_WORLD).numpy()
+        c = ht.random.rand(
+            12, 32, 44, split=1, dtype=ht.float32, comm=ht.MPI_WORLD, device=ht_device
+        ).numpy()
         self.assertFalse(np.array_equal(a, c))
         self.assertFalse(np.array_equal(b, c))
 
     def test_randint(self):
         # Checked that the random values are in the correct range
-        a = ht.random.randint(low=0, high=10, size=(10, 10))
+        a = ht.random.randint(low=0, high=10, size=(10, 10), device=ht_device)
         self.assertEqual(a.dtype, ht.int64)
         a = a.numpy()
         self.assertTrue(((0 <= a) & (a < 10)).all())
@@ -172,33 +189,33 @@ class TestRandom(unittest.TestCase):
         self.assertTrue(((100000 <= a) & (a < 150000)).all())
 
         # For the range [0, 1) only the value 0 is allowed
-        a = ht.random.randint(1, size=(10,), split=0)
-        b = ht.zeros((10,), dtype=ht.int64, split=0)
+        a = ht.random.randint(1, size=(10,), split=0, device=ht_device)
+        b = ht.zeros((10,), dtype=ht.int64, split=0, device=ht_device)
         self.assertTrue(ht.equal(a, b))
 
         # Two arrays with the same seed and same number of elements have the same random values
         ht.random.seed(13579)
         shape = (15, 13, 9, 21, 65)
-        a = ht.random.randint(15, 100, size=shape, split=0)
+        a = ht.random.randint(15, 100, size=shape, split=0, device=ht_device)
         a = a.numpy().flatten()
 
         ht.random.seed(13579)
         elements = np.prod(shape)
-        b = ht.random.randint(low=15, high=100, size=(elements,))
+        b = ht.random.randint(low=15, high=100, size=(elements,), device=ht_device)
         b = b.numpy()
         self.assertTrue(np.array_equal(a, b))
 
         # Two arrays with the same seed and shape have identical values
         ht.random.seed(13579)
-        a = ht.random.randint(10000, size=shape, split=2)
+        a = ht.random.randint(10000, size=shape, split=2, device=ht_device)
         a = a.numpy()
 
         ht.random.seed(13579)
-        b = ht.random.randint(low=0, high=10000, size=shape, split=2)
+        b = ht.random.randint(low=0, high=10000, size=shape, split=2, device=ht_device)
         b = b.numpy()
 
         ht.random.seed(13579)
-        c = ht.random.randint(low=0, high=10000)
+        c = ht.random.randint(low=0, high=10000, device=ht_device)
         self.assertTrue(np.equal(b[0, 0, 0, 0, 0], c))
 
         self.assertTrue(np.array_equal(a, b))
@@ -212,17 +229,21 @@ class TestRandom(unittest.TestCase):
         self.assertTrue(std < 2900)
 
         with self.assertRaises(ValueError):
-            ht.random.randint(5, 5, size=(10, 10), split=0)
+            ht.random.randint(5, 5, size=(10, 10), split=0, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.random.randint(low=0, high=10, size=(3, -4))
+            ht.random.randint(low=0, high=10, size=(3, -4), device=ht_device)
         with self.assertRaises(ValueError):
-            ht.random.randint(low=0, high=10, size=(15,), dtype=ht.float32)
+            ht.random.randint(low=0, high=10, size=(15,), dtype=ht.float32, device=ht_device)
 
         # int32 tests
         ht.random.seed(4545)
-        a = ht.random.randint(50, 1000, size=(13, 45), dtype=ht.int32, split=0, comm=ht.MPI_WORLD)
+        a = ht.random.randint(
+            50, 1000, size=(13, 45), dtype=ht.int32, split=0, comm=ht.MPI_WORLD, device=ht_device
+        )
         ht.random.set_state(("Threefry", 4545, 0x10000000000000000))
-        b = ht.random.randint(50, 1000, size=(13, 45), dtype=ht.int32, split=0, comm=ht.MPI_WORLD)
+        b = ht.random.randint(
+            50, 1000, size=(13, 45), dtype=ht.int32, split=0, comm=ht.MPI_WORLD, device=ht_device
+        )
 
         self.assertEqual(a.dtype, ht.int32)
         self.assertEqual(a._DNDarray__array.dtype, torch.int32)
@@ -234,7 +255,9 @@ class TestRandom(unittest.TestCase):
         self.assertTrue(((50 <= a) & (a < 1000)).all())
         self.assertTrue(((50 <= b) & (b < 1000)).all())
 
-        c = ht.random.randint(50, 1000, size=(13, 45), dtype=ht.int32, split=0, comm=ht.MPI_WORLD)
+        c = ht.random.randint(
+            50, 1000, size=(13, 45), dtype=ht.int32, split=0, comm=ht.MPI_WORLD, device=ht_device
+        )
         c = c.numpy()
         self.assertFalse(np.array_equal(a, c))
         self.assertFalse(np.array_equal(b, c))
@@ -242,7 +265,12 @@ class TestRandom(unittest.TestCase):
 
         ht.random.seed(0xFFFFFFF)
         a = ht.random.randint(
-            10000, size=(123, 42, 13, 21), split=3, dtype=ht.int32, comm=ht.MPI_WORLD
+            10000,
+            size=(123, 42, 13, 21),
+            split=3,
+            dtype=ht.int32,
+            comm=ht.MPI_WORLD,
+            device=ht_device,
         )
         a = a.numpy()
         mean = np.mean(a)
@@ -258,7 +286,7 @@ class TestRandom(unittest.TestCase):
         # Test that the random values have the correct distribution
         ht.random.seed(54321)
         shape = (5, 10, 13, 23, 15, 20)
-        a = ht.random.randn(*shape, split=0)
+        a = ht.random.randn(*shape, split=0, device=ht_device)
         self.assertEqual(a.dtype, ht.float64)
         a = a.numpy()
         mean = np.mean(a)
@@ -271,13 +299,13 @@ class TestRandom(unittest.TestCase):
         # Compare to a second array with a different shape but same number of elements and same seed
         ht.random.seed(54321)
         elements = np.prod(shape)
-        b = ht.random.randn(elements, split=0)
+        b = ht.random.randn(elements, split=0, device=ht_device)
         b = b.numpy()
         a = a.flatten()
         self.assertTrue(np.allclose(a, b))
 
         # Creating the same array two times without resetting seed results in different elements
-        c = ht.random.randn(elements, split=0)
+        c = ht.random.randn(elements, split=0, device=ht_device)
         c = c.numpy()
         self.assertEqual(c.shape, b.shape)
         self.assertFalse(np.allclose(b, c))
@@ -289,9 +317,9 @@ class TestRandom(unittest.TestCase):
 
         # Two arrays are the same for same seed and split-axis != 0
         ht.random.seed(12345)
-        a = ht.random.randn(*shape, split=5)
+        a = ht.random.randn(*shape, split=5, device=ht_device)
         ht.random.seed(12345)
-        b = ht.random.randn(*shape, split=5)
+        b = ht.random.randn(*shape, split=5, device=ht_device)
         self.assertTrue(ht.equal(a, b))
         a = a.numpy()
         b = b.numpy()
@@ -299,7 +327,9 @@ class TestRandom(unittest.TestCase):
 
         # Tests with float32
         ht.random.seed(54321)
-        a = ht.random.randn(30, 30, 30, dtype=ht.float32, split=2, comm=ht.MPI_WORLD)
+        a = ht.random.randn(
+            30, 30, 30, dtype=ht.float32, split=2, comm=ht.MPI_WORLD, device=ht_device
+        )
         self.assertEqual(a.dtype, ht.float32)
         self.assertEqual(a._DNDarray__array[0, 0, 0].dtype, torch.float32)
         a = a.numpy()
@@ -312,10 +342,14 @@ class TestRandom(unittest.TestCase):
         self.assertTrue(0.99 < std < 1.01)
 
         ht.random.set_state(("Threefry", 54321, 0x10000000000000000))
-        b = ht.random.randn(30, 30, 30, dtype=ht.float32, split=2, comm=ht.MPI_WORLD).numpy()
+        b = ht.random.randn(
+            30, 30, 30, dtype=ht.float32, split=2, comm=ht.MPI_WORLD, device=ht_device
+        ).numpy()
         self.assertTrue(np.allclose(a, b))
 
-        c = ht.random.randn(30, 30, 30, dtype=ht.float32, split=2, comm=ht.MPI_WORLD).numpy()
+        c = ht.random.randn(
+            30, 30, 30, dtype=ht.float32, split=2, comm=ht.MPI_WORLD, device=ht_device
+        ).numpy()
         self.assertFalse(np.allclose(a, c))
         self.assertFalse(np.allclose(b, c))
 

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -1,9 +1,12 @@
 import unittest
+import os
 
 import torch
 
 import heat as ht
 import numpy as np
+
+ht.use_device(os.environ.get("DEVICE"))
 
 
 class TestRandom(unittest.TestCase):
@@ -62,7 +65,7 @@ class TestRandom(unittest.TestCase):
         ht.random.seed(seed)
         b = ht.random.rand(100, split=None)
         a = a.numpy().flatten()
-        b = b._DNDarray__array.numpy()
+        b = b._DNDarray__array.cpu().numpy()
         self.assertTrue(np.array_equal(a, b))
 
         # On different shape and split the same random values are used
@@ -121,7 +124,7 @@ class TestRandom(unittest.TestCase):
         ht.random.seed(9876)
         b = ht.random.rand(np.prod(shape), dtype=ht.float32, comm=ht.MPI_WORLD)
         a = a.numpy().flatten()
-        b = b._DNDarray__array.numpy()
+        b = b._DNDarray__array.cpu().numpy()
         self.assertTrue(np.array_equal(a, b))
         self.assertEqual(a.dtype, np.float32)
 

--- a/heat/core/tests/test_relational.py
+++ b/heat/core/tests/test_relational.py
@@ -2,7 +2,12 @@ import unittest
 import os
 import heat as ht
 
-ht.use_device(os.environ.get("DEVICE"))
+if os.environ.get("DEVICE") == "gpu":
+    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+    ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
+else:
+    ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestRelational(unittest.TestCase):

--- a/heat/core/tests/test_relational.py
+++ b/heat/core/tests/test_relational.py
@@ -1,6 +1,8 @@
 import unittest
-
+import os
 import heat as ht
+
+ht.use_device(os.environ.get("DEVICE"))
 
 
 class TestRelational(unittest.TestCase):

--- a/heat/core/tests/test_rounding.py
+++ b/heat/core/tests/test_rounding.py
@@ -2,6 +2,14 @@ import torch
 import unittest
 import numpy as np
 import heat as ht
+import os
+
+if os.environ.get("DEVICE") == "gpu":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+else:
+    device = torch.device("cpu")
+    ht.use_device("cpu")
 
 
 class TestRounding(unittest.TestCase):
@@ -87,7 +95,7 @@ class TestRounding(unittest.TestCase):
 
     def test_ceil(self):
         start, end, step = -5.0, 5.0, 1.4
-        comparison = torch.arange(start, end, step, dtype=torch.float64).ceil()
+        comparison = torch.arange(start, end, step, dtype=torch.float64, device=device).ceil()
 
         # exponential of float32
         float32_tensor = ht.arange(start, end, step, dtype=ht.float32)
@@ -130,15 +138,15 @@ class TestRounding(unittest.TestCase):
 
         # test the exceptions
         with self.assertRaises(TypeError):
-            ht.clip(torch.arange(10), 2, 5)
+            ht.clip(torch.arange(10, device=device), 2, 5)
         with self.assertRaises(ValueError):
             ht.arange(20).clip(None, None)
         with self.assertRaises(TypeError):
-            ht.clip(ht.arange(20), 5, 15, out=torch.arange(20))
+            ht.clip(ht.arange(20), 5, 15, out=torch.arange(20, device=device))
 
     def test_floor(self):
         start, end, step = -5.0, 5.0, 1.4
-        comparison = torch.arange(start, end, step, dtype=torch.float64).floor()
+        comparison = torch.arange(start, end, step, dtype=torch.float64, device=device).floor()
 
         # exponential of float32
         float32_tensor = ht.arange(start, end, step, dtype=ht.float32)
@@ -165,7 +173,7 @@ class TestRounding(unittest.TestCase):
     def test_trunc(self):
         base_array = np.random.randn(20)
 
-        comparison = torch.tensor(base_array, dtype=torch.float64).trunc()
+        comparison = torch.tensor(base_array, dtype=torch.float64, device=device).trunc()
 
         # trunc of float32
         float32_tensor = ht.array(base_array, dtype=ht.float32)

--- a/heat/core/tests/test_rounding.py
+++ b/heat/core/tests/test_rounding.py
@@ -5,11 +5,11 @@ import heat as ht
 import os
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestRounding(unittest.TestCase):

--- a/heat/core/tests/test_rounding.py
+++ b/heat/core/tests/test_rounding.py
@@ -4,31 +4,36 @@ import numpy as np
 import heat as ht
 import os
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestRounding(unittest.TestCase):
     def test_abs(self):
         # for abs==absolute
-        float32_tensor = ht.arange(-10, 10, dtype=ht.float32, split=0)
+        float32_tensor = ht.arange(-10, 10, dtype=ht.float32, split=0, device=ht_device)
         absolute_values = ht.abs(float32_tensor)
         # for fabs
-        int8_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.int8, split=0)
+        int8_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.int8, split=0, device=ht_device)
         int8_absolute_values_fabs = ht.fabs(int8_tensor_fabs)
-        int16_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.int16, split=0)
+        int16_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.int16, split=0, device=ht_device)
         int16_absolute_values_fabs = ht.fabs(int16_tensor_fabs)
-        int32_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.int32, split=0)
+        int32_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.int32, split=0, device=ht_device)
         int32_absolute_values_fabs = ht.fabs(int32_tensor_fabs)
-        int64_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.int64, split=0)
+        int64_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.int64, split=0, device=ht_device)
         int64_absolute_values_fabs = ht.fabs(int64_tensor_fabs)
-        float32_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.float32, split=0)
+        float32_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.float32, split=0, device=ht_device)
         float32_absolute_values_fabs = ht.fabs(float32_tensor_fabs)
-        float64_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.float64, split=0)
+        float64_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.float64, split=0, device=ht_device)
         float64_absolute_values_fabs = ht.fabs(float64_tensor_fabs)
 
         # basic absolute test
@@ -45,20 +50,20 @@ class TestRounding(unittest.TestCase):
 
         # check whether output works
         # for abs==absolute
-        output_tensor = ht.zeros(20, split=0)
+        output_tensor = ht.zeros(20, split=0, device=ht_device)
         self.assertEqual(output_tensor.sum(axis=0, keepdim=True), 0)
         ht.absolute(float32_tensor, out=output_tensor)
 
         self.assertEqual(output_tensor.sum(axis=0), 100)
         # for fabs
-        output_tensor_fabs = ht.zeros(21, split=0)
+        output_tensor_fabs = ht.zeros(21, split=0, device=ht_device)
         self.assertEqual(output_tensor_fabs.sum(axis=0), 0)
         ht.fabs(float32_tensor_fabs, out=output_tensor_fabs)
         self.assertEqual(output_tensor_fabs.sum(axis=0), 110.5)
 
         # dtype parameter
         # for abs==absolute
-        int64_tensor = ht.arange(-10, 10, dtype=ht.int64)
+        int64_tensor = ht.arange(-10, 10, dtype=ht.int64, device=ht_device)
         absolute_values = ht.abs(int64_tensor, dtype=ht.float32)
         self.assertIsInstance(absolute_values, ht.DNDarray)
         self.assertEqual(absolute_values.sum(axis=0), 100)
@@ -88,7 +93,7 @@ class TestRounding(unittest.TestCase):
 
         # test with unsplit tensor
         # for fabs
-        float32_unsplit_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.float32)
+        float32_unsplit_tensor_fabs = ht.arange(-10.5, 10.5, dtype=ht.float32, device=ht_device)
         float32_unsplit_absolute_values_fabs = ht.fabs(float32_unsplit_tensor_fabs)
         self.assertEqual(float32_unsplit_absolute_values_fabs.sum(), 110.5)
         self.assertEqual(float32_unsplit_absolute_values_fabs.dtype, ht.float32)
@@ -98,7 +103,7 @@ class TestRounding(unittest.TestCase):
         comparison = torch.arange(start, end, step, dtype=torch.float64, device=device).ceil()
 
         # exponential of float32
-        float32_tensor = ht.arange(start, end, step, dtype=ht.float32)
+        float32_tensor = ht.arange(start, end, step, dtype=ht.float32, device=ht_device)
         float32_floor = float32_tensor.ceil()
         self.assertIsInstance(float32_floor, ht.DNDarray)
         self.assertEqual(float32_floor.dtype, ht.float32)
@@ -106,7 +111,7 @@ class TestRounding(unittest.TestCase):
         self.assertTrue((float32_floor._DNDarray__array == comparison.float()).all())
 
         # exponential of float64
-        float64_tensor = ht.arange(start, end, step, dtype=ht.float64)
+        float64_tensor = ht.arange(start, end, step, dtype=ht.float64, device=ht_device)
         float64_floor = float64_tensor.ceil()
         self.assertIsInstance(float64_floor, ht.DNDarray)
         self.assertEqual(float64_floor.dtype, ht.float64)
@@ -123,14 +128,14 @@ class TestRounding(unittest.TestCase):
         elements = 20
 
         # float tensor
-        float32_tensor = ht.arange(elements, dtype=ht.float32, split=0)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, split=0, device=ht_device)
         clipped = float32_tensor.clip(5, 15)
         self.assertIsInstance(clipped, ht.DNDarray)
         self.assertEqual(clipped.dtype, ht.float32)
         self.assertEqual(clipped.sum(axis=0), 195)
 
         # long tensor
-        int64_tensor = ht.arange(elements, dtype=ht.int64, split=0)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, split=0, device=ht_device)
         clipped = int64_tensor.clip(4, 16)
         self.assertIsInstance(clipped, ht.DNDarray)
         self.assertEqual(clipped.dtype, ht.int64)
@@ -140,7 +145,7 @@ class TestRounding(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.clip(torch.arange(10, device=device), 2, 5)
         with self.assertRaises(ValueError):
-            ht.arange(20).clip(None, None)
+            ht.arange(20, device=ht_device).clip(None, None)
         with self.assertRaises(TypeError):
             ht.clip(ht.arange(20), 5, 15, out=torch.arange(20, device=device))
 
@@ -149,7 +154,7 @@ class TestRounding(unittest.TestCase):
         comparison = torch.arange(start, end, step, dtype=torch.float64, device=device).floor()
 
         # exponential of float32
-        float32_tensor = ht.arange(start, end, step, dtype=ht.float32)
+        float32_tensor = ht.arange(start, end, step, dtype=ht.float32, device=ht_device)
         float32_floor = float32_tensor.floor()
         self.assertIsInstance(float32_floor, ht.DNDarray)
         self.assertEqual(float32_floor.dtype, ht.float32)
@@ -157,7 +162,7 @@ class TestRounding(unittest.TestCase):
         self.assertTrue((float32_floor._DNDarray__array == comparison.float()).all())
 
         # exponential of float64
-        float64_tensor = ht.arange(start, end, step, dtype=ht.float64)
+        float64_tensor = ht.arange(start, end, step, dtype=ht.float64, device=ht_device)
         float64_floor = float64_tensor.floor()
         self.assertIsInstance(float64_floor, ht.DNDarray)
         self.assertEqual(float64_floor.dtype, ht.float64)
@@ -176,14 +181,14 @@ class TestRounding(unittest.TestCase):
         comparison = torch.tensor(base_array, dtype=torch.float64, device=device).trunc()
 
         # trunc of float32
-        float32_tensor = ht.array(base_array, dtype=ht.float32)
+        float32_tensor = ht.array(base_array, dtype=ht.float32, device=ht_device)
         float32_floor = float32_tensor.trunc()
         self.assertIsInstance(float32_floor, ht.DNDarray)
         self.assertEqual(float32_floor.dtype, ht.float32)
         self.assertTrue((float32_floor._DNDarray__array == comparison.float()).all())
 
         # trunc of float64
-        float64_tensor = ht.array(base_array, dtype=ht.float64)
+        float64_tensor = ht.array(base_array, dtype=ht.float64, device=ht_device)
         float64_floor = float64_tensor.trunc()
         self.assertIsInstance(float64_floor, ht.DNDarray)
         self.assertEqual(float64_floor.dtype, ht.float64)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -5,18 +5,23 @@ from itertools import combinations
 import os
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestStatistics(unittest.TestCase):
     def test_argmax(self):
         torch.manual_seed(1)
-        data = ht.random.randn(3, 4, 5)
+        data = ht.random.randn(3, 4, 5, device=ht_device)
 
         # 3D local tensor, major axis
         result = ht.argmax(data, axis=0)
@@ -41,7 +46,7 @@ class TestStatistics(unittest.TestCase):
         )
 
         # 1D split tensor, no axis
-        data = ht.arange(-10, 10, split=0)
+        data = ht.arange(-10, 10, split=0, device=ht_device)
         result = ht.argmax(data)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
@@ -52,7 +57,7 @@ class TestStatistics(unittest.TestCase):
         self.assertTrue((result._DNDarray__array == torch.tensor([19], device=device)))
 
         # 2D split tensor, along the axis
-        data = ht.array(ht.random.randn(4, 5), is_split=0)
+        data = ht.array(ht.random.randn(4, 5, device=ht_device), is_split=0, device=ht_device)
         result = ht.argmax(data, axis=1)
         expected = torch.argmax(data._DNDarray__array, dim=1)
         self.assertIsInstance(result, ht.DNDarray)
@@ -65,7 +70,7 @@ class TestStatistics(unittest.TestCase):
 
         # 2D split tensor, across the axis
         size = ht.MPI_WORLD.size * 2
-        data = ht.tril(ht.ones((size, size), split=0), k=-1)
+        data = ht.tril(ht.ones((size, size), split=0, device=ht_device), k=-1)
 
         result = ht.argmax(data, axis=0)
         self.assertIsInstance(result, ht.DNDarray)
@@ -80,9 +85,9 @@ class TestStatistics(unittest.TestCase):
 
         # 2D split tensor, across the axis, output tensor
         size = ht.MPI_WORLD.size * 2
-        data = ht.tril(ht.ones((size, size), split=0), k=-1)
+        data = ht.tril(ht.ones((size, size), split=0, device=ht_device), k=-1)
 
-        output = ht.empty((size,))
+        output = ht.empty((size,), device=ht_device)
         result = ht.argmax(data, axis=0, out=output)
 
         self.assertIsInstance(result, ht.DNDarray)
@@ -107,7 +112,7 @@ class TestStatistics(unittest.TestCase):
 
     def test_argmin(self):
         torch.manual_seed(1)
-        data = ht.random.randn(3, 4, 5)
+        data = ht.random.randn(3, 4, 5, device=ht_device)
 
         # 3D local tensor, no axis
         result = ht.argmin(data)
@@ -142,7 +147,7 @@ class TestStatistics(unittest.TestCase):
         )
 
         # 2D split tensor, along the axis
-        data = ht.array(ht.random.randn(4, 5), is_split=0)
+        data = ht.array(ht.random.randn(4, 5), is_split=0, device=ht_device)
         result = ht.argmin(data, axis=1)
         expected = torch.argmin(data._DNDarray__array, dim=1)
         self.assertIsInstance(result, ht.DNDarray)
@@ -155,7 +160,7 @@ class TestStatistics(unittest.TestCase):
 
         # 2D split tensor, across the axis
         size = ht.MPI_WORLD.size * 2
-        data = ht.triu(ht.ones((size, size), split=0), k=1)
+        data = ht.triu(ht.ones((size, size), split=0, device=ht_device), k=1)
 
         result = ht.argmin(data, axis=0)
         self.assertIsInstance(result, ht.DNDarray)
@@ -170,9 +175,9 @@ class TestStatistics(unittest.TestCase):
 
         # 2D split tensor, across the axis, output tensor
         size = ht.MPI_WORLD.size * 2
-        data = ht.triu(ht.ones((size, size), split=0), k=1)
+        data = ht.triu(ht.ones((size, size), split=0, device=ht_device), k=1)
 
-        output = ht.empty((size,))
+        output = ht.empty((size,), device=ht_device)
         result = ht.argmin(data, axis=0, out=output)
 
         self.assertIsInstance(result, ht.DNDarray)
@@ -196,44 +201,56 @@ class TestStatistics(unittest.TestCase):
             ht.argmin(data, axis=-4)
 
     def test_cov(self):
-        x = ht.array([[0, 2], [1, 1], [2, 0]], dtype=ht.float, split=1).T
+        x = ht.array([[0, 2], [1, 1], [2, 0]], dtype=ht.float, split=1, device=ht_device).T
         if x.comm.size < 3:
             cov = ht.cov(x)
-            actual = ht.array([[1, -1], [-1, 1]], split=0)
+            actual = ht.array([[1, -1], [-1, 1]], split=0, device=ht_device)
             self.assertTrue(ht.equal(cov, actual))
 
         data = np.loadtxt("heat/datasets/data/iris.csv", delimiter=";")
         np_cov = np.cov(data[:, 0], data[:, 1:3], rowvar=False)
 
-        htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0)
+        htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0, device=ht_device)
         ht_cov = ht.cov(htdata[:, 0], htdata[:, 1:3], rowvar=False)
-        self.assertTrue(ht.allclose(ht.array(np_cov, dtype=ht.float) - ht_cov, 0, atol=1e-4))
+        self.assertTrue(
+            ht.allclose(ht.array(np_cov, dtype=ht.float, device=ht_device) - ht_cov, 0, atol=1e-4)
+        )
 
         np_cov = np.cov(data, rowvar=False)
         ht_cov = ht.cov(htdata, rowvar=False)
-        self.assertTrue(ht.allclose(ht.array(np_cov, dtype=ht.float) - ht_cov, 0, atol=1e-4))
+        self.assertTrue(
+            ht.allclose(ht.array(np_cov, dtype=ht.float, device=ht_device) - ht_cov, 0, atol=1e-4)
+        )
 
         np_cov = np.cov(data, rowvar=False, ddof=1)
         ht_cov = ht.cov(htdata, rowvar=False, ddof=1)
-        self.assertTrue(ht.allclose(ht.array(np_cov, dtype=ht.float) - ht_cov, 0, atol=1e-4))
+        self.assertTrue(
+            ht.allclose(ht.array(np_cov, dtype=ht.float, device=ht_device) - ht_cov, 0, atol=1e-4)
+        )
 
         np_cov = np.cov(data, rowvar=False, bias=True)
         ht_cov = ht.cov(htdata, rowvar=False, bias=True)
-        self.assertTrue(ht.allclose(ht.array(np_cov, dtype=ht.float) - ht_cov, 0, atol=1e-4))
+        self.assertTrue(
+            ht.allclose(ht.array(np_cov, dtype=ht.float, device=ht_device) - ht_cov, 0, atol=1e-4)
+        )
 
         if 1 < x.comm.size < 5:
-            htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=1)
+            htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=1, device=ht_device)
             np_cov = np.cov(data, rowvar=False)
             ht_cov = ht.cov(htdata, rowvar=False)
-            self.assertTrue(ht.allclose(ht.array(np_cov, dtype=ht.float), ht_cov, atol=1e-4))
+            self.assertTrue(
+                ht.allclose(ht.array(np_cov, dtype=ht.float, device=ht_device), ht_cov, atol=1e-4)
+            )
 
             np_cov = np.cov(data, data, rowvar=True)
 
-            htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0)
+            htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0, device=ht_device)
             ht_cov = ht.cov(htdata, htdata, rowvar=True)
-            self.assertTrue(ht.allclose(ht.array(np_cov, dtype=ht.float), ht_cov, atol=1e-4))
+            self.assertTrue(
+                ht.allclose(ht.array(np_cov, dtype=ht.float, device=ht_device), ht_cov, atol=1e-4)
+            )
 
-            htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0)
+            htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0, device=ht_device)
             with self.assertRaises(RuntimeError):
                 ht.cov(htdata[1:], rowvar=False)
             with self.assertRaises(RuntimeError):
@@ -246,16 +263,16 @@ class TestStatistics(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.cov(htdata, ddof="str")
         with self.assertRaises(ValueError):
-            ht.cov(ht.zeros((1, 2, 3)))
+            ht.cov(ht.zeros((1, 2, 3), device=ht_device))
         with self.assertRaises(ValueError):
-            ht.cov(htdata, ht.zeros((1, 2, 3)))
+            ht.cov(htdata, ht.zeros((1, 2, 3), device=ht_device))
         with self.assertRaises(ValueError):
             ht.cov(htdata, ddof=10000)
 
     def test_average(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
 
-        ht_array = ht.array(data, dtype=float)
+        ht_array = ht.array(data, dtype=float, device=ht_device)
         comparison = np.asanyarray(data)
 
         # check global average
@@ -292,9 +309,13 @@ class TestStatistics(unittest.TestCase):
         self.assertTrue((avg_horizontal.numpy() == np.average(comparison, axis=1)).all())
 
         # check weighted average over all float elements of split 3d tensor, across split axis
-        random_volume = ht.array(torch.randn((3, 3, 3), dtype=torch.float64), is_split=1)
+        random_volume = ht.array(
+            torch.randn((3, 3, 3), dtype=torch.float64, device=device), is_split=1, device=ht_device
+        )
         size = random_volume.comm.size
-        random_weights = ht.array(torch.randn((3 * size,), dtype=torch.float64))
+        random_weights = ht.array(
+            torch.randn((3 * size,), dtype=torch.float64, device=device), device=ht_device
+        )
         avg_volume = ht.average(random_volume, weights=random_weights, axis=1)
         np_avg_volume = np.average(random_volume.numpy(), weights=random_weights.numpy(), axis=1)
         self.assertIsInstance(avg_volume, ht.DNDarray)
@@ -313,7 +334,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(avg_volume_with_cumwgt[1].split, avg_volume_with_cumwgt[0].split)
 
         # check average over all float elements of split 3d tensor, tuple axis
-        random_volume = ht.random.randn(3, 3, 3, split=0)
+        random_volume = ht.random.randn(3, 3, 3, split=0, device=ht_device)
         avg_volume = ht.average(random_volume, axis=(1, 2))
 
         self.assertIsInstance(avg_volume, ht.DNDarray)
@@ -324,9 +345,9 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(avg_volume.split, 0)
 
         # check weighted average over all float elements of split 5d tensor, along split axis
-        random_5d = ht.random.randn(random_volume.comm.size, 2, 3, 4, 5, split=0)
+        random_5d = ht.random.randn(random_volume.comm.size, 2, 3, 4, 5, split=0, device=ht_device)
         axis = 1
-        random_weights = ht.random.randn(random_5d.gshape[axis])
+        random_weights = ht.random.randn(random_5d.gshape[axis], device=ht_device)
         avg_5d = random_5d.average(weights=random_weights, axis=axis)
 
         self.assertIsInstance(avg_5d, ht.DNDarray)
@@ -345,13 +366,15 @@ class TestStatistics(unittest.TestCase):
             ht.average(random_5d, weights=random_weights, axis=None)
         with self.assertRaises(NotImplementedError):
             ht.average(random_5d, weights=random_weights, axis=(1, 2))
-        random_weights = ht.random.randn(random_5d.gshape[axis], random_5d.gshape[axis + 1])
+        random_weights = ht.random.randn(
+            random_5d.gshape[axis], random_5d.gshape[axis + 1], device=ht_device
+        )
         with self.assertRaises(TypeError):
             ht.average(random_5d, weights=random_weights, axis=axis)
-        random_weights = ht.random.randn(random_5d.gshape[axis] + 1)
+        random_weights = ht.random.randn(random_5d.gshape[axis] + 1, device=ht_device)
         with self.assertRaises(ValueError):
             ht.average(random_5d, weights=random_weights, axis=axis)
-        random_weights = ht.zeros((random_5d.gshape[axis]))
+        random_weights = ht.zeros((random_5d.gshape[axis]), device=ht_device)
         with self.assertRaises(ZeroDivisionError):
             ht.average(random_5d, weights=random_weights, axis=axis)
         with self.assertRaises(TypeError):
@@ -364,7 +387,7 @@ class TestStatistics(unittest.TestCase):
     def test_max(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
 
-        ht_array = ht.array(data)
+        ht_array = ht.array(data, device=ht_device)
         comparison = torch.tensor(data, device=device)
 
         # check global max
@@ -405,7 +428,7 @@ class TestStatistics(unittest.TestCase):
         )
 
         # check max over all float elements of split 3d tensor, across split axis
-        random_volume = ht.random.randn(3, 3, 3, split=1)
+        random_volume = ht.random.randn(3, 3, 3, split=1, device=ht_device)
         maximum_volume = ht.max(random_volume, axis=1)
 
         self.assertIsInstance(maximum_volume, ht.DNDarray)
@@ -416,7 +439,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(maximum_volume.split, None)
 
         # check max over all float elements of split 3d tensor, tuple axis
-        random_volume = ht.random.randn(3, 3, 3, split=0)
+        random_volume = ht.random.randn(3, 3, 3, split=0, device=ht_device)
         maximum_volume = ht.max(random_volume, axis=(1, 2))
         alt_maximum_volume = ht.max(random_volume, axis=(2, 1))
 
@@ -428,7 +451,7 @@ class TestStatistics(unittest.TestCase):
         self.assertTrue((maximum_volume == alt_maximum_volume).all())
 
         # check max over all float elements of split 5d tensor, along split axis
-        random_5d = ht.random.randn(1, 2, 3, 4, 5, split=0)
+        random_5d = ht.random.randn(1, 2, 3, 4, 5, split=0, device=ht_device)
         maximum_5d = ht.max(random_5d, axis=1)
 
         self.assertIsInstance(maximum_5d, ht.DNDarray)
@@ -441,7 +464,7 @@ class TestStatistics(unittest.TestCase):
         # Calculating max with empty local vectors works
         size = ht.MPI_WORLD.size
         if size > 1:
-            a = ht.arange(size - 1, split=0)
+            a = ht.arange(size - 1, split=0, device=ht_device)
             res = ht.max(a)
             expected = torch.tensor([size - 2], dtype=a.dtype.torch_type(), device=device)
             self.assertTrue(torch.equal(res._DNDarray__array, expected))
@@ -458,8 +481,8 @@ class TestStatistics(unittest.TestCase):
         data1 = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
         data2 = [[0, 3, 2], [5, 4, 7], [6, 9, 8], [9, 10, 11]]
 
-        ht_array1 = ht.array(data1)
-        ht_array2 = ht.array(data2)
+        ht_array1 = ht.array(data1, device=ht_device)
+        ht_array2 = ht.array(data2, device=ht_device)
         comparison1 = torch.tensor(data1, device=device)
         comparison2 = torch.tensor(data2, device=device)
 
@@ -478,8 +501,8 @@ class TestStatistics(unittest.TestCase):
         # TODO: add check for uneven distribution of dimensions (see Issue #273)
         size = ht.MPI_WORLD.size
         torch.manual_seed(1)
-        random_volume_1 = ht.random.randn(12 * size, 3, 3, split=0)
-        random_volume_2 = ht.random.randn(12 * size, 1, 3, split=0)
+        random_volume_1 = ht.random.randn(12 * size, 3, 3, split=0, device=ht_device)
+        random_volume_2 = ht.random.randn(12 * size, 1, 3, split=0, device=ht_device)
         maximum_volume = ht.maximum(random_volume_1, random_volume_2)
 
         self.assertIsInstance(maximum_volume, ht.DNDarray)
@@ -491,8 +514,12 @@ class TestStatistics(unittest.TestCase):
 
         # check maximum over float elements of split 3d tensors with different split axis
         torch.manual_seed(1)
-        random_volume_1_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=0)
-        random_volume_2_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=1)
+        random_volume_1_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=0, device=ht_device
+        )
+        random_volume_2_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=1, device=ht_device
+        )
         maximum_volume_splitdiff = ht.maximum(random_volume_1_splitdiff, random_volume_2_splitdiff)
         self.assertIsInstance(maximum_volume_splitdiff, ht.DNDarray)
         self.assertEqual(maximum_volume_splitdiff.shape, (size * 3, size * 3, 4))
@@ -501,24 +528,36 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(maximum_volume_splitdiff._DNDarray__array.dtype, torch.float64)
         self.assertEqual(maximum_volume_splitdiff.split, 0)
 
-        random_volume_1_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=1)
-        random_volume_2_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=0)
+        random_volume_1_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=1, device=ht_device
+        )
+        random_volume_2_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=0, device=ht_device
+        )
         maximum_volume_splitdiff = ht.maximum(random_volume_1_splitdiff, random_volume_2_splitdiff)
         self.assertEqual(maximum_volume_splitdiff.split, 0)
 
-        random_volume_1_split_none = ht.random.randn(size * 3, size * 3, 4, split=None)
-        random_volume_2_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=1)
+        random_volume_1_split_none = ht.random.randn(
+            size * 3, size * 3, 4, split=None, device=ht_device
+        )
+        random_volume_2_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=1, device=ht_device
+        )
         maximum_volume_splitdiff = ht.maximum(random_volume_1_split_none, random_volume_2_splitdiff)
         self.assertEqual(maximum_volume_splitdiff.split, 1)
 
-        random_volume_1_split_none = ht.random.randn(size * 3, size * 3, 4, split=0)
-        random_volume_2_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=None)
+        random_volume_1_split_none = ht.random.randn(
+            size * 3, size * 3, 4, split=0, device=ht_device
+        )
+        random_volume_2_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=None, device=ht_device
+        )
         maximum_volume_splitdiff = ht.maximum(random_volume_1_split_none, random_volume_2_splitdiff)
         self.assertEqual(maximum_volume_splitdiff.split, 0)
 
         # check output buffer
         out_shape = ht.stride_tricks.broadcast_shape(random_volume_1.gshape, random_volume_2.gshape)
-        output = ht.empty(out_shape)
+        output = ht.empty(out_shape, device=ht_device)
         ht.maximum(random_volume_1, random_volume_2, out=output)
         self.assertIsInstance(output, ht.DNDarray)
         self.assertEqual(output.shape, (ht.MPI_WORLD.size * 12, 3, 3))
@@ -528,7 +567,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(output.split, random_volume_1.split)
 
         # check exceptions
-        random_volume_3 = ht.random.randn(4, 2, 3, split=0)
+        random_volume_3 = ht.random.randn(4, 2, 3, split=0, device=ht_device)
         with self.assertRaises(ValueError):
             ht.maximum(random_volume_1, random_volume_3)
         random_volume_3 = torch.ones(12, 3, 3, device=device)
@@ -537,7 +576,7 @@ class TestStatistics(unittest.TestCase):
         output = torch.ones(12, 3, 3, device=device)
         with self.assertRaises(TypeError):
             ht.maximum(random_volume_1, random_volume_2, out=output)
-        output = ht.ones((12, 4, 3))
+        output = ht.ones((12, 4, 3), device=ht_device)
         with self.assertRaises(ValueError):
             ht.maximum(random_volume_1, random_volume_2, out=output)
 
@@ -546,7 +585,7 @@ class TestStatistics(unittest.TestCase):
         array_1_len = 5
         array_2_len = 5
 
-        x = ht.zeros((2, 3, 4))
+        x = ht.zeros((2, 3, 4), device=ht_device)
         with self.assertRaises(ValueError):
             x.mean(axis=10)
         with self.assertRaises(TypeError):
@@ -554,7 +593,7 @@ class TestStatistics(unittest.TestCase):
         with self.assertRaises(ValueError):
             ht.mean(x, axis=(0, "10"))
 
-        a = ht.arange(1, 5)
+        a = ht.arange(1, 5, device=ht_device)
         self.assertEqual(a.mean(), 2.5)
 
         # ones
@@ -565,7 +604,7 @@ class TestStatistics(unittest.TestCase):
             hold = list(range(len(dimensions)))
             hold.append(None)
             for i in hold:  # loop over the number of split dimension of the test array
-                z = ht.ones(dimensions, split=i)
+                z = ht.ones(dimensions, split=i, device=ht_device)
                 res = z.mean()
                 total_dims_list = list(z.shape)
                 self.assertTrue((res == 1).all())
@@ -606,16 +645,18 @@ class TestStatistics(unittest.TestCase):
                             self.assertEqual(res.split, z.split)
 
         # values for the iris dataset mean measured by libreoffice calc
-        ax0 = ht.array([5.84333333333333, 3.054, 3.75866666666667, 1.19866666666667])
+        ax0 = ht.array(
+            [5.84333333333333, 3.054, 3.75866666666667, 1.19866666666667], device=ht_device
+        )
         for sp in [None, 0, 1]:
-            iris = ht.load("heat/datasets/data/iris.h5", "data", split=sp)
+            iris = ht.load("heat/datasets/data/iris.h5", "data", split=sp, device=ht_device)
             self.assertTrue(ht.allclose(ht.mean(iris), 3.46366666666667))
             self.assertTrue(ht.allclose(ht.mean(iris, axis=0), ax0))
 
     def test_min(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
 
-        ht_array = ht.array(data)
+        ht_array = ht.array(data, device=ht_device)
         comparison = torch.tensor(data, device=device)
 
         # check global max
@@ -656,7 +697,7 @@ class TestStatistics(unittest.TestCase):
         )
 
         # check max over all float elements of split 3d tensor, across split axis
-        random_volume = ht.random.randn(3, 3, 3, split=1)
+        random_volume = ht.random.randn(3, 3, 3, split=1, device=ht_device)
         minimum_volume = ht.min(random_volume, axis=1)
 
         self.assertIsInstance(minimum_volume, ht.DNDarray)
@@ -667,7 +708,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(minimum_volume.split, None)
 
         # check min over all float elements of split 3d tensor, tuple axis
-        random_volume = ht.random.randn(3, 3, 3, split=0)
+        random_volume = ht.random.randn(3, 3, 3, split=0, device=ht_device)
         minimum_volume = ht.min(random_volume, axis=(1, 2))
         alt_minimum_volume = ht.min(random_volume, axis=(2, 1))
 
@@ -679,7 +720,7 @@ class TestStatistics(unittest.TestCase):
         self.assertTrue((minimum_volume == alt_minimum_volume).all())
 
         # check max over all float elements of split 5d tensor, along split axis
-        random_5d = ht.random.randn(1, 2, 3, 4, 5, split=0)
+        random_5d = ht.random.randn(1, 2, 3, 4, 5, split=0, device=ht_device)
         minimum_5d = ht.min(random_5d, axis=1)
 
         self.assertIsInstance(minimum_5d, ht.DNDarray)
@@ -692,7 +733,7 @@ class TestStatistics(unittest.TestCase):
         # Calculating min with empty local vectors works
         size = ht.MPI_WORLD.size
         if size > 1:
-            a = ht.arange(size - 1, split=0)
+            a = ht.arange(size - 1, split=0, device=ht_device)
             res = ht.min(a)
             expected = torch.tensor([0], dtype=a.dtype.torch_type(), device=device)
             self.assertTrue(torch.equal(res._DNDarray__array, expected))
@@ -709,8 +750,8 @@ class TestStatistics(unittest.TestCase):
         data1 = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
         data2 = [[0, 3, 2], [5, 4, 7], [6, 9, 8], [9, 10, 11]]
 
-        ht_array1 = ht.array(data1)
-        ht_array2 = ht.array(data2)
+        ht_array1 = ht.array(data1, device=ht_device)
+        ht_array2 = ht.array(data2, device=ht_device)
         comparison1 = torch.tensor(data1, device=device)
         comparison2 = torch.tensor(data2, device=device)
 
@@ -729,8 +770,8 @@ class TestStatistics(unittest.TestCase):
         # TODO: add check for uneven distribution of dimensions (see Issue #273)
         size = ht.MPI_WORLD.size
         torch.manual_seed(1)
-        random_volume_1 = ht.random.randn(12 * size, 3, 3, split=0)
-        random_volume_2 = ht.random.randn(12 * size, 1, 3, split=0)
+        random_volume_1 = ht.random.randn(12 * size, 3, 3, split=0, device=ht_device)
+        random_volume_2 = ht.random.randn(12 * size, 1, 3, split=0, device=ht_device)
         minimum_volume = ht.minimum(random_volume_1, random_volume_2)
 
         self.assertIsInstance(minimum_volume, ht.DNDarray)
@@ -742,8 +783,12 @@ class TestStatistics(unittest.TestCase):
 
         # check minimum over float elements of split 3d tensors with different split axis
         torch.manual_seed(1)
-        random_volume_1_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=0)
-        random_volume_2_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=1)
+        random_volume_1_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=0, device=ht_device
+        )
+        random_volume_2_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=1, device=ht_device
+        )
         minimum_volume_splitdiff = ht.minimum(random_volume_1_splitdiff, random_volume_2_splitdiff)
         self.assertIsInstance(minimum_volume_splitdiff, ht.DNDarray)
         self.assertEqual(minimum_volume_splitdiff.shape, (size * 3, size * 3, 4))
@@ -752,24 +797,36 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(minimum_volume_splitdiff._DNDarray__array.dtype, torch.float64)
         self.assertEqual(minimum_volume_splitdiff.split, 0)
 
-        random_volume_1_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=1)
-        random_volume_2_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=0)
+        random_volume_1_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=1, device=ht_device
+        )
+        random_volume_2_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=0, device=ht_device
+        )
         minimum_volume_splitdiff = ht.minimum(random_volume_1_splitdiff, random_volume_2_splitdiff)
         self.assertEqual(minimum_volume_splitdiff.split, 0)
 
-        random_volume_1_split_none = ht.random.randn(size * 3, size * 3, 4, split=None)
-        random_volume_2_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=1)
+        random_volume_1_split_none = ht.random.randn(
+            size * 3, size * 3, 4, split=None, device=ht_device
+        )
+        random_volume_2_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=1, device=ht_device
+        )
         minimum_volume_splitdiff = ht.minimum(random_volume_1_split_none, random_volume_2_splitdiff)
         self.assertEqual(minimum_volume_splitdiff.split, 1)
 
-        random_volume_1_split_none = ht.random.randn(size * 3, size * 3, 4, split=0)
-        random_volume_2_splitdiff = ht.random.randn(size * 3, size * 3, 4, split=None)
+        random_volume_1_split_none = ht.random.randn(
+            size * 3, size * 3, 4, split=0, device=ht_device
+        )
+        random_volume_2_splitdiff = ht.random.randn(
+            size * 3, size * 3, 4, split=None, device=ht_device
+        )
         minimum_volume_splitdiff = ht.minimum(random_volume_1_split_none, random_volume_2_splitdiff)
         self.assertEqual(minimum_volume_splitdiff.split, 0)
 
         # check output buffer
         out_shape = ht.stride_tricks.broadcast_shape(random_volume_1.gshape, random_volume_2.gshape)
-        output = ht.empty(out_shape)
+        output = ht.empty(out_shape, device=ht_device)
         ht.minimum(random_volume_1, random_volume_2, out=output)
         self.assertIsInstance(output, ht.DNDarray)
         self.assertEqual(output.shape, (ht.MPI_WORLD.size * 12, 3, 3))
@@ -779,7 +836,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(output.split, random_volume_1.split)
 
         # check exceptions
-        random_volume_3 = ht.random.randn(4, 2, 3, split=0)
+        random_volume_3 = ht.random.randn(4, 2, 3, split=0, device=ht_device)
         with self.assertRaises(ValueError):
             ht.minimum(random_volume_1, random_volume_3)
         random_volume_3 = torch.ones(12, 3, 3, device=device)
@@ -788,13 +845,13 @@ class TestStatistics(unittest.TestCase):
         output = torch.ones(12, 3, 3, device=device)
         with self.assertRaises(TypeError):
             ht.minimum(random_volume_1, random_volume_2, out=output)
-        output = ht.ones((12, 4, 3))
+        output = ht.ones((12, 4, 3), device=ht_device)
         with self.assertRaises(ValueError):
             ht.minimum(random_volume_1, random_volume_2, out=output)
 
     def test_std(self):
         # test raises
-        x = ht.zeros((2, 3, 4))
+        x = ht.zeros((2, 3, 4), device=ht_device)
         with self.assertRaises(TypeError):
             ht.std(x, axis=0, bessel=1)
         with self.assertRaises(ValueError):
@@ -810,7 +867,7 @@ class TestStatistics(unittest.TestCase):
         array_2_len = ht.MPI_WORLD.size * 2
 
         # test raises
-        x = ht.zeros((2, 3, 4))
+        x = ht.zeros((2, 3, 4), device=ht_device)
         with self.assertRaises(TypeError):
             ht.var(x, axis=0, bessel=1)
         with self.assertRaises(ValueError):
@@ -818,7 +875,7 @@ class TestStatistics(unittest.TestCase):
         with self.assertRaises(TypeError):
             ht.var(x, axis="01")
 
-        a = ht.arange(1, 5)
+        a = ht.arange(1, 5, device=ht_device)
         self.assertEqual(a.var(), 1.666666666666666)
 
         # ones
@@ -828,7 +885,7 @@ class TestStatistics(unittest.TestCase):
             hold = list(range(len(dimensions)))
             hold.append(None)
             for i in hold:  # loop over the number of dimensions of the test array
-                z = ht.ones(dimensions, split=i)
+                z = ht.ones(dimensions, split=i, device=ht_device)
                 res = z.var()
                 total_dims_list = list(z.shape)
                 self.assertTrue(ht.allclose(res, 0))
@@ -851,11 +908,11 @@ class TestStatistics(unittest.TestCase):
                     if i == it:
                         res = z.var(axis=it)
                         self.assertTrue(ht.allclose(res, 0))
-                z = ht.ones(dimensions, split=i)
+                z = ht.ones(dimensions, split=i, device=ht_device)
                 res = z.var(bessel=False)
                 self.assertTrue(ht.allclose(res, 0))
 
         # values for the iris dataset var measured by libreoffice calc
         for sp in [None, 0, 1]:
-            iris = ht.load_hdf5("heat/datasets/data/iris.h5", "data", split=sp)
+            iris = ht.load_hdf5("heat/datasets/data/iris.h5", "data", split=sp, device=ht_device)
             self.assertTrue(ht.allclose(ht.var(iris, bessel=True), 3.90318519755147))

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -6,11 +6,11 @@ import os
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestStatistics(unittest.TestCase):

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -649,7 +649,7 @@ class TestStatistics(unittest.TestCase):
             [5.84333333333333, 3.054, 3.75866666666667, 1.19866666666667], device=ht_device
         )
         for sp in [None, 0, 1]:
-            iris = ht.load("heat/datasets/data/iris.csv", sep=";", split=sp)
+            iris = ht.load("heat/datasets/data/iris.csv", sep=";", split=sp, device=ht_device)
             self.assertTrue(ht.allclose(ht.mean(iris), 3.46366666666667))
             self.assertTrue(ht.allclose(ht.mean(iris, axis=0), ax0))
 
@@ -914,5 +914,5 @@ class TestStatistics(unittest.TestCase):
 
         # values for the iris dataset var measured by libreoffice calc
         for sp in [None, 0, 1]:
-            iris = ht.load("heat/datasets/data/iris.csv", sep=";", split=sp)
+            iris = ht.load("heat/datasets/data/iris.csv", sep=";", split=sp, device=ht_device)
             self.assertTrue(ht.allclose(ht.var(iris, bessel=True), 3.90318519755147))

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -75,7 +75,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(result.lshape, (size,))
         self.assertEqual(result.split, None)
         # skip test on gpu; argmax works different
-        if result.device != ht.gpu:
+        if not (torch.cuda.is_available() and result.device == ht.gpu):
             self.assertTrue((result._DNDarray__array != 0).all())
 
         # 2D split tensor, across the axis, output tensor
@@ -92,7 +92,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(output.lshape, (size,))
         self.assertEqual(output.split, None)
         # skip test on gpu; argmax works different
-        if output.device != ht.gpu:
+        if not (torch.cuda.is_available() and output.device == ht.gpu):
             self.assertTrue((output._DNDarray__array != 0).all())
 
         # check exceptions
@@ -165,7 +165,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(result.lshape, (size,))
         self.assertEqual(result.split, None)
         # skip test on gpu; argmin works different
-        if result.device != ht.gpu:
+        if not (torch.cuda.is_available() and result.device == ht.gpu):
             self.assertTrue((result._DNDarray__array != 0).all())
 
         # 2D split tensor, across the axis, output tensor
@@ -182,7 +182,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual(output.lshape, (size,))
         self.assertEqual(output.split, None)
         # skip test on gpu; argmin works different
-        if output.device != ht.gpu:
+        if not (torch.cuda.is_available() and output.device == ht.gpu):
             self.assertTrue((output._DNDarray__array != 0).all())
 
         # check exceptions

--- a/heat/core/tests/test_stride_tricks.py
+++ b/heat/core/tests/test_stride_tricks.py
@@ -2,12 +2,17 @@ import unittest
 import os
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and ht.torch.cuda.is_available():
+    ht.use_device("gpu")
     ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and ht.torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    ht.torch.cuda.set_device(device)
 
 
 class TestStrideTricks(unittest.TestCase):

--- a/heat/core/tests/test_stride_tricks.py
+++ b/heat/core/tests/test_stride_tricks.py
@@ -1,6 +1,8 @@
 import unittest
-
+import os
 import heat as ht
+
+ht.use_device(os.environ.get("DEVICE"))
 
 
 class TestStrideTricks(unittest.TestCase):

--- a/heat/core/tests/test_stride_tricks.py
+++ b/heat/core/tests/test_stride_tricks.py
@@ -2,7 +2,12 @@ import unittest
 import os
 import heat as ht
 
-ht.use_device(os.environ.get("DEVICE"))
+if os.environ.get("DEVICE") == "gpu":
+    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+    ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
+else:
+    ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestStrideTricks(unittest.TestCase):

--- a/heat/core/tests/test_suites/basic_test.py
+++ b/heat/core/tests/test_suites/basic_test.py
@@ -63,7 +63,7 @@ class BasicTest(TestCase):
         if isinstance(expected_array, torch.Tensor):
             # Does not work because heat sets an index while torch does not
             # self.assertEqual(expected_array.device, torch.device(heat_array.device.torch_device))
-            expected_array = expected_array.numpy()
+            expected_array = expected_array.cpu().numpy()
 
         # Determine with what kind of numbers we are working
         compare_func = (
@@ -97,7 +97,7 @@ class BasicTest(TestCase):
             "Local shapes do not match. "
             "Got {} expected {}".format(heat_array.lshape, expected_array[slices].shape),
         )
-        local_numpy = heat_array._DNDarray__array.numpy()
+        local_numpy = heat_array._DNDarray__array.cpu().numpy()
 
         # Array is distributed correctly
         equal_res = np.array(compare_func(local_numpy, expected_array[slices]))
@@ -207,7 +207,7 @@ class BasicTest(TestCase):
             if distributed_result:
                 self.assert_array_equal(ht_res, np_res)
             else:
-                self.assertTrue(np.array_equal(ht_res._DNDarray__array.numpy(), np_res))
+                self.assertTrue(np.array_equal(ht_res._DNDarray__array.cpu().numpy(), np_res))
 
     def _create_random_array(self, shape):
         seed = np.random.randint(1000000, size=(1,))

--- a/heat/core/tests/test_suites/basic_test.py
+++ b/heat/core/tests/test_suites/basic_test.py
@@ -93,7 +93,7 @@ class BasicTest(TestCase):
 
         if not heat_array.is_balanced():
             # Array is distributed correctly
-            print("Heat array is unbalanced, balancing now")
+            # print("Heat array is unbalanced, balancing now")
             heat_array.balance_()
 
         split = heat_array.split
@@ -343,7 +343,7 @@ class BasicTest(TestCase):
         ValueError if the dtype is not a subtype of numpy.integer or numpy.floating
         """
         seed = np.random.randint(1000000, size=(1,))
-        print("using seed {} for random values".format(seed))
+        # print("using seed {} for random values".format(seed))
         self.comm.Bcast(seed, root=0)
         np.random.seed(seed=seed.item())
         if issubclass(dtype, np.floating):

--- a/heat/core/tests/test_suites/test_basic_test.py
+++ b/heat/core/tests/test_suites/test_basic_test.py
@@ -1,6 +1,14 @@
+import os
 import heat as ht
 import numpy as np
 import torch
+
+if os.environ.get("DEVICE") == "gpu":
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
+else:
+    ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 from heat.core.tests.test_suites.basic_test import BasicTest
 

--- a/heat/core/tests/test_trigonometrics.py
+++ b/heat/core/tests/test_trigonometrics.py
@@ -2,13 +2,23 @@ import torch
 import unittest
 import math
 import heat as ht
+import os
+
+if os.environ.get("DEVICE") == "gpu":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+else:
+    device = torch.device("cpu")
+    ht.use_device("cpu")
 
 
 class TestTrigonometrics(unittest.TestCase):
     def test_rad2deg(self):
         # base elements
         elements = [0.0, 0.2, 0.6, 0.9, 1.2, 2.7, 3.14]
-        comparison = 180.0 * torch.tensor(elements, dtype=torch.float64) / 3.141592653589793
+        comparison = (
+            180.0 * torch.tensor(elements, dtype=torch.float64, device=device) / 3.141592653589793
+        )
 
         # rad2deg with float32
         float32_tensor = ht.array(elements, dtype=ht.float32)
@@ -33,7 +43,9 @@ class TestTrigonometrics(unittest.TestCase):
     def test_degrees(self):
         # base elements
         elements = [0.0, 0.2, 0.6, 0.9, 1.2, 2.7, 3.14]
-        comparison = 180.0 * torch.tensor(elements, dtype=torch.float64) / 3.141592653589793
+        comparison = (
+            180.0 * torch.tensor(elements, dtype=torch.float64, device=device) / 3.141592653589793
+        )
 
         # degrees with float32
         float32_tensor = ht.array(elements, dtype=ht.float32)
@@ -58,7 +70,9 @@ class TestTrigonometrics(unittest.TestCase):
     def test_deg2rad(self):
         # base elements
         elements = [0.0, 20.0, 45.0, 78.0, 94.0, 120.0, 180.0, 270.0, 311.0]
-        comparison = 3.141592653589793 * torch.tensor(elements, dtype=torch.float64) / 180.0
+        comparison = (
+            3.141592653589793 * torch.tensor(elements, dtype=torch.float64, device=device) / 180.0
+        )
 
         # deg2rad with float32
         float32_tensor = ht.array(elements, dtype=ht.float32)
@@ -83,7 +97,9 @@ class TestTrigonometrics(unittest.TestCase):
     def test_radians(self):
         # base elements
         elements = [0.0, 20.0, 45.0, 78.0, 94.0, 120.0, 180.0, 270.0, 311.0]
-        comparison = 3.141592653589793 * torch.tensor(elements, dtype=torch.float64) / 180.0
+        comparison = (
+            3.141592653589793 * torch.tensor(elements, dtype=torch.float64, device=device) / 180.0
+        )
 
         # radians with float32
         float32_tensor = ht.array(elements, dtype=ht.float32)
@@ -108,7 +124,7 @@ class TestTrigonometrics(unittest.TestCase):
     def test_arctan(self):
         # base elements
         elements = 30
-        comparison = torch.arange(elements, dtype=torch.float64).atan()
+        comparison = torch.arange(elements, dtype=torch.float64, device=device).atan()
 
         # arctan of float32
         float32_tensor = ht.arange(elements, dtype=ht.float32)
@@ -147,7 +163,7 @@ class TestTrigonometrics(unittest.TestCase):
     def test_arcsin(self):
         # base elements
         elements = [-1.0, -0.83, -0.12, 0.0, 0.24, 0.67, 1.0]
-        comparison = torch.tensor(elements, dtype=torch.float64).asin()
+        comparison = torch.tensor(elements, dtype=torch.float64, device=device).asin()
 
         # arcsin of float32
         float32_tensor = ht.array(elements, dtype=ht.float32)
@@ -179,7 +195,7 @@ class TestTrigonometrics(unittest.TestCase):
     def test_arccos(self):
         # base elements
         elements = [-1.0, -0.83, -0.12, 0.0, 0.24, 0.67, 1.0]
-        comparison = torch.tensor(elements, dtype=torch.float64).acos()
+        comparison = torch.tensor(elements, dtype=torch.float64, device=device).acos()
 
         # arccos of float32
         float32_tensor = ht.array(elements, dtype=ht.float32)
@@ -211,7 +227,7 @@ class TestTrigonometrics(unittest.TestCase):
     def test_cos(self):
         # base elements
         elements = 30
-        comparison = torch.arange(elements, dtype=torch.float64).cos()
+        comparison = torch.arange(elements, dtype=torch.float64, device=device).cos()
 
         # cosine of float32
         float32_tensor = ht.arange(elements, dtype=ht.float32)
@@ -250,7 +266,7 @@ class TestTrigonometrics(unittest.TestCase):
     def test_cosh(self):
         # base elements
         elements = 30
-        comparison = torch.arange(elements, dtype=torch.float64).cosh()
+        comparison = torch.arange(elements, dtype=torch.float64, device=device).cosh()
 
         # hyperbolic cosine of float32
         float32_tensor = ht.arange(elements, dtype=ht.float32)
@@ -289,7 +305,7 @@ class TestTrigonometrics(unittest.TestCase):
     def test_sin(self):
         # base elements
         elements = 30
-        comparison = torch.arange(elements, dtype=torch.float64).sin()
+        comparison = torch.arange(elements, dtype=torch.float64, device=device).sin()
 
         # sine of float32
         float32_tensor = ht.arange(elements, dtype=ht.float32)
@@ -328,7 +344,7 @@ class TestTrigonometrics(unittest.TestCase):
     def test_sinh(self):
         # base elements
         elements = 30
-        comparison = torch.arange(elements, dtype=torch.float64).sinh()
+        comparison = torch.arange(elements, dtype=torch.float64, device=device).sinh()
 
         # hyperbolic sine of float32
         float32_tensor = ht.arange(elements, dtype=ht.float32)
@@ -367,7 +383,7 @@ class TestTrigonometrics(unittest.TestCase):
     def test_tan(self):
         # base elements
         elements = 30
-        comparison = torch.arange(elements, dtype=torch.float64).tan()
+        comparison = torch.arange(elements, dtype=torch.float64, device=device).tan()
 
         # tangent of float32
         float32_tensor = ht.arange(elements, dtype=ht.float32)
@@ -406,7 +422,7 @@ class TestTrigonometrics(unittest.TestCase):
     def test_tanh(self):
         # base elements
         elements = 30
-        comparison = torch.arange(elements, dtype=torch.float64).tanh()
+        comparison = torch.arange(elements, dtype=torch.float64, device=device).tanh()
 
         # hyperbolic tangent of float32
         float32_tensor = ht.arange(elements, dtype=ht.float32)

--- a/heat/core/tests/test_trigonometrics.py
+++ b/heat/core/tests/test_trigonometrics.py
@@ -4,12 +4,17 @@ import math
 import heat as ht
 import os
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestTrigonometrics(unittest.TestCase):
@@ -21,14 +26,14 @@ class TestTrigonometrics(unittest.TestCase):
         )
 
         # rad2deg with float32
-        float32_tensor = ht.array(elements, dtype=ht.float32)
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
         float32_rad2deg = ht.rad2deg(float32_tensor)
         self.assertIsInstance(float32_rad2deg, ht.DNDarray)
         self.assertEqual(float32_rad2deg.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_rad2deg._DNDarray__array.double(), comparison))
 
         # rad2deg with float64
-        float64_tensor = ht.array(elements, dtype=ht.float64)
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
         float64_rad2deg = ht.rad2deg(float64_tensor)
         self.assertIsInstance(float64_rad2deg, ht.DNDarray)
         self.assertEqual(float64_rad2deg.dtype, ht.float64)
@@ -48,14 +53,14 @@ class TestTrigonometrics(unittest.TestCase):
         )
 
         # degrees with float32
-        float32_tensor = ht.array(elements, dtype=ht.float32)
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
         float32_degrees = ht.degrees(float32_tensor)
         self.assertIsInstance(float32_degrees, ht.DNDarray)
         self.assertEqual(float32_degrees.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_degrees._DNDarray__array.double(), comparison))
 
         # degrees with float64
-        float64_tensor = ht.array(elements, dtype=ht.float64)
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
         float64_degrees = ht.degrees(float64_tensor)
         self.assertIsInstance(float64_degrees, ht.DNDarray)
         self.assertEqual(float64_degrees.dtype, ht.float64)
@@ -75,14 +80,14 @@ class TestTrigonometrics(unittest.TestCase):
         )
 
         # deg2rad with float32
-        float32_tensor = ht.array(elements, dtype=ht.float32)
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
         float32_deg2rad = ht.deg2rad(float32_tensor)
         self.assertIsInstance(float32_deg2rad, ht.DNDarray)
         self.assertEqual(float32_deg2rad.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_deg2rad._DNDarray__array.double(), comparison))
 
         # deg2rad with float64
-        float64_tensor = ht.array(elements, dtype=ht.float64)
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
         float64_deg2rad = ht.deg2rad(float64_tensor)
         self.assertIsInstance(float64_deg2rad, ht.DNDarray)
         self.assertEqual(float64_deg2rad.dtype, ht.float64)
@@ -102,14 +107,14 @@ class TestTrigonometrics(unittest.TestCase):
         )
 
         # radians with float32
-        float32_tensor = ht.array(elements, dtype=ht.float32)
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
         float32_radians = ht.radians(float32_tensor)
         self.assertIsInstance(float32_radians, ht.DNDarray)
         self.assertEqual(float32_radians.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_radians._DNDarray__array.double(), comparison))
 
         # radians with float64
-        float64_tensor = ht.array(elements, dtype=ht.float64)
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
         float64_radians = ht.radians(float64_tensor)
         self.assertIsInstance(float64_radians, ht.DNDarray)
         self.assertEqual(float64_radians.dtype, ht.float64)
@@ -127,28 +132,28 @@ class TestTrigonometrics(unittest.TestCase):
         comparison = torch.arange(elements, dtype=torch.float64, device=device).atan()
 
         # arctan of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_arctan = ht.arctan(float32_tensor)
         self.assertIsInstance(float32_arctan, ht.DNDarray)
         self.assertEqual(float32_arctan.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_arctan._DNDarray__array.double(), comparison))
 
         # arctan of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_arctan = ht.arctan(float64_tensor)
         self.assertIsInstance(float64_arctan, ht.DNDarray)
         self.assertEqual(float64_arctan.dtype, ht.float64)
         self.assertTrue(torch.allclose(float64_arctan._DNDarray__array.double(), comparison))
 
         # arctan of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_arctan = ht.arctan(int32_tensor)
         self.assertIsInstance(int32_arctan, ht.DNDarray)
         self.assertEqual(int32_arctan.dtype, ht.float64)
         self.assertTrue(torch.allclose(float32_arctan._DNDarray__array.double(), comparison))
 
         # arctan of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_arctan = ht.arctan(int64_tensor)
         self.assertIsInstance(int64_arctan, ht.DNDarray)
         self.assertEqual(int64_arctan.dtype, ht.float64)
@@ -166,21 +171,21 @@ class TestTrigonometrics(unittest.TestCase):
         comparison = torch.tensor(elements, dtype=torch.float64, device=device).asin()
 
         # arcsin of float32
-        float32_tensor = ht.array(elements, dtype=ht.float32)
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
         float32_arcsin = ht.arcsin(float32_tensor)
         self.assertIsInstance(float32_arcsin, ht.DNDarray)
         self.assertEqual(float32_arcsin.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_arcsin._DNDarray__array.double(), comparison))
 
         # arcsin of float64
-        float64_tensor = ht.array(elements, dtype=ht.float64)
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
         float64_arcsin = ht.arcsin(float64_tensor)
         self.assertIsInstance(float64_arcsin, ht.DNDarray)
         self.assertEqual(float64_arcsin.dtype, ht.float64)
         self.assertTrue(torch.allclose(float64_arcsin._DNDarray__array.double(), comparison))
 
         # arcsin of value out of domain
-        nan_tensor = ht.array([1.2])
+        nan_tensor = ht.array([1.2], device=ht_device)
         nan_arcsin = ht.arcsin(nan_tensor)
         self.assertIsInstance(float64_arcsin, ht.DNDarray)
         self.assertEqual(nan_arcsin.dtype, ht.float32)
@@ -198,21 +203,21 @@ class TestTrigonometrics(unittest.TestCase):
         comparison = torch.tensor(elements, dtype=torch.float64, device=device).acos()
 
         # arccos of float32
-        float32_tensor = ht.array(elements, dtype=ht.float32)
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
         float32_arccos = ht.arccos(float32_tensor)
         self.assertIsInstance(float32_arccos, ht.DNDarray)
         self.assertEqual(float32_arccos.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_arccos._DNDarray__array.double(), comparison))
 
         # arccos of float64
-        float64_tensor = ht.array(elements, dtype=ht.float64)
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
         float64_arccos = ht.arccos(float64_tensor)
         self.assertIsInstance(float64_arccos, ht.DNDarray)
         self.assertEqual(float64_arccos.dtype, ht.float64)
         self.assertTrue(torch.allclose(float64_arccos._DNDarray__array.double(), comparison))
 
         # arccos of value out of domain
-        nan_tensor = ht.array([1.2])
+        nan_tensor = ht.array([1.2], device=ht_device)
         nan_arccos = ht.arccos(nan_tensor)
         self.assertIsInstance(float64_arccos, ht.DNDarray)
         self.assertEqual(nan_arccos.dtype, ht.float32)
@@ -230,28 +235,28 @@ class TestTrigonometrics(unittest.TestCase):
         comparison = torch.arange(elements, dtype=torch.float64, device=device).cos()
 
         # cosine of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_cos = ht.cos(float32_tensor)
         self.assertIsInstance(float32_cos, ht.DNDarray)
         self.assertEqual(float32_cos.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_cos._DNDarray__array.double(), comparison))
 
         # cosine of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_cos = ht.cos(float64_tensor)
         self.assertIsInstance(float64_cos, ht.DNDarray)
         self.assertEqual(float64_cos.dtype, ht.float64)
         self.assertTrue(torch.allclose(float64_cos._DNDarray__array.double(), comparison))
 
         # cosine of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_cos = ht.cos(int32_tensor)
         self.assertIsInstance(int32_cos, ht.DNDarray)
         self.assertEqual(int32_cos.dtype, ht.float64)
         self.assertTrue(torch.allclose(float32_cos._DNDarray__array.double(), comparison))
 
         # cosine of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_cos = int64_tensor.cos()
         self.assertIsInstance(int64_cos, ht.DNDarray)
         self.assertEqual(int64_cos.dtype, ht.float64)
@@ -269,28 +274,28 @@ class TestTrigonometrics(unittest.TestCase):
         comparison = torch.arange(elements, dtype=torch.float64, device=device).cosh()
 
         # hyperbolic cosine of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_cosh = float32_tensor.cosh()
         self.assertIsInstance(float32_cosh, ht.DNDarray)
         self.assertEqual(float32_cosh.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_cosh._DNDarray__array.double(), comparison))
 
         # hyperbolic cosine of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_cosh = ht.cosh(float64_tensor)
         self.assertIsInstance(float64_cosh, ht.DNDarray)
         self.assertEqual(float64_cosh.dtype, ht.float64)
         self.assertTrue(torch.allclose(float64_cosh._DNDarray__array.double(), comparison))
 
         # hyperbolic cosine of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_cosh = ht.cosh(int32_tensor)
         self.assertIsInstance(int32_cosh, ht.DNDarray)
         self.assertEqual(int32_cosh.dtype, ht.float64)
         self.assertTrue(torch.allclose(float32_cosh._DNDarray__array.double(), comparison))
 
         # hyperbolic cosine of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_cosh = ht.cosh(int64_tensor)
         self.assertIsInstance(int64_cosh, ht.DNDarray)
         self.assertEqual(int64_cosh.dtype, ht.float64)
@@ -308,28 +313,28 @@ class TestTrigonometrics(unittest.TestCase):
         comparison = torch.arange(elements, dtype=torch.float64, device=device).sin()
 
         # sine of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_sin = float32_tensor.sin()
         self.assertIsInstance(float32_sin, ht.DNDarray)
         self.assertEqual(float32_sin.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_sin._DNDarray__array.double(), comparison))
 
         # sine of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_sin = ht.sin(float64_tensor)
         self.assertIsInstance(float64_sin, ht.DNDarray)
         self.assertEqual(float64_sin.dtype, ht.float64)
         self.assertTrue(torch.allclose(float64_sin._DNDarray__array.double(), comparison))
 
         # sine of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_sin = ht.sin(int32_tensor)
         self.assertIsInstance(int32_sin, ht.DNDarray)
         self.assertEqual(int32_sin.dtype, ht.float64)
         self.assertTrue(torch.allclose(int32_sin._DNDarray__array.double(), comparison))
 
         # sine of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_sin = ht.sin(int64_tensor)
         self.assertIsInstance(int64_sin, ht.DNDarray)
         self.assertEqual(int64_sin.dtype, ht.float64)
@@ -347,28 +352,28 @@ class TestTrigonometrics(unittest.TestCase):
         comparison = torch.arange(elements, dtype=torch.float64, device=device).sinh()
 
         # hyperbolic sine of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_sinh = float32_tensor.sinh()
         self.assertIsInstance(float32_sinh, ht.DNDarray)
         self.assertEqual(float32_sinh.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_sinh._DNDarray__array.double(), comparison))
 
         # hyperbolic sine of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_sinh = ht.sinh(float64_tensor)
         self.assertIsInstance(float64_sinh, ht.DNDarray)
         self.assertEqual(float64_sinh.dtype, ht.float64)
         self.assertTrue(torch.allclose(float64_sinh._DNDarray__array.double(), comparison))
 
         # hyperbolic sine of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_sinh = ht.sinh(int32_tensor)
         self.assertIsInstance(int32_sinh, ht.DNDarray)
         self.assertEqual(int32_sinh.dtype, ht.float64)
         self.assertTrue(torch.allclose(int32_sinh._DNDarray__array.double(), comparison))
 
         # hyperbolic sine of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_sinh = ht.sinh(int64_tensor)
         self.assertIsInstance(int64_sinh, ht.DNDarray)
         self.assertEqual(int64_sinh.dtype, ht.float64)
@@ -386,28 +391,28 @@ class TestTrigonometrics(unittest.TestCase):
         comparison = torch.arange(elements, dtype=torch.float64, device=device).tan()
 
         # tangent of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_tan = float32_tensor.tan()
         self.assertIsInstance(float32_tan, ht.DNDarray)
         self.assertEqual(float32_tan.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_tan._DNDarray__array.double(), comparison))
 
         # tangent of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_tan = ht.tan(float64_tensor)
         self.assertIsInstance(float64_tan, ht.DNDarray)
         self.assertEqual(float64_tan.dtype, ht.float64)
         self.assertTrue(torch.allclose(float64_tan._DNDarray__array.double(), comparison))
 
         # tangent of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_tan = ht.tan(int32_tensor)
         self.assertIsInstance(int32_tan, ht.DNDarray)
         self.assertEqual(int32_tan.dtype, ht.float64)
         self.assertTrue(torch.allclose(int32_tan._DNDarray__array.double(), comparison))
 
         # tangent of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_tan = ht.tan(int64_tensor)
         self.assertIsInstance(int64_tan, ht.DNDarray)
         self.assertEqual(int64_tan.dtype, ht.float64)
@@ -425,28 +430,28 @@ class TestTrigonometrics(unittest.TestCase):
         comparison = torch.arange(elements, dtype=torch.float64, device=device).tanh()
 
         # hyperbolic tangent of float32
-        float32_tensor = ht.arange(elements, dtype=ht.float32)
+        float32_tensor = ht.arange(elements, dtype=ht.float32, device=ht_device)
         float32_tanh = float32_tensor.tanh()
         self.assertIsInstance(float32_tanh, ht.DNDarray)
         self.assertEqual(float32_tanh.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_tanh._DNDarray__array.double(), comparison))
 
         # hyperbolic tangent of float64
-        float64_tensor = ht.arange(elements, dtype=ht.float64)
+        float64_tensor = ht.arange(elements, dtype=ht.float64, device=ht_device)
         float64_tanh = ht.tanh(float64_tensor)
         self.assertIsInstance(float64_tanh, ht.DNDarray)
         self.assertEqual(float64_tanh.dtype, ht.float64)
         self.assertTrue(torch.allclose(float64_tanh._DNDarray__array.double(), comparison))
 
         # hyperbolic tangent of ints, automatic conversion to intermediate floats
-        int32_tensor = ht.arange(elements, dtype=ht.int32)
+        int32_tensor = ht.arange(elements, dtype=ht.int32, device=ht_device)
         int32_tanh = ht.tanh(int32_tensor)
         self.assertIsInstance(int32_tanh, ht.DNDarray)
         self.assertEqual(int32_tanh.dtype, ht.float64)
         self.assertTrue(torch.allclose(int32_tanh._DNDarray__array.double(), comparison))
 
         # hyperbolic tangent of longs, automatic conversion to intermediate floats
-        int64_tensor = ht.arange(elements, dtype=ht.int64)
+        int64_tensor = ht.arange(elements, dtype=ht.int64, device=ht_device)
         int64_tanh = ht.tanh(int64_tensor)
         self.assertIsInstance(int64_tanh, ht.DNDarray)
         self.assertEqual(int64_tanh.dtype, ht.float64)

--- a/heat/core/tests/test_trigonometrics.py
+++ b/heat/core/tests/test_trigonometrics.py
@@ -5,11 +5,11 @@ import heat as ht
 import os
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestTrigonometrics(unittest.TestCase):

--- a/heat/core/tests/test_types.py
+++ b/heat/core/tests/test_types.py
@@ -1,8 +1,15 @@
 import numpy as np
 import torch
 import unittest
-
+import os
 import heat as ht
+
+if os.environ.get("DEVICE") == "gpu":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+else:
+    device = torch.device("cpu")
+    ht.use_device("cpu")
 
 
 class TestTypes(unittest.TestCase):
@@ -32,7 +39,10 @@ class TestTypes(unittest.TestCase):
         self.assertIsInstance(elaborate_value, ht.DNDarray)
         self.assertEqual(elaborate_value.shape, (2, 3))
         self.assertEqual(
-            (elaborate_value._DNDarray__array == torch.tensor(ground_truth, dtype=torch_type))
+            (
+                elaborate_value._DNDarray__array
+                == torch.tensor(ground_truth, dtype=torch_type, device=device)
+            )
             .all()
             .item(),
             1,

--- a/heat/core/tests/test_types.py
+++ b/heat/core/tests/test_types.py
@@ -5,11 +5,11 @@ import os
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+    ht.torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestTypes(unittest.TestCase):

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -89,7 +89,7 @@ class generic:
                 )
         except AttributeError:
             # this is the case of that the first/only element of value is not a DNDarray
-            array = torch.tensor(*value, dtype=torch_type)
+            array = torch.tensor(*value, dtype=torch_type, device=device.torch_device)
         except TypeError as exception:
             # re-raise the exception to be consistent with numpy's exception interface
             raise ValueError(str(exception))

--- a/heat/ml/cluster/tests/test_kmeans.py
+++ b/heat/ml/cluster/tests/test_kmeans.py
@@ -3,7 +3,12 @@ import unittest
 
 import heat as ht
 
-ht.use_device(os.environ.get("DEVICE"))
+if os.environ.get("DEVICE") == "gpu":
+    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+    ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
+else:
+    ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestKMeans(unittest.TestCase):

--- a/heat/ml/cluster/tests/test_kmeans.py
+++ b/heat/ml/cluster/tests/test_kmeans.py
@@ -3,18 +3,25 @@ import unittest
 
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if ht.torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and ht.torch.cuda.is_available():
+    ht.use_device("gpu")
     ht.torch.cuda.set_device(ht.torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and ht.torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    ht.torch.cuda.set_device(device)
 
 
 class TestKMeans(unittest.TestCase):
     def test_fit_iris(self):
         # get some test data
-        iris = ht.load_hdf5(os.path.join(os.getcwd(), "heat/datasets/data/iris.h5"), "data")
+        iris = ht.load_hdf5(
+            os.path.join(os.getcwd(), "heat/datasets/data/iris.h5"), "data", device=ht_device
+        )
 
         # fit the clusters
         k = 3

--- a/heat/ml/cluster/tests/test_kmeans.py
+++ b/heat/ml/cluster/tests/test_kmeans.py
@@ -3,6 +3,8 @@ import unittest
 
 import heat as ht
 
+ht.use_device(os.environ.get("DEVICE"))
+
 
 class TestKMeans(unittest.TestCase):
     def test_fit_iris(self):

--- a/heat/ml/regression/lasso/lasso.py
+++ b/heat/ml/regression/lasso/lasso.py
@@ -118,7 +118,7 @@ class HeatLasso:
         _, n = X.shape
 
         # Initialize model parameters
-        theta = ht.zeros((n, 1), dtype=float)
+        theta = ht.zeros((n, 1), dtype=float, device=X.device)
 
         # Looping until max number of iterations or convergence
         for i in range(self.max_iter):

--- a/heat/ml/regression/lasso/lasso.py
+++ b/heat/ml/regression/lasso/lasso.py
@@ -435,7 +435,7 @@ class PytorchLasso:
         _, n = X.shape
 
         # Initialize model parameters
-        theta = torch.zeros(n, 1)
+        theta = torch.zeros(n, 1, device=X.device)
         # Looping until max number of iterations or convergence
         for i in range(self.max_iter):
 

--- a/heat/ml/regression/lasso/tests/test_lasso.py
+++ b/heat/ml/regression/lasso/tests/test_lasso.py
@@ -4,20 +4,33 @@ import numpy as np
 import torch
 import heat as ht
 
-if os.environ.get("DEVICE") == "gpu":
-    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+if os.environ.get("DEVICE") == "gpu" and torch.cuda.is_available():
+    ht.use_device("gpu")
     torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
     ht.use_device("cpu")
 device = ht.get_device().torch_device
+ht_device = None
+if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
+    device = ht.gpu.torch_device
+    ht_device = ht.gpu
+    torch.cuda.set_device(device)
 
 
 class TestLasso(unittest.TestCase):
     def test_lasso(self):
         # ToDo: add additional tests
         # get some test data
-        X = ht.load_hdf5(os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"), dataset="x")
-        y = ht.load_hdf5(os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"), dataset="y")
+        X = ht.load_hdf5(
+            os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"),
+            dataset="x",
+            device=ht_device,
+        )
+        y = ht.load_hdf5(
+            os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"),
+            dataset="y",
+            device=ht_device,
+        )
 
         # normalize dataset
         X = X / ht.sqrt((ht.mean(X ** 2, axis=0)))
@@ -48,8 +61,16 @@ class TestLasso(unittest.TestCase):
         self.assertIsInstance(yest, ht.DNDarray)
         self.assertEqual(yest.shape, (m,))
 
-        X = ht.load_hdf5(os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"), dataset="x")
-        y = ht.load_hdf5(os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"), dataset="y")
+        X = ht.load_hdf5(
+            os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"),
+            dataset="x",
+            device=ht_device,
+        )
+        y = ht.load_hdf5(
+            os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"),
+            dataset="y",
+            device=ht_device,
+        )
 
         # Now the same stuff again in PyTorch
         X = torch.tensor(X._DNDarray__array, device=device)
@@ -84,8 +105,16 @@ class TestLasso(unittest.TestCase):
         self.assertIsInstance(yest, torch.Tensor)
         self.assertEqual(yest.shape, (m,))
 
-        X = ht.load_hdf5(os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"), dataset="x")
-        y = ht.load_hdf5(os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"), dataset="y")
+        X = ht.load_hdf5(
+            os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"),
+            dataset="x",
+            device=ht_device,
+        )
+        y = ht.load_hdf5(
+            os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"),
+            dataset="y",
+            device=ht_device,
+        )
 
         # Now the same stuff again in PyTorch
         X = X._DNDarray__array.cpu().numpy()

--- a/heat/ml/regression/lasso/tests/test_lasso.py
+++ b/heat/ml/regression/lasso/tests/test_lasso.py
@@ -4,6 +4,13 @@ import numpy as np
 import torch
 import heat as ht
 
+if os.environ.get("DEVICE") == "gpu":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+else:
+    device = torch.device("cpu")
+    ht.use_device("cpu")
+
 
 class TestLasso(unittest.TestCase):
     def test_lasso(self):
@@ -45,8 +52,8 @@ class TestLasso(unittest.TestCase):
         y = ht.load_hdf5(os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"), dataset="y")
 
         # Now the same stuff again in PyTorch
-        X = torch.tensor(X._DNDarray__array)
-        y = torch.tensor(y._DNDarray__array)
+        X = torch.tensor(X._DNDarray__array, device=device)
+        y = torch.tensor(y._DNDarray__array, device=device)
 
         # normalize dataset
         X = X / torch.sqrt((torch.mean(X ** 2, 0)))
@@ -81,8 +88,8 @@ class TestLasso(unittest.TestCase):
         y = ht.load_hdf5(os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"), dataset="y")
 
         # Now the same stuff again in PyTorch
-        X = X._DNDarray__array.numpy()
-        y = y._DNDarray__array.numpy()
+        X = X._DNDarray__array.cpu().numpy()
+        y = y._DNDarray__array.cpu().numpy()
 
         # normalize dataset
         X = X / np.sqrt((np.mean(X ** 2, axis=0, keepdims=True)))

--- a/heat/ml/regression/lasso/tests/test_lasso.py
+++ b/heat/ml/regression/lasso/tests/test_lasso.py
@@ -18,6 +18,7 @@ if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
 
 
 if ht.io.supports_hdf5():
+
     class TestLasso(unittest.TestCase):
         def test_lasso(self):
             # ToDo: add additional tests

--- a/heat/ml/regression/lasso/tests/test_lasso.py
+++ b/heat/ml/regression/lasso/tests/test_lasso.py
@@ -5,11 +5,11 @@ import torch
 import heat as ht
 
 if os.environ.get("DEVICE") == "gpu":
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ht.use_device("gpu" if torch.cuda.is_available() else "cpu")
+    torch.cuda.set_device(torch.device(ht.get_device().torch_device))
 else:
-    device = torch.device("cpu")
     ht.use_device("cpu")
+device = ht.get_device().torch_device
 
 
 class TestLasso(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering",
     ],
-    install_requires=["mpi4py>=3.0.0", "numpy>=1.13.0", "torch==1.3.0"],
+    install_requires=["mpi4py>=3.0.0", "numpy>=1.13.0", "torch==1.3.1"],
     extras_require={
         "hdf5": ["h5py>=2.8.0"],
         "netcdf": ["netCDF4>=1.4.0,<=1.5.2"],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering",
     ],
-    install_requires=["mpi4py>=3.0.0", "numpy>=1.13.0", "torch==1.3.1"],
+    install_requires=["mpi4py>=3.0.0", "numpy>=1.13.0", "torch>=1.3.0"],
     extras_require={
         "hdf5": ["h5py>=2.8.0"],
         "netcdf": ["netCDF4>=1.4.0,<=1.5.2"],


### PR DESCRIPTION
## Description

This fix enables the usage of GPU-tensors in heat if ht.use_device is globally set to "gpu". The existing unit tests are modified to test the cpu or gpu only. Also, tensors on locally set devices can be tested.

Fixes: #

Changes proposed:
– unit tests depend on selected device (Environment variable DEVICE=gpu for global, lgpu for locally defined gpu tensors, cpu otherwise)
– additional copy operations GPU <-> CPU for not cuda-aware MPI
– smaller fixes on some core functions for accepting gpu tensors

## Type of change
• Setting device parameter in torch functions
• bugfixes
• test modifications

Select relevant options.

[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update

Are all split configurations tested and accounted for?
[x] yes [ ] no
Does this change require a documentation update outside of the changes proposed?
[ ] yes [x] no
Does this change modify the behaviour of other functions?
[ ] yes [x] no
Are there code practices which require justification?
[ ] yes [ ] no
