### PR TITLE
Travis errno fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ script:
   # Running multiple mpi process count, generate a unique coverage report for each one and merge into one report
   - |
     docker exec -t unittest /bin/bash -c '. /root/.bashrc && \
-      for i in {1..4}; do mpirun --mca btl_vader_single_copy_mechanism none --allow-run-as-root -np $i coverage run --source=heat --parallel-mode -m pytest heat/ || exit; done && \
-      mpirun --mca btl_vader_single_copy_mechanism none --allow-run-as-root -np 7 coverage run --source=heat --parallel-mode -m pytest heat/ && \
+      for i in {1..4}; do mpirun --mca btl_vader_single_copy_mechanism none --mca btl ^openib --allow-run-as-root -np $i coverage run --source=heat --parallel-mode -m pytest heat/ || exit; done && \
+      mpirun --mca btl_vader_single_copy_mechanism none --mca btl ^openib --allow-run-as-root -np 7 coverage run --source=heat --parallel-mode -m pytest heat/ && \
       coverage combine && \
       coverage report && \
       coverage xml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 
 script:
   # Running multiple mpi process count, generate a unique coverage report for each one and merge into one report
+  # See https://github.com/open-mpi/ompi/issues/4948 and https://github.com/open-mpi/ompi/issues/1393 for the --mca settings
   - |
     docker exec -t unittest /bin/bash -c '. /root/.bashrc && \
       for i in {1..4}; do mpirun --mca btl_vader_single_copy_mechanism none --mca btl ^openib --allow-run-as-root -np $i coverage run --source=heat --parallel-mode -m pytest heat/ || exit; done && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,13 @@ services:
 
 before_install:
   - pip install codecov
-  - docker pull markusgoetz/heat
+  - docker pull simonsdockerid/heat
   - docker run -dt --name unittest -v $PWD:/heat markusgoetz/heat
   - pip install pre-commit
 
 install:
   - pre-commit run --all-files
   - docker exec -t unittest /bin/bash -c '. /root/.bashrc && pip install -q -e .[hdf5,netcdf] && pip list'
-  # See https://github.com/open-mpi/ompi/issues/4948 for more information
-  - docker exec -t unittest /bin/bash -c 'export OMPI_MCA_btl_vader_single_copy_mechanism=none'
 
 script:
   # Running multiple mpi process count, generate a unique coverage report for each one and merge into one report

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 before_install:
   - pip install codecov
-  - docker pull simonsdockerid/heat
+  - docker pull markusgoetz/heat
   - docker run -dt --name unittest -v $PWD:/heat markusgoetz/heat
   - pip install pre-commit
 
@@ -19,8 +19,8 @@ script:
   # Running multiple mpi process count, generate a unique coverage report for each one and merge into one report
   - |
     docker exec -t unittest /bin/bash -c '. /root/.bashrc && \
-      for i in {1..4}; do mpirun --allow-run-as-root -np $i coverage run --source=heat --parallel-mode -m pytest heat/ || exit; done && \
-      mpirun --allow-run-as-root -np 7 coverage run --source=heat --parallel-mode -m pytest heat/ && \
+      for i in {1..4}; do mpirun --mca btl_vader_single_copy_mechanism none --allow-run-as-root -np $i coverage run --source=heat --parallel-mode -m pytest heat/ || exit; done && \
+      mpirun --mca btl_vader_single_copy_mechanism none --allow-run-as-root -np 7 coverage run --source=heat --parallel-mode -m pytest heat/ && \
       coverage combine && \
       coverage report && \
       coverage xml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
 install:
   - pre-commit run --all-files
   - docker exec -t unittest /bin/bash -c '. /root/.bashrc && pip install -q -e .[hdf5,netcdf] && pip list'
+  # See https://github.com/open-mpi/ompi/issues/4948 for more information
+  - export OMPI_MCA_btl_vader_single_copy_mechanism=none
 
 script:
   # Running multiple mpi process count, generate a unique coverage report for each one and merge into one report

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - pre-commit run --all-files
   - docker exec -t unittest /bin/bash -c '. /root/.bashrc && pip install -q -e .[hdf5,netcdf] && pip list'
   # See https://github.com/open-mpi/ompi/issues/4948 for more information
-  - export OMPI_MCA_btl_vader_single_copy_mechanism=none
+  - docker exec -t unittest /bin/bash -c 'export OMPI_MCA_btl_vader_single_copy_mechanism=none'
 
 script:
   # Running multiple mpi process count, generate a unique coverage report for each one and merge into one report

--- a/heat/core/tests/Dockerfile
+++ b/heat/core/tests/Dockerfile
@@ -12,4 +12,5 @@ RUN python3 -m venv ~/.virtualenvs/heat && \
 
 RUN echo "cd /heat && \
     . ~/.virtualenvs/heat/bin/activate && \
-    module load mpi" >> /root/.bashrc
+    module load mpi && \
+    export OMPI_MCA_btl_vader_single_copy_mechanism=none" >> /root/.bashrc

--- a/heat/core/tests/Dockerfile
+++ b/heat/core/tests/Dockerfile
@@ -12,5 +12,4 @@ RUN python3 -m venv ~/.virtualenvs/heat && \
 
 RUN echo "cd /heat && \
     . ~/.virtualenvs/heat/bin/activate && \
-    module load mpi && \
-    export OMPI_MCA_btl_vader_single_copy_mechanism=none" >> /root/.bashrc
+    module load mpi" >> /root/.bashrc


### PR DESCRIPTION
## Description

After some searching around I found [this thread](https://github.com/open-mpi/ompi/issues/4948)  about the problem with the erros in the travis log:

```
Read -1, expected <someNumber>, errno =1
Read -1, expected <someNumber>, errno =1
Read -1, expected <someNumber>, errno =1
Read -1, expected <someNumber>, errno =1
Read -1, expected <someNumber>, errno =1
...
```

Trying out some of the proposed fixes, I finally found one that is actually working in our case.

Maybe someone of you knows more about what I am disabling by this option but as far as I understood it, docker has some security settings which result in this error messages. 
Another approach would be turning of these settings (as described [here](https://github.com/open-mpi/ompi/issues/4948#issuecomment-512987494)), which would maybe improve the performance but I did not try it out because I did not fully understand what I would have to do.

## Type of change

Select relevant options.

[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update

Are all split configurations tested and accounted for?
[ ] yes [x] no
Does this change require a documentation update outside of the changes proposed?
[ ] yes [x] no
Does this change modify the behaviour of other functions?
[ ] yes [x] no
Are there code practices which require justification?
[ ] yes [x] no
