### PR TITLE
Bug/argmin axis out of bounds

### DIFF
--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -76,7 +76,7 @@ def argmax(x, axis=None, out=None, **kwargs):
             indices = torch.argmax(*args, **kwargs).reshape(1)
             maxima = args[0].flatten()[indices]
             # artificially flatten the input tensor shape to correct the offset computation
-            axis = None 
+            axis = None
             shape = [np.prod(shape)]
         # usual case where indices and maximum values are both returned. Axis is not equal to None
         else:

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -76,7 +76,7 @@ def argmax(x, axis=None, out=None, **kwargs):
             indices = torch.argmax(*args, **kwargs).reshape(1)
             maxima = args[0].flatten()[indices]
             # artificially flatten the input tensor shape to correct the offset computation
-            axis = None
+            axis = 0
             shape = [np.prod(shape)]
         # usual case where indices and maximum values are both returned. Axis is not equal to None
         else:
@@ -176,7 +176,7 @@ def argmin(x, axis=None, out=None, **kwargs):
             minimums = args[0].flatten()[indices]
 
             # artificially flatten the input tensor shape to correct the offset computation
-            axis = None
+            axis = 0
             shape = [np.prod(shape)]
         # usual case where indices and minimum values are both returned. Axis is not equal to None
         else:

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -70,14 +70,13 @@ def argmax(x, axis=None, out=None, **kwargs):
         axis = kwargs.get("dim", -1)
         shape = x.shape
 
-        # case where the argmin axis is set to None
-        # argmin will be the flattened index, computed standalone and the actual minimum value obtain separately
+        # case where the argmax axis is set to None
+        # argmax will be the flattened index, computed standalone and the actual maximum value obtain separately
         if len(args) <= 1 and axis < 0:
             indices = torch.argmax(*args, **kwargs).reshape(1)
             maxima = args[0].flatten()[indices]
-
             # artificially flatten the input tensor shape to correct the offset computation
-            axis = x.split
+            axis = None 
             shape = [np.prod(shape)]
         # usual case where indices and maximum values are both returned. Axis is not equal to None
         else:

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -176,7 +176,7 @@ def argmin(x, axis=None, out=None, **kwargs):
             minimums = args[0].flatten()[indices]
 
             # artificially flatten the input tensor shape to correct the offset computation
-            axis = x.split
+            axis = None
             shape = [np.prod(shape)]
         # usual case where indices and minimum values are both returned. Axis is not equal to None
         else:


### PR DESCRIPTION
## Description
In statistics.local_argmax and local_argmin, in the case where argmin/max are called with `axis=None`, `x` gets flattened so setting `axis = x.split` only works if `x.split=0`. The flattened tensor has no dimension larger than 0.

Fixes: #441


Changes proposed:
-set `axis = 0` instead of `axis=x.split` in statistics.local_argmax, local_argmin

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Are all split configurations tested and accounted for?
- [x] yes
- [ ] no

Does this change require a documentation update outside of the changes proposed?
- [ ] yes
- [x] no

Does this change modify the behaviour of other functions?
- [ ] yes
- [x] no

Are there code practices which require justification?
- [ ] yes
- [x] no
