### PR TITLE
Bub/413 balance bug

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -600,10 +600,8 @@ class DNDarray:
 
     def balance_(self):
         """
-        Function for balancing a DNDarray between all nodes.
-        To determine if this is needed use the is_balanced() function.
-        If the DNDarray is already balanced this function will do nothing.
-        This function modifies the DNDarray itself and does not return anything.
+        Function for balancing a DNDarray between all nodes. To determine if this is needed use the is_balanced function.
+        If the DNDarray is already balanced this function will do nothing. This function modifies the DNDarray itself and will not return anything.
 
         Examples
         --------
@@ -640,7 +638,7 @@ class DNDarray:
         sl_dtype = self.dtype.torch_type()
         # units -> {pr, 1st index, 2nd index}
         lshape_map = torch.zeros((self.comm.size, len(self.gshape)), dtype=int)
-        lshape_map[self.comm.rank, :] = torch.tensor(self.lshape)
+        lshape_map[self.comm.rank, :] = torch.Tensor(self.lshape)
         lshape_map_comm = self.comm.Iallreduce(MPI.IN_PLACE, lshape_map, MPI.SUM)
 
         chunk_map = torch.zeros((self.comm.size, len(self.gshape)), dtype=int)
@@ -657,28 +655,42 @@ class DNDarray:
         lshape_cumsum_old = lshape_cumsum.clone()
         data_start = torch.nonzero(lshape_map[..., self.split])
         data_start = data_start[0].item() if data_start.numel() > 0 else 0
+        # print()
+        # print(lshape_cumsum)
+        # print(chunk_cumsum)
         # # need the data start as well for process 0
+        # print('\t', lshape_map[..., self.split])
         rank = self.comm.rank
         for rcv_pr in range(self.comm.size):
             st = chunk_cumsum[rcv_pr].item()
             sp = chunk_cumsum[rcv_pr + 1].item()
-            hld = torch.nonzero(st <= lshape_cumsum_old).flatten()
+            # print(rcv_pr, lshape_cumsum)
+            hld = torch.nonzero(st <= lshape_cumsum[rcv_pr:]).flatten() + rcv_pr
             st_pr = hld[0].item() if hld.numel() > 0 else -1
             st_pr = st_pr if rcv_pr != 0 else data_start
-            hld = torch.nonzero(sp <= lshape_cumsum_old).flatten()
-            sp_pr = hld[0].item() if hld.numel() > 0 else -1
+            hld = torch.nonzero(sp <= lshape_cumsum[rcv_pr:]).flatten() + rcv_pr
+            sp_pr = hld[0].item() if hld.numel() > 0 else self.comm.size
+            # print(rcv_pr, st_pr, sp_pr, torch.nonzero(sp <= lshape_cumsum[rcv_pr:]).flatten())
             # st_pr and sp_pr are the processes on which the data sits at the beginning
             # need to loop from st_pr to sp_pr + 1 and send the pr
+            # print(rcv_pr, data_required, lshape_map[rcv_pr, self.split].item())
+
             for snd_pr in range(st_pr, sp_pr + 1):
+                if snd_pr == self.comm.size:
+                    break
                 data_required = abs(sp - st - lshape_map[rcv_pr, self.split].item())
                 send_slice = [slice(None)] * self.numdims
                 keep_slice = [slice(None)] * self.numdims
-                # send amount
-                send_amt = data_required if data_required <= lshape_map[snd_pr, self.split] \
-                    else lshape_map[snd_pr, self.split]
+                # send_amt = (chunk_map[rcv_pr, self.split] - lshape_map[snd_pr, self.split]).item()
+                send_amt = data_required if data_required <= lshape_map[snd_pr, self.split] else lshape_map[snd_pr, self.split]
                 if (sp - st) <= lshape_map[rcv_pr, self.split].item() or snd_pr == rcv_pr:
                     send_amt = 0
-
+                # if lshape_map[rcv_pr, self.split] > data_required:
+                #     send_amt =
+                # send amount is the data still needed by recv if that is available on the snd
+                # send_amt = data_required if data_required <= lshape_map[snd_pr, self.split].item() \
+                #     else lshape_map[snd_pr, self.split].item()
+                # print('r', rcv_pr, 's', snd_pr, send_amt, 'data req:', data_required, sp - st, lshape_map[rcv_pr, self.split].item())
                 if snd_pr > rcv_pr and send_amt != 0:  # data passed to a lower rank (off the top)
                     if rank == snd_pr:
                         send_slice[self.split] = slice(0, send_amt)
@@ -695,7 +707,7 @@ class DNDarray:
                         data = torch.zeros(shp, dtype=sl_dtype)
                         self.comm.Recv(data, source=snd_pr, tag=rcv_pr + self.comm.size + snd_pr)
                         self.__array = torch.cat((self.__array, data), dim=self.split)
-                if snd_pr < rcv_pr and send_amt != 0:  # data passed from the bottom
+                if snd_pr < rcv_pr and send_amt != 0:  # data passed to a high rank (from the bottom)
                     if rank == snd_pr:
                         send_slice[self.split] = slice(
                             self.lshape[self.split] - send_amt, self.lshape[self.split]
@@ -717,6 +729,7 @@ class DNDarray:
                 lshape_cumsum[rcv_pr] += send_amt
                 lshape_map[rcv_pr, self.split] += send_amt
                 lshape_map[snd_pr, self.split] -= send_amt
+                # print('\t', lshape_map[..., self.split], send_amt, '\n')
             if lshape_map[rcv_pr, self.split] > chunk_map[rcv_pr, self.split]:
                 # if there is still some data left on the process then move it to the next one
                 send_slice = [slice(None)] * self.numdims
@@ -741,10 +754,141 @@ class DNDarray:
                     data = torch.zeros(shp, dtype=sl_dtype)
                     self.comm.Recv(data, source=snd, tag=rcv + self.comm.size + snd)
                     self.__array = torch.cat((data, self.__array), dim=self.split)
+                # print('here2', rcv_pr, send_amt)
                 lshape_cumsum[rcv_pr] -= send_amt
                 lshape_cumsum[rcv_pr + 1] += send_amt
                 lshape_map[rcv_pr, self.split] -= send_amt
                 lshape_map[rcv_pr + 1, self.split] += send_amt
+                # print('\t', lshape_map[..., self.split], send_amt, '\n')
+
+        # # create list of which processes need to send data to lower ranked nodes
+        # send_list = [
+        #     True
+        #     if lshape_map[pr, self.split] != (chunk_map[pr, self.split])
+        #     and lshape_map[pr, self.split] != 0
+        #     else False
+        #     for pr in range(1, self.comm.size)
+        # ]
+        # send_list.insert(
+        #     0, True if lshape_map[0, self.split] > (chunk_map[0, self.split]) else False
+        # )
+        # first_pr_w_data = send_list.index(True)  # first process with *too much* data
+        # last_pr_w_data = next(
+        #     (
+        #         i
+        #         for i in reversed(range(len(lshape_map[:, self.split])))
+        #         if lshape_map[i, self.split] > chunk_map[i, self.split]
+        #     )
+        # )
+        #
+        # # create arbitrary slices for which data to send and which data to keep
+        # send_slice = [slice(None)] * self.numdims
+        # keep_slice = [slice(None)] * self.numdims
+        #
+        # # first send the first entries of the data to the 0th node and then the next data to the 1st ...
+        # # this will redistributed the data forward
+        # if first_pr_w_data != 0:
+        #     for spr in range(first_pr_w_data, last_pr_w_data + 1):
+        #         if self.comm.rank == spr:
+        #             for pr in range(spr):
+        #                 send_amt = abs(
+        #                     (chunk_map[pr, self.split] - lshape_map[pr, self.split]).item()
+        #                 )
+        #                 send_amt = (
+        #                     send_amt
+        #                     if send_amt < self.lshape[self.split]
+        #                     else self.lshape[self.split]
+        #                 )
+        #                 if send_amt:
+        #                     send_slice[self.split] = slice(0, send_amt)
+        #                     keep_slice[self.split] = slice(send_amt, self.lshape[self.split])
+        #
+        #                     self.comm.Isend(
+        #                         self.__array[send_slice].clone(),
+        #                         dest=pr,
+        #                         tag=pr + self.comm.size + spr,
+        #                     )
+        #                     self.__array = self.__array[keep_slice].clone()
+        #
+        #         # else:
+        #         for pr in range(spr):
+        #             snt = abs((chunk_map[pr, self.split] - lshape_map[pr, self.split]).item())
+        #             snt = (
+        #                 snt
+        #                 if snt < lshape_map[spr, self.split]
+        #                 else lshape_map[spr, self.split].item()
+        #             )
+        #
+        #             if self.comm.rank == pr and snt:
+        #                 shp = list(self.gshape)
+        #                 shp[self.split] = snt
+        #                 data = torch.zeros(shp, dtype=sl_dtype)
+        #                 self.comm.Recv(data, source=spr, tag=pr + self.comm.size + spr)
+        #                 self.__array = torch.cat((self.__array, data), dim=self.split)
+        #             lshape_map[pr, self.split] += snt
+        #             lshape_map[spr, self.split] -= snt
+        #
+        # if self.is_balanced():
+        #     return
+        #
+        # # now the DNDarray is balanced from 0 to x, (by pulling data from the higher ranking nodes)
+        # # next we balance the data from x to the self.comm.size
+        # send_list = [
+        #     True if lshape_map[pr, self.split] > (chunk_map[pr, self.split]) else False
+        #     for pr in range(self.comm.size)
+        # ]
+        # first_pr_w_data = send_list.index(True)  # first process with *too much* data
+        # last_pr_w_data = next(
+        #     (
+        #         i
+        #         for i in reversed(range(len(lshape_map[:, self.split])))
+        #         if lshape_map[i, self.split] > chunk_map[i, self.split]
+        #     )
+        # )
+        #
+        # send_slice = [slice(None)] * self.numdims
+        # keep_slice = [slice(None)] * self.numdims
+        # # need to send from the last one with data
+        # # start from x then push the data to the next one. then do the same at x+1 until the last process
+        # balanced_process = [False for _ in range(self.comm.size)]
+        # for pr in range(self.comm.size):
+        #     balanced_process[pr] = (
+        #         True if chunk_map[pr, self.split] == lshape_map[pr, self.split] else False
+        #     )
+        #     if pr > 0:
+        #         if any(i is False for i in balanced_process[:pr]):
+        #             balanced_process[pr] = False
+        #
+        # for pr, b in enumerate(balanced_process[:-1]):
+        #     if not b:  # if the process is not balanced
+        #         send_amt = abs((chunk_map[pr, self.split] - lshape_map[pr, self.split]).item())
+        #         send_amt = (
+        #             send_amt
+        #             if send_amt < lshape_map[pr, self.split]
+        #             else lshape_map[pr, self.split]
+        #         )
+        #         if send_amt:
+        #             if self.comm.rank == pr:  # send data to the next process
+        #                 send_slice[self.split] = slice(
+        #                     self.lshape[self.split] - send_amt, self.lshape[self.split]
+        #                 )
+        #                 keep_slice[self.split] = slice(0, self.lshape[self.split] - send_amt)
+        #
+        #                 self.comm.Send(
+        #                     self.__array[send_slice].clone(),
+        #                     dest=pr + 1,
+        #                     tag=pr + self.comm.size + pr + 1,
+        #                 )
+        #                 self.__array = self.__array[keep_slice].clone()
+        #
+        #             if self.comm.rank == pr + 1:  # receive data on the next process
+        #                 shp = list(self.gshape)
+        #                 shp[self.split] = send_amt
+        #                 data = torch.zeros(shp, dtype=sl_dtype)
+        #                 self.comm.Recv(data, source=pr, tag=pr + self.comm.size + pr + 1)
+        #                 self.__array = torch.cat((data, self.__array), dim=self.split)
+        #             lshape_map[pr, self.split] -= send_amt
+        #             lshape_map[pr + 1, self.split] += send_amt
 
     def __bool__(self):
         """

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -726,10 +726,9 @@ class DNDarray:
             if snd_pr > rcv_pr:  # data passed to a lower rank (off the top)
                 send_slice[self.split] = slice(0, send_amt)
                 keep_slice[self.split] = slice(send_amt, self.lshape[self.split])
