### PR TITLE
remove outdated tests for logical_xor

### DIFF
--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -288,8 +288,6 @@ class TestLogical(unittest.TestCase):
         first_tensor = ht.array([[True, True], [False, False]])
         second_tensor = ht.array([[True, False], [True, False]])
         result_tensor = ht.array([[False, True], [True, False]])
-        int_tensor = ht.array([[-1, 0], [2, 1]])
-        float_tensor = ht.array([[-1.4, 0.2], [2.5, 1.3]])
 
         self.assertTrue(ht.equal(ht.logical_xor(first_tensor, second_tensor), result_tensor))
         self.assertTrue(
@@ -298,18 +296,3 @@ class TestLogical(unittest.TestCase):
                 ht.array([[False, False], [False, False]]),
             )
         )
-
-        with self.assertRaises(RuntimeError):
-            self.assertTrue(
-                ht.equal(
-                    ht.logical_xor(int_tensor, int_tensor),
-                    ht.array([[False, False], [False, False]]),
-                )
-            )
-        with self.assertRaises(RuntimeError):
-            self.assertTrue(
-                ht.equal(
-                    ht.logical_xor(float_tensor, float_tensor),
-                    ht.array([[False, False], [False, False]]),
-                )
-            )


### PR DESCRIPTION
## Description
bugfix for outdated tests because the pytorch function torch.logical_xor now allows more datatypes.

Select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Are all split configurations tested and accounted for?
- [X] yes
- [ ] no

Does this change require a documentation update outside of the changes proposed?
- [ ] yes
- [X] no

Does this change modify the behaviour of other functions?
- [ ] yes
- [x] no

Are there code practices which require justification?
- [ ] yes
- [x] no
