### PR TITLE
Features/mean var merge cleanup

### DIFF
--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -772,6 +772,12 @@ def mean(x, axis=None):
 
     output_shape = list(x.shape)
     if isinstance(axis, (list, tuple, dndarray.DNDarray, torch.Tensor)):
+        if isinstance(axis, (list, tuple)):
+            if len(set(axis)) != len(axis):
+                raise ValueError("duplicate value in axis")
+        if isinstance(axis, (dndarray.DNDarray, torch.Tensor)):
+            if axis.unique().numel() != axis.numel():
+                raise ValueError("duplicate value in axis")
         if any([not isinstance(j, int) for j in axis]):
             raise ValueError(
                 "items in axis iterable must be integers, axes: {}".format([type(q) for q in axis])
@@ -1317,6 +1323,12 @@ def var(x, axis=None, bessel=True):
         # case for var in one dimension
         output_shape = list(x.shape)
         if isinstance(axis, (list, tuple, dndarray.DNDarray, torch.Tensor)):
+            if isinstance(axis, (list, tuple)):
+                if len(set(axis)) != len(axis):
+                    raise ValueError("duplicate value in axis")
+            if isinstance(axis, (dndarray.DNDarray, torch.Tensor)):
+                if axis.unique().numel() != axis.numel():
+                    raise ValueError("duplicate value in axis")
             if any([not isinstance(j, int) for j in axis]):
                 raise ValueError(
                     "items in axis iterable must be integers, axes: {}".format(

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -857,15 +857,6 @@ def merge_moments(m1, m2, bessel=True):
         algorithms, IEEE International Conference on Cluster Computing and Workshops, 2009, Oct 2009, New Orleans, LA,
         USA.
     """
-    if not isinstance(m1, (tuple, list)):
-        raise TypeError("m1 must be a tuple or a list, currently {}".format(type(m1)))
-    if not isinstance(m2, (tuple, list)):
-        raise TypeError("m2 must be a tuple or a list, currently {}".format(type(m2)))
-    if len(m1) != len(m2):
-        raise ValueError(
-            "length of m1 and m2 must be equal, currently {} and {}".format(len(m1), len(m2))
-        )
-
     n1, n2 = m1[-1], m2[-1]
     mu1, mu2 = m1[-2], m2[-2]
     n = n1 + n2

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -739,7 +739,9 @@ def mean(x, axis=None):
         x.comm.Allreduce(MPI.IN_PLACE, mu_tot, MPI.SUM)
 
         for i in range(1, x.comm.size):
-            mu_tot[0, :], n_tot[0] = merge_moments((mu_tot[0, :], n_tot[0]), (mu_tot[i, :], n_tot[i]))
+            mu_tot[0, :], n_tot[0] = merge_moments(
+                (mu_tot[0, :], n_tot[0]), (mu_tot[i, :], n_tot[i])
+            )
         return mu_tot[0][0] if mu_tot[0].size == 1 else mu_tot[0]
 
     # ----------------------------------------------------------------------------------------------
@@ -763,8 +765,7 @@ def mean(x, axis=None):
 
             for i in range(1, x.comm.size):
                 mu_tot[0, 0], mu_tot[0, 1] = merge_moments(
-                    (mu_tot[0, 0], mu_tot[0, 1]),
-                    (mu_tot[i, 0], mu_tot[i, 1]),
+                    (mu_tot[0, 0], mu_tot[0, 1]), (mu_tot[i, 0], mu_tot[i, 1])
                 )
             return mu_tot[0][0]
 
@@ -784,7 +785,9 @@ def mean(x, axis=None):
         output_shape = [output_shape[it] for it in range(len(output_shape)) if it not in axis]
         # multiple dimensions
         if x.split is None:
-            return factories.array(torch.mean(x._DNDarray__array, dim=axis), is_split=x.split, device=x.device)
+            return factories.array(
+                torch.mean(x._DNDarray__array, dim=axis), is_split=x.split, device=x.device
+            )
 
         if x.split in axis:
             # merge in the direction of the split
@@ -808,7 +811,9 @@ def mean(x, axis=None):
 
         if x.split is None:
             # print(torch.mean(x._DNDarray__array, dim=axis))
-            return factories.array(torch.mean(x._DNDarray__array, dim=axis), is_split=None, device=x.device)
+            return factories.array(
+                torch.mean(x._DNDarray__array, dim=axis), is_split=None, device=x.device
+            )
         elif axis == x.split:
             return reduce_means_elementwise(output_shape)
         else:
@@ -816,7 +821,7 @@ def mean(x, axis=None):
             return factories.array(
                 torch.mean(x._DNDarray__array, dim=axis),
                 is_split=x.split if axis > x.split else x.split - 1,
-                device=x.device
+                device=x.device,
             )
     raise TypeError(
         "axis (axis) must be an int or a list, ht.DNDarray, "
@@ -857,7 +862,9 @@ def merge_moments(m1, m2, bessel=True):
     if not isinstance(m2, (tuple, list)):
         raise TypeError("m2 must be a tuple or a list, currently {}".format(type(m2)))
     if len(m1) != len(m2):
-        raise ValueError("length of m1 and m2 must be equal, currently {} and {}".format(len(m1), len(m2)))
+        raise ValueError(
+            "length of m1 and m2 must be equal, currently {} and {}".format(len(m1), len(m2))
+        )
 
     n1, n2 = m1[-1], m2[-1]
     mu1, mu2 = m1[-2], m2[-2]
@@ -1275,7 +1282,7 @@ def var(x, axis=None, bessel=True):
             var_tot[0, 0, :], var_tot[0, 1, :], n_tot[0] = merge_moments(
                 (var_tot[0, 0, :], var_tot[0, 1, :], n_tot[0]),
                 (var_tot[i, 0, :], var_tot[i, 1, :], n_tot[i]),
-                bessel=bessel
+                bessel=bessel,
             )
         return var_tot[0, 0, :][0] if var_tot[0, 0, :].size == 1 else var_tot[0, 0, :]
 
@@ -1314,7 +1321,9 @@ def var(x, axis=None, bessel=True):
         if isinstance(axis, (list, tuple, dndarray.DNDarray, torch.Tensor)):
             if any([not isinstance(j, int) for j in axis]):
                 raise ValueError(
-                    "items in axis iterable must be integers, axes: {}".format([type(q) for q in axis])
+                    "items in axis iterable must be integers, axes: {}".format(
+                        [type(q) for q in axis]
+                    )
                 )
             if any(d < 0 for d in axis):
                 axis = [stride_tricks.sanitize_axis(x.shape, j) for j in axis]
@@ -1326,7 +1335,9 @@ def var(x, axis=None, bessel=True):
             output_shape = [output_shape[it] for it in range(len(output_shape)) if it not in axis]
             # multiple dimensions
             if x.split is None:
-                return factories.array(torch.var(x._DNDarray__array, dim=axis), is_split=x.split, device=x.device)
+                return factories.array(
+                    torch.var(x._DNDarray__array, dim=axis), is_split=x.split, device=x.device
+                )
             if x.split in axis:
                 # merge in the direction of the split
                 return reduce_vars_elementwise(output_shape)
@@ -1347,12 +1358,16 @@ def var(x, axis=None, bessel=True):
             output_shape = output_shape if output_shape else (1,)
 
             if x.split is None:  # x is *not* distributed -> no need to distributed
-                return factories.array(torch.var(x._DNDarray__array, dim=axis, unbiased=bessel), device=x.device)
+                return factories.array(
+                    torch.var(x._DNDarray__array, dim=axis, unbiased=bessel), device=x.device
+                )
             elif axis == x.split:  # x is distributed and axis chosen is == to split
                 return reduce_vars_elementwise(output_shape)
             else:
                 # singular axis given (axis) not equal to split direction (x.split)
                 lcl = torch.var(x._DNDarray__array, dim=axis, keepdim=False)
-                return factories.array(lcl, is_split=x.split if axis > x.split else x.split - 1, device=x.device)
+                return factories.array(
+                    lcl, is_split=x.split if axis > x.split else x.split - 1, device=x.device
+                )
         else:
             raise TypeError("axis (axis) must be an int, tuple, list, etc.; currently it is {}. ")

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -1355,7 +1355,4 @@ def var(x, axis=None, bessel=True):
                 lcl = torch.var(x._DNDarray__array, dim=axis, keepdim=False)
                 return factories.array(lcl, is_split=x.split if axis > x.split else x.split - 1, device=x.device)
         else:
-            raise TypeError(
-                "axis (axis) must be an int, currently is {}. "
-                "Check if multidim var is available in PyTorch".format(type(axis))
-            )
+            raise TypeError("axis (axis) must be an int, tuple, list, etc.; currently it is {}. ")

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -874,15 +874,15 @@ class TestStatistics(unittest.TestCase):
         # test raises
         x = ht.zeros((2, 3, 4), device=ht_device)
         with self.assertRaises(ValueError):
-            x.mean(axis=10)
+            x.var(axis=10)
         with self.assertRaises(ValueError):
-            x.mean(axis=[4])
+            x.var(axis=[4])
         with self.assertRaises(ValueError):
-            x.mean(axis=[-4])
+            x.var(axis=[-4])
         with self.assertRaises(TypeError):
-            ht.mean(x, axis="01")
+            ht.var(x, axis="01")
         with self.assertRaises(ValueError):
-            ht.mean(x, axis=(0, "10"))
+            ht.var(x, axis=(0, "10"))
 
         a = ht.arange(1, 5, device=ht_device)
         self.assertEqual(a.var(), 1.666666666666666)
@@ -898,7 +898,7 @@ class TestStatistics(unittest.TestCase):
                 res = z.var(bessel=False)
                 total_dims_list = list(z.shape)
                 self.assertTrue((res == 0).all())
-                # loop over the different single dimensions for mean
+                # loop over the different single dimensions for var
                 for it in range(len(z.shape)):
                     res = z.var(axis=it)
                     self.assertTrue(ht.allclose(res, 0))
@@ -923,7 +923,7 @@ class TestStatistics(unittest.TestCase):
                     ",".join(map(str, comb)) for comb in combinations(list(range(len(z.shape))), 2)
                 ]
 
-                for it in loop_list:  # loop over the different combinations of dimensions for mean
+                for it in loop_list:  # loop over the different combinations of dimensions for var
                     lp_split = [int(q) for q in it.split(",")]
                     res = z.var(axis=lp_split)
                     self.assertTrue((res == 0).all())

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -873,12 +873,16 @@ class TestStatistics(unittest.TestCase):
 
         # test raises
         x = ht.zeros((2, 3, 4), device=ht_device)
-        with self.assertRaises(TypeError):
-            ht.var(x, axis=0, bessel=1)
         with self.assertRaises(ValueError):
-            ht.var(x, axis=10)
+            x.mean(axis=10)
+        with self.assertRaises(ValueError):
+            x.mean(axis=[4])
+        with self.assertRaises(ValueError):
+            x.mean(axis=[-4])
         with self.assertRaises(TypeError):
-            ht.var(x, axis="01")
+            ht.mean(x, axis="01")
+        with self.assertRaises(ValueError):
+            ht.mean(x, axis=(0, "10"))
 
         a = ht.arange(1, 5, device=ht_device)
         self.assertEqual(a.var(), 1.666666666666666)
@@ -891,7 +895,7 @@ class TestStatistics(unittest.TestCase):
             hold.append(None)
             for split in hold:  # loop over the number of dimensions of the test array
                 z = ht.ones(dimensions, split=split, device=ht_device)
-                res = z.var()
+                res = z.var(bessel=False)
                 total_dims_list = list(z.shape)
                 self.assertTrue((res == 0).all())
                 # loop over the different single dimensions for mean

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -598,6 +598,8 @@ class TestStatistics(unittest.TestCase):
             ht.mean(x, axis=(0, "10"))
         with self.assertRaises(ValueError):
             ht.mean(x, axis=(0, 0))
+        with self.assertRaises(ValueError):
+            ht.mean(x, axis=torch.Tensor([0, 0]))
 
         a = ht.arange(1, 5, device=ht_device)
         self.assertEqual(a.mean(), 2.5)
@@ -887,6 +889,8 @@ class TestStatistics(unittest.TestCase):
             ht.var(x, axis=(0, "10"))
         with self.assertRaises(ValueError):
             ht.var(x, axis=(0, 0))
+        with self.assertRaises(ValueError):
+            ht.mean(x, axis=torch.Tensor([0, 0]))
 
         a = ht.arange(1, 5, device=ht_device)
         self.assertEqual(a.var(), 1.666666666666666)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -596,6 +596,8 @@ class TestStatistics(unittest.TestCase):
             ht.mean(x, axis="01")
         with self.assertRaises(ValueError):
             ht.mean(x, axis=(0, "10"))
+        with self.assertRaises(ValueError):
+            ht.mean(x, axis=(0, 0))
 
         a = ht.arange(1, 5, device=ht_device)
         self.assertEqual(a.mean(), 2.5)
@@ -883,6 +885,8 @@ class TestStatistics(unittest.TestCase):
             ht.var(x, axis="01")
         with self.assertRaises(ValueError):
             ht.var(x, axis=(0, "10"))
+        with self.assertRaises(ValueError):
+            ht.var(x, axis=(0, 0))
 
         a = ht.arange(1, 5, device=ht_device)
         self.assertEqual(a.var(), 1.666666666666666)


### PR DESCRIPTION
## Description

This is a cleanup of the mean and var functions. The moment merging function is rewritten to be used by both mean and var (it is also possible to expand this function to be used for higher order moments).
The var function also supports multi-dimensional axis arguments (the algorithm is the same as it is for mean)

Fixes: #156 

Changes proposed:
- combination of moment merging functions into one function
- add multi-dimensional axis support to var

## Type of change

Select relevant options.

- New feature (non-breaking change which adds functionality)
- Documentation update

Are all split configurations tested and accounted for?
- [x] yes
- [ ] no

Does this change require a documentation update outside of the changes proposed?
- [ ] yes
- [x] no

Does this change modify the behaviour of other functions?
- [ ] yes
- [x] no

Are there code practices which require justification?
- [ ] yes
- [x] no