-            self.comm.Isend(
-                self.__array[send_slice].clone(), dest=rcv_pr, tag=rcv_pr + self.comm.size + snd_pr
-            )
-            self.__array = self.__array[keep_slice].clone()
+            data = self.__array[send_slice].clone()
+            self.comm.Isend(data, dest=rcv_pr, tag=rcv_pr + self.comm.size + snd_pr)
+            self.__array = self.__array[keep_slice]
         if rank == rcv_pr:
             shp = list(self.gshape)
             shp[self.split] = send_amt

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -650,47 +650,37 @@ class DNDarray:
         lshape_map_comm.wait()
         chunk_map_comm.wait()
         lshape_cumsum = torch.cumsum(lshape_map[..., self.split], dim=0)
-        chunk_cumsum = torch.cat((torch.tensor([0]),
-                                  torch.cumsum(chunk_map[..., self.split], dim=0)), dim=0)
-        lshape_cumsum_old = lshape_cumsum.clone()
+        chunk_cumsum = torch.cat(
+            (torch.tensor([0]), torch.cumsum(chunk_map[..., self.split], dim=0)), dim=0
+        )
         data_start = torch.nonzero(lshape_map[..., self.split])
         data_start = data_start[0].item() if data_start.numel() > 0 else 0
-        # print()
-        # print(lshape_cumsum)
-        # print(chunk_cumsum)
         # # need the data start as well for process 0
-        # print('\t', lshape_map[..., self.split])
         rank = self.comm.rank
         for rcv_pr in range(self.comm.size):
             st = chunk_cumsum[rcv_pr].item()
             sp = chunk_cumsum[rcv_pr + 1].item()
-            # print(rcv_pr, lshape_cumsum)
             hld = torch.nonzero(st <= lshape_cumsum[rcv_pr:]).flatten() + rcv_pr
             st_pr = hld[0].item() if hld.numel() > 0 else -1
             st_pr = st_pr if rcv_pr != 0 else data_start
             hld = torch.nonzero(sp <= lshape_cumsum[rcv_pr:]).flatten() + rcv_pr
             sp_pr = hld[0].item() if hld.numel() > 0 else self.comm.size
-            # print(rcv_pr, st_pr, sp_pr, torch.nonzero(sp <= lshape_cumsum[rcv_pr:]).flatten())
             # st_pr and sp_pr are the processes on which the data sits at the beginning
             # need to loop from st_pr to sp_pr + 1 and send the pr
-            # print(rcv_pr, data_required, lshape_map[rcv_pr, self.split].item())
-
             for snd_pr in range(st_pr, sp_pr + 1):
                 if snd_pr == self.comm.size:
                     break
                 data_required = abs(sp - st - lshape_map[rcv_pr, self.split].item())
                 send_slice = [slice(None)] * self.numdims
                 keep_slice = [slice(None)] * self.numdims
-                # send_amt = (chunk_map[rcv_pr, self.split] - lshape_map[snd_pr, self.split]).item()
-                send_amt = data_required if data_required <= lshape_map[snd_pr, self.split] else lshape_map[snd_pr, self.split]
+                send_amt = (
+                    data_required
+                    if data_required <= lshape_map[snd_pr, self.split]
+                    else lshape_map[snd_pr, self.split]
+                )
                 if (sp - st) <= lshape_map[rcv_pr, self.split].item() or snd_pr == rcv_pr:
                     send_amt = 0
-                # if lshape_map[rcv_pr, self.split] > data_required:
-                #     send_amt =
                 # send amount is the data still needed by recv if that is available on the snd
-                # send_amt = data_required if data_required <= lshape_map[snd_pr, self.split].item() \
-                #     else lshape_map[snd_pr, self.split].item()
-                # print('r', rcv_pr, 's', snd_pr, send_amt, 'data req:', data_required, sp - st, lshape_map[rcv_pr, self.split].item())
                 if snd_pr > rcv_pr and send_amt != 0:  # data passed to a lower rank (off the top)
                     if rank == snd_pr:
                         send_slice[self.split] = slice(0, send_amt)
@@ -698,7 +688,7 @@ class DNDarray:
                         self.comm.Isend(
                             self.__array[send_slice].clone(),
                             dest=rcv_pr,
-                            tag=rcv_pr + self.comm.size + snd_pr
+                            tag=rcv_pr + self.comm.size + snd_pr,
                         )
                         self.__array = self.__array[keep_slice].clone()
                     if rank == rcv_pr:
@@ -707,7 +697,9 @@ class DNDarray:
                         data = torch.zeros(shp, dtype=sl_dtype)
                         self.comm.Recv(data, source=snd_pr, tag=rcv_pr + self.comm.size + snd_pr)
                         self.__array = torch.cat((self.__array, data), dim=self.split)
-                if snd_pr < rcv_pr and send_amt != 0:  # data passed to a high rank (from the bottom)
+                if (
+                    snd_pr < rcv_pr and send_amt != 0
+                ):  # data passed to a high rank (from the bottom)
                     if rank == snd_pr:
                         send_slice[self.split] = slice(
                             self.lshape[self.split] - send_amt, self.lshape[self.split]
@@ -716,7 +708,7 @@ class DNDarray:
                         self.comm.Isend(
                             self.__array[send_slice].clone(),
                             dest=rcv_pr,
-                            tag=rcv_pr + self.comm.size + snd_pr
+                            tag=rcv_pr + self.comm.size + snd_pr,
                         )
                         self.__array = self.__array[keep_slice].clone()
                     if rank == rcv_pr:
@@ -729,9 +721,8 @@ class DNDarray:
                 lshape_cumsum[rcv_pr] += send_amt
                 lshape_map[rcv_pr, self.split] += send_amt
                 lshape_map[snd_pr, self.split] -= send_amt
-                # print('\t', lshape_map[..., self.split], send_amt, '\n')
             if lshape_map[rcv_pr, self.split] > chunk_map[rcv_pr, self.split]:
-                # if there is still some data left on the process then move it to the next one
+                # if there is any data left on the process then send it to the next one
                 send_slice = [slice(None)] * self.numdims
                 keep_slice = [slice(None)] * self.numdims
                 send_amt = lshape_map[rcv_pr, self.split] - chunk_map[rcv_pr, self.split]
@@ -743,9 +734,7 @@ class DNDarray:
                     )
                     keep_slice[self.split] = slice(0, self.lshape[self.split] - send_amt)
                     self.comm.Isend(
-                        self.__array[send_slice].clone(),
-                        dest=rcv,
-                        tag=rcv + self.comm.size + snd
+                        self.__array[send_slice].clone(), dest=rcv, tag=rcv + self.comm.size + snd
                     )
                     self.__array = self.__array[keep_slice].clone()
                 if rank == rcv:
@@ -754,141 +743,10 @@ class DNDarray:
                     data = torch.zeros(shp, dtype=sl_dtype)
                     self.comm.Recv(data, source=snd, tag=rcv + self.comm.size + snd)
                     self.__array = torch.cat((data, self.__array), dim=self.split)
-                # print('here2', rcv_pr, send_amt)
                 lshape_cumsum[rcv_pr] -= send_amt
                 lshape_cumsum[rcv_pr + 1] += send_amt
                 lshape_map[rcv_pr, self.split] -= send_amt
                 lshape_map[rcv_pr + 1, self.split] += send_amt
-                # print('\t', lshape_map[..., self.split], send_amt, '\n')
-
-        # # create list of which processes need to send data to lower ranked nodes
-        # send_list = [
-        #     True
-        #     if lshape_map[pr, self.split] != (chunk_map[pr, self.split])
-        #     and lshape_map[pr, self.split] != 0
-        #     else False
-        #     for pr in range(1, self.comm.size)
-        # ]
-        # send_list.insert(
-        #     0, True if lshape_map[0, self.split] > (chunk_map[0, self.split]) else False
-        # )
-        # first_pr_w_data = send_list.index(True)  # first process with *too much* data
-        # last_pr_w_data = next(
-        #     (
-        #         i
-        #         for i in reversed(range(len(lshape_map[:, self.split])))
-        #         if lshape_map[i, self.split] > chunk_map[i, self.split]
-        #     )
-        # )
-        #
-        # # create arbitrary slices for which data to send and which data to keep
-        # send_slice = [slice(None)] * self.numdims
-        # keep_slice = [slice(None)] * self.numdims
-        #
-        # # first send the first entries of the data to the 0th node and then the next data to the 1st ...
-        # # this will redistributed the data forward
-        # if first_pr_w_data != 0:
-        #     for spr in range(first_pr_w_data, last_pr_w_data + 1):
-        #         if self.comm.rank == spr:
-        #             for pr in range(spr):
-        #                 send_amt = abs(
-        #                     (chunk_map[pr, self.split] - lshape_map[pr, self.split]).item()
-        #                 )
-        #                 send_amt = (
-        #                     send_amt
-        #                     if send_amt < self.lshape[self.split]
-        #                     else self.lshape[self.split]
-        #                 )
-        #                 if send_amt:
-        #                     send_slice[self.split] = slice(0, send_amt)
-        #                     keep_slice[self.split] = slice(send_amt, self.lshape[self.split])
-        #
-        #                     self.comm.Isend(
-        #                         self.__array[send_slice].clone(),
-        #                         dest=pr,
-        #                         tag=pr + self.comm.size + spr,
-        #                     )
-        #                     self.__array = self.__array[keep_slice].clone()
-        #
-        #         # else:
-        #         for pr in range(spr):
-        #             snt = abs((chunk_map[pr, self.split] - lshape_map[pr, self.split]).item())
-        #             snt = (
-        #                 snt
-        #                 if snt < lshape_map[spr, self.split]
-        #                 else lshape_map[spr, self.split].item()
-        #             )
-        #
-        #             if self.comm.rank == pr and snt:
-        #                 shp = list(self.gshape)
-        #                 shp[self.split] = snt
-        #                 data = torch.zeros(shp, dtype=sl_dtype)
-        #                 self.comm.Recv(data, source=spr, tag=pr + self.comm.size + spr)
-        #                 self.__array = torch.cat((self.__array, data), dim=self.split)
-        #             lshape_map[pr, self.split] += snt
-        #             lshape_map[spr, self.split] -= snt
-        #
-        # if self.is_balanced():
-        #     return
-        #
-        # # now the DNDarray is balanced from 0 to x, (by pulling data from the higher ranking nodes)
-        # # next we balance the data from x to the self.comm.size
-        # send_list = [
-        #     True if lshape_map[pr, self.split] > (chunk_map[pr, self.split]) else False
-        #     for pr in range(self.comm.size)
-        # ]
-        # first_pr_w_data = send_list.index(True)  # first process with *too much* data
-        # last_pr_w_data = next(
-        #     (
-        #         i
-        #         for i in reversed(range(len(lshape_map[:, self.split])))
-        #         if lshape_map[i, self.split] > chunk_map[i, self.split]
-        #     )
-        # )
-        #
-        # send_slice = [slice(None)] * self.numdims
-        # keep_slice = [slice(None)] * self.numdims
-        # # need to send from the last one with data
-        # # start from x then push the data to the next one. then do the same at x+1 until the last process
-        # balanced_process = [False for _ in range(self.comm.size)]
-        # for pr in range(self.comm.size):
-        #     balanced_process[pr] = (
-        #         True if chunk_map[pr, self.split] == lshape_map[pr, self.split] else False
-        #     )
-        #     if pr > 0:
-        #         if any(i is False for i in balanced_process[:pr]):
-        #             balanced_process[pr] = False
-        #
-        # for pr, b in enumerate(balanced_process[:-1]):
-        #     if not b:  # if the process is not balanced
-        #         send_amt = abs((chunk_map[pr, self.split] - lshape_map[pr, self.split]).item())
-        #         send_amt = (
-        #             send_amt
-        #             if send_amt < lshape_map[pr, self.split]
-        #             else lshape_map[pr, self.split]
-        #         )
-        #         if send_amt:
-        #             if self.comm.rank == pr:  # send data to the next process
-        #                 send_slice[self.split] = slice(
-        #                     self.lshape[self.split] - send_amt, self.lshape[self.split]
-        #                 )
-        #                 keep_slice[self.split] = slice(0, self.lshape[self.split] - send_amt)
-        #
-        #                 self.comm.Send(
-        #                     self.__array[send_slice].clone(),
-        #                     dest=pr + 1,
-        #                     tag=pr + self.comm.size + pr + 1,
-        #                 )
-        #                 self.__array = self.__array[keep_slice].clone()
-        #
-        #             if self.comm.rank == pr + 1:  # receive data on the next process
-        #                 shp = list(self.gshape)
-        #                 shp[self.split] = send_amt
-        #                 data = torch.zeros(shp, dtype=sl_dtype)
-        #                 self.comm.Recv(data, source=pr, tag=pr + self.comm.size + pr + 1)
-        #                 self.__array = torch.cat((data, self.__array), dim=self.split)
-        #             lshape_map[pr, self.split] -= send_amt
-        #             lshape_map[pr + 1, self.split] += send_amt
 
     def __bool__(self):
         """

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -727,13 +727,13 @@ class DNDarray:
                 send_slice[self.split] = slice(0, send_amt)
                 keep_slice[self.split] = slice(send_amt, self.lshape[self.split])
             data = self.__array[send_slice].clone()
-            self.comm.Isend(data, dest=rcv_pr, tag=rcv_pr + self.comm.size + snd_pr)
+            self.comm.Send(data, dest=rcv_pr, tag=685)
             self.__array = self.__array[keep_slice]
         if rank == rcv_pr:
             shp = list(self.gshape)
             shp[self.split] = send_amt
             data = torch.zeros(shp, dtype=sl_dtype)
-            self.comm.Recv(data, source=snd_pr, tag=rcv_pr + self.comm.size + snd_pr)
+            self.comm.Recv(data, source=snd_pr, tag=685)
             if snd_pr < rcv_pr:  # data passed from a lower rank (append to top)
                 self.__array = torch.cat((data, self.__array), dim=self.split)
             if snd_pr > rcv_pr:  # data passed from a higher rank (append to bottom)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -185,7 +185,7 @@ class TestArithmetics(unittest.TestCase):
                         lp_array = ht.manipulations.resplit(ht_array[arb_slice], sp)
                         np_array = ht_array[arb_slice].numpy()
 
-                        ht_diff = ht.float(ht.diff(lp_array, n=nl, axis=ax))
+                        ht_diff = ht.diff(lp_array, n=nl, axis=ax)
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
 
                         self.assertTrue(ht.equal(ht_diff, np_diff))

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -189,7 +189,7 @@ class TestArithmetics(unittest.TestCase):
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
                         # print(ht_diff._DNDarray__array.dtype, np_diff._DNDarray__array.dtype)
                         # print(dim, ax, sp, nl, ht.allclose((ht_diff - np_diff), 0))
-                        print(dim, ax, sp, nl, ht.nonzero(ht_diff - np_diff))
+                        print(ht_diff.comm.rank, dim, ax, sp, nl, ht.nonzero(ht_diff - np_diff))
                         self.assertTrue(ht.equal(ht_diff, np_diff))
                         self.assertEqual(ht_diff.split, sp)
                         # self.assertEqual(ht_diff.dtype, lp_array.dtype)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -185,12 +185,12 @@ class TestArithmetics(unittest.TestCase):
                         lp_array = ht.manipulations.resplit(ht_array[arb_slice], sp)
                         np_array = ht_array[arb_slice].numpy()
 
-                        ht_diff = ht.diff(lp_array, n=nl, axis=ax)
-                        np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
-                        print(ht_diff, np_diff)
+                        ht_diff = ht.float(ht.diff(lp_array, n=nl, axis=ax))
+                        np_diff = ht.array(np.diff(np_array, n=nl, axis=ax), dtype=ht_array.dtype)
+                        print(ht.allclose((ht_diff - np_diff), 0))
                         self.assertTrue(ht.equal(ht_diff, np_diff))
                         self.assertEqual(ht_diff.split, sp)
-                        self.assertEqual(ht_diff.dtype, lp_array.dtype)
+                        # self.assertEqual(ht_diff.dtype, lp_array.dtype)
 
         np_array = ht_array.numpy()
         ht_diff = ht.diff(ht_array, n=2)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -187,7 +187,7 @@ class TestArithmetics(unittest.TestCase):
 
                         ht_diff = ht.float(ht.diff(lp_array, n=nl, axis=ax))
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax), dtype=ht_array.dtype)
-                        print(ht.allclose((ht_diff - np_diff), 0))
+                        print(dim, ax, sp, nl, ht.allclose((ht_diff - np_diff), 0))
                         self.assertTrue(ht.equal(ht_diff, np_diff))
                         self.assertEqual(ht_diff.split, sp)
                         # self.assertEqual(ht_diff.dtype, lp_array.dtype)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -189,7 +189,13 @@ class TestArithmetics(unittest.TestCase):
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
                         # print(ht_diff._DNDarray__array.dtype, np_diff._DNDarray__array.dtype)
                         # print(dim, ax, sp, nl, ht.allclose((ht_diff - np_diff), 0))
-                        print(ht_diff.comm.rank, dim, ax, sp, nl, ht.nonzero(ht_diff - np_diff))
+                        print(
+                            ht_diff.comm.rank, dim, ax, sp, nl, ht.nonzero(ht_diff - np_diff).lshape
+                        )
+                        nz = torch.nonzero((ht_diff - np_diff)._DNDarray__array)
+                        if nz.numel() > 0:
+                            print("h", ht_diff._DNDarray__array[nz], np_diff._DNDarray__array[nz])
+
                         self.assertTrue(ht.equal(ht_diff, np_diff))
                         self.assertEqual(ht_diff.split, sp)
                         # self.assertEqual(ht_diff.dtype, lp_array.dtype)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -186,8 +186,10 @@ class TestArithmetics(unittest.TestCase):
                         np_array = ht_array[arb_slice].numpy()
 
                         ht_diff = ht.float(ht.diff(lp_array, n=nl, axis=ax))
-                        np_diff = ht.array(np.diff(np_array, n=nl, axis=ax), dtype=ht_array.dtype)
-                        print(dim, ax, sp, nl, ht.allclose((ht_diff - np_diff), 0))
+                        np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
+                        # print(ht_diff._DNDarray__array.dtype, np_diff._DNDarray__array.dtype)
+                        # print(dim, ax, sp, nl, ht.allclose((ht_diff - np_diff), 0))
+                        print(dim, ax, sp, nl, ht.nonzero(ht_diff - np_diff))
                         self.assertTrue(ht.equal(ht_diff, np_diff))
                         self.assertEqual(ht_diff.split, sp)
                         # self.assertEqual(ht_diff.dtype, lp_array.dtype)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -187,16 +187,10 @@ class TestArithmetics(unittest.TestCase):
 
                         ht_diff = ht.float(ht.diff(lp_array, n=nl, axis=ax))
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
-                        # print(ht_diff._DNDarray__array.dtype, np_diff._DNDarray__array.dtype)
-                        # print(dim, ax, sp, nl, ht.allclose((ht_diff - np_diff), 0))
-                        print(ht_diff.comm.rank, dim, ax, sp, nl, ht.nonzero(ht_diff - np_diff))
-                        nz = torch.nonzero((ht_diff - np_diff)._DNDarray__array)
-                        if nz.numel() > 0:
-                            print("h", ht_diff._DNDarray__array[nz], np_diff._DNDarray__array[nz])
 
                         self.assertTrue(ht.equal(ht_diff, np_diff))
                         self.assertEqual(ht_diff.split, sp)
-                        # self.assertEqual(ht_diff.dtype, lp_array.dtype)
+                        self.assertEqual(ht_diff.dtype, lp_array.dtype)
 
         np_array = ht_array.numpy()
         ht_diff = ht.diff(ht_array, n=2)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -189,9 +189,7 @@ class TestArithmetics(unittest.TestCase):
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
                         # print(ht_diff._DNDarray__array.dtype, np_diff._DNDarray__array.dtype)
                         # print(dim, ax, sp, nl, ht.allclose((ht_diff - np_diff), 0))
-                        print(
-                            ht_diff.comm.rank, dim, ax, sp, nl, ht.nonzero(ht_diff - np_diff).lshape
-                        )
+                        print(ht_diff.comm.rank, dim, ax, sp, nl, ht.nonzero(ht_diff - np_diff))
                         nz = torch.nonzero((ht_diff - np_diff)._DNDarray__array)
                         if nz.numel() > 0:
                             print("h", ht_diff._DNDarray__array[nz], np_diff._DNDarray__array[nz])

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -187,6 +187,7 @@ class TestArithmetics(unittest.TestCase):
 
                         ht_diff = ht.diff(lp_array, n=nl, axis=ax)
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
+                        print(ht_diff, np_diff)
                         self.assertTrue(ht.equal(ht_diff, np_diff))
                         self.assertEqual(ht_diff.split, sp)
                         self.assertEqual(ht_diff.dtype, lp_array.dtype)

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -60,6 +60,22 @@ class TestDNDarray(unittest.TestCase):
         htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0)
         self.assertTrue(ht.equal(htdata, ht.array(data, split=0, dtype=ht.float)))
 
+        if ht.MPI_WORLD.size > 4:
+            rank = ht.MPI_WORLD.rank
+            if rank == 2:
+                arr = torch.tensor([0, 1])
+            elif rank == 3:
+                arr = torch.tensor([2, 3, 4, 5])
+            elif rank == 4:
+                arr = torch.tensor([6, 7, 8, 9])
+            else:
+                arr = torch.empty([0], dtype=torch.int64)
+            a = ht.array(arr, is_split=0)
+            a.balance_()
+            comp = ht.arange(10, split=0)
+
+            self.assertTrue(ht.equal(a, comp))
+
     def test_bool_cast(self):
         # simple scalar tensor
         a = ht.ones(1)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -790,9 +790,9 @@ class TestStatistics(unittest.TestCase):
         # the rest of the tests are covered by var
 
     def test_var(self):
-        array_0_len = 14
-        array_1_len = 14
-        array_2_len = 14
+        array_0_len = ht.MPI_WORLD.size * 2
+        array_1_len = ht.MPI_WORLD.size * 2
+        array_2_len = ht.MPI_WORLD.size * 2
 
         # test raises
         x = ht.zeros((2, 3, 4))

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering",
     ],
-    install_requires=["mpi4py>=3.0.0", "numpy>=1.13.0", "torch==1.3.0"],
+    install_requires=["mpi4py>=3.0.0", "numpy>=1.13.0", "torch>=1.3.0"],
     extras_require={
         "hdf5": ["h5py>=2.8.0"],
         "netcdf": ["netCDF4>=1.4.0,<=1.5.2"],


### PR DESCRIPTION
## Description

re-wrote the balance function for better legibility, fixed bug.
balance now only loops over the number of processes once, once a process is balanced then it pushes the rest of the data to the next process. if there is not enough data on the process then it is pulled from the next processes with data

Fixes: #413 #414 

Changes proposed:
- update of balance function

## Type of change

Select relevant options.

[X] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update

Are all split configurations tested and accounted for?
[X] yes [ ] no
Does this change require a documentation update outside of the changes proposed?
[ ] yes [X] no
Does this change modify the behaviour of other functions?
[ ] yes [X] no (it might but if anything it should correct any issues)
Are there code practices which require justification?
[X] yes [ ] no
    - deep loops used with rank selection