### PR TITLE
Features/451 isclose

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -931,7 +931,7 @@ class DNDarray:
     def isclose(self, other, rtol=1e-05, atol=1e-08, equal_nan=False):
         """
         Parameters:
-        -----------	
+        -----------
 
         x, y : tensor
             Input tensors to compare.
@@ -942,10 +942,10 @@ class DNDarray:
         equal_nan : bool
             Whether to compare NaN’s as equal. If True, NaN’s in x will be considered equal to NaN’s in y in the output array.
 
-        Returns:	
+        Returns:
         --------
 
-        isclose : boolean tensor of where a and b are equal within the given tolerance. 
+        isclose : boolean tensor of where a and b are equal within the given tolerance.
             If both x and y are scalars, returns a single boolean value.
         """
         return logical.isclose(self, other, rtol, atol, equal_nan)

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -928,6 +928,28 @@ class DNDarray:
         """
         return relational.eq(self, other)
 
+    def isclose(self, other, rtol=1e-05, atol=1e-08, equal_nan=False):
+    """
+    Parameters:
+    -----------	
+
+    x, y : tensor
+        Input tensors to compare.
+    rtol : float
+        The relative tolerance parameter.
+    atol : float
+        The absolute tolerance parameter.
+    equal_nan : bool
+        Whether to compare NaN’s as equal. If True, NaN’s in x will be considered equal to NaN’s in y in the output array.
+
+    Returns:	
+    --------
+
+    isclose : boolean tensor of where a and b are equal within the given tolerance. 
+        If both x and y are scalars, returns a single boolean value.
+    """
+    return logical.isclose(self, other, rtol, atol, equal_nan)
+
     def __matmul__(self, other):
         """
         Matrix multiplication of two DNDarrays

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -929,26 +929,26 @@ class DNDarray:
         return relational.eq(self, other)
 
     def isclose(self, other, rtol=1e-05, atol=1e-08, equal_nan=False):
-    """
-    Parameters:
-    -----------	
+        """
+        Parameters:
+        -----------	
 
-    x, y : tensor
-        Input tensors to compare.
-    rtol : float
-        The relative tolerance parameter.
-    atol : float
-        The absolute tolerance parameter.
-    equal_nan : bool
-        Whether to compare NaN’s as equal. If True, NaN’s in x will be considered equal to NaN’s in y in the output array.
+        x, y : tensor
+            Input tensors to compare.
+        rtol : float
+            The relative tolerance parameter.
+        atol : float
+            The absolute tolerance parameter.
+        equal_nan : bool
+            Whether to compare NaN’s as equal. If True, NaN’s in x will be considered equal to NaN’s in y in the output array.
 
-    Returns:	
-    --------
+        Returns:	
+        --------
 
-    isclose : boolean tensor of where a and b are equal within the given tolerance. 
-        If both x and y are scalars, returns a single boolean value.
-    """
-    return logical.isclose(self, other, rtol, atol, equal_nan)
+        isclose : boolean tensor of where a and b are equal within the given tolerance. 
+            If both x and y are scalars, returns a single boolean value.
+        """
+        return logical.isclose(self, other, rtol, atol, equal_nan)
 
     def __matmul__(self, other):
         """

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -331,9 +331,7 @@ def __sanitize_close_input(x, y):
             x = factories.array(x, dtype=dtype, device=device)
         else:
             if not isinstance(x, dndarray.DNDarray):
-                raise TypeError(
-                    "Expected DNDarray or numeric scalar, input was {}".format(type(x))
-                )
+                raise TypeError("Expected DNDarray or numeric scalar, input was {}".format(type(x)))
 
         return x
 

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -316,7 +316,7 @@ def logical_xor(t1, t2):
     return operations.__binary_op(torch.logical_xor, t1, t2)
 
 
-def _sanitize_close_input(x, y):
+def __sanitize_close_input(x, y):
     if np.isscalar(x):
         try:
             if isinstance(y, dndarray.DNDarray):

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -325,12 +325,12 @@ def __sanitize_close_input(x, y):
         Verifies that x is either a scalar, or a ht.DNDarray. If a scalar, x gets wrapped in a ht.DNDarray.
         Raises TypeError if x is neither.
         """
-        if np.ndim(x) == 0:
-            dtype = getattr(x, "dtype", float)
-            device = getattr(y, "device", None)
-            x = factories.array(x, dtype=dtype, device=device)
-        else:
-            if not isinstance(x, dndarray.DNDarray):
+        if not isinstance(x, dndarray.DNDarray):
+            if np.ndim(x) == 0:
+                dtype = getattr(x, "dtype", float)
+                device = getattr(y, "device", None)
+                x = factories.array(x, dtype=dtype, device=device)
+            else:
                 raise TypeError("Expected DNDarray or numeric scalar, input was {}".format(type(x)))
 
         return x

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -318,7 +318,7 @@ def logical_xor(t1, t2):
 
 def __sanitize_close_input(x, y):
     """
-    Makes sure that both x and y are ht.DNDarrays. 
+    Makes sure that both x and y are ht.DNDarrays.
     Provides copies of x and y distributed along the same split axis (if original split axes do not match).
     """
 
@@ -347,17 +347,17 @@ def __sanitize_close_input(x, y):
 
     # Do redistribution out-of-place
     # If only one of the tensors is distributed, unsplit/gather it
-    if (x.split is not None) and (y.split is None):
+    if x.split is not None and y.split is None:
         t1 = manipulations.resplit(x, axis=None)
         t2 = y.copy()
 
-    elif (x.split is None) and (y.split is not None):
+    elif x.split is None and y.split is not None:
         t1 = x.copy()
         t2 = manipulations.resplit(y, axis=None)
 
     # If both x and y are split, but along different axes, y is redistributed to be split along the same axis as x
     # TODO: needs broadcasting first depending on shapes
-    elif (x.split is not None) and (y.split is not None) and (x.split != y.split):
+    elif x.split is not None and y.split is not None and x.split != y.split:
         t1 = x.copy()
         t2 = manipulations.resplit(y, axis=x.split)
 

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -118,7 +118,7 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
     True
     """
 
-    t1, t2 = _sanitize_close_input(x, y)
+    t1, t2 = __sanitize_close_input(x, y)
 
     # no sanitation for shapes of x and y needed, torch.allclose raises relevant errors
     _local_allclose = torch.tensor(
@@ -198,7 +198,7 @@ def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
     isclose : boolean tensor of where a and b are equal within the given tolerance.
         If both x and y are scalars, returns a single boolean value.
     """
-    t1, t2 = _sanitize_close_input(x, y)
+    t1, t2 = __sanitize_close_input(x, y)
 
     # no sanitation for shapes of x and y needed, torch.isclose raises relevant errors
     _local_isclose = torch.isclose(t1._DNDarray__array, t2._DNDarray__array, rtol, atol, equal_nan)
@@ -326,17 +326,14 @@ def __sanitize_close_input(x, y):
         Raises TypeError if x is neither.
         """
         if np.ndim(x) == 0:
-            try:
-                if isinstance(y, dndarray.DNDarray):
-                    x = factories.array(float(x), device=y.device)
-                else:
-                    x = factories.array(float(x))
-            except (ValueError, TypeError):
-                raise TypeError("Data type not supported, input was {}".format(type(x)))
-        elif not isinstance(x, dndarray.DNDarray):
-            raise TypeError(
-                "Only tensors and numeric scalars are supported, but input was {}".format(type(x))
-            )
+            dtype = getattr(x, "dtype", float)
+            device = getattr(y, "device", None)
+            x = factories.array(x, dtype=dtype, device=device)
+        else:
+            if not isinstance(x, dndarray.DNDarray):
+                raise TypeError(
+                    "Expected DNDarray or numeric scalar, input was {}".format(type(x))
+                )
 
         return x
 

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -317,33 +317,33 @@ def logical_xor(t1, t2):
 
 
 def __sanitize_close_input(x, y):
-    if np.isscalar(x):
-        try:
-            if isinstance(y, dndarray.DNDarray):
-                x = factories.array(float(x), device=y.device)
-            else:
-                x = factories.array(float(x))
-        except (ValueError, TypeError):
-            raise TypeError("Data type not supported, input was {}".format(type(x)))
+    """
+    Makes sure that both x and y are ht.DNDarrays. 
+    Provides copies of x and y distributed along the same split axis (if original split axes do not match).
+    """
 
-    elif not isinstance(x, dndarray.DNDarray):
-        raise TypeError(
-            "Only tensors and numeric scalars are supported, but input was {}".format(type(x))
-        )
+    def sanitize_input_type(x, y):
+        """
+        Verifies that x is either a scalar, or a ht.DNDarray. If a scalar, x gets wrapped in a ht.DNDarray.
+        Raises TypeError if x is neither.
+        """
+        if np.ndim(x) == 0:
+            try:
+                if isinstance(y, dndarray.DNDarray):
+                    x = factories.array(float(x), device=y.device)
+                else:
+                    x = factories.array(float(x))
+            except (ValueError, TypeError):
+                raise TypeError("Data type not supported, input was {}".format(type(x)))
+        elif not isinstance(x, dndarray.DNDarray):
+            raise TypeError(
+                "Only tensors and numeric scalars are supported, but input was {}".format(type(x))
+            )
 
-    if np.isscalar(y):
-        try:
-            if isinstance(x, dndarray.DNDarray):
-                y = factories.array(float(y), device=x.device)
-            else:
-                y = factories.array(float(y))
-        except (ValueError, TypeError):
-            raise TypeError("Data type not supported, input was {}".format(type(y)))
+        return x
 
-    elif not isinstance(y, dndarray.DNDarray):
-        raise TypeError(
-            "Only tensors and numeric scalars are supported, but input was {}".format(type(y))
-        )
+    x = sanitize_input_type(x, y)
+    y = sanitize_input_type(y, x)
 
     # Do redistribution out-of-place
     # If only one of the tensors is distributed, unsplit/gather it

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -8,7 +8,7 @@ from . import operations
 from . import dndarray
 from . import types
 
-__all__ = ["all", "allclose", "any", "logical_and", "logical_not", "logical_or", "logical_xor"]
+__all__ = ["all", "allclose", "any", "isclose", "logical_and", "logical_not", "logical_or", "logical_xor"]
 
 
 def all(x, axis=None, out=None, keepdim=None):
@@ -214,6 +214,29 @@ def any(x, axis=None, out=None, keepdim=False):
     )
 
 
+def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
+"""
+Parameters:
+-----------	
+
+x, y : tensor
+    Input tensors to compare.
+rtol : float
+    The relative tolerance parameter (see Notes).
+atol : float
+    The absolute tolerance parameter (see Notes).
+equal_nan : bool
+    Whether to compare NaN’s as equal. If True, NaN’s in x will be considered equal to NaN’s in y in the output array.
+
+Returns:	
+--------
+
+allclose : bool
+    Returns True if the two arrays are equal within the given tolerance; False otherwise.
+
+"""
+pass
+
 def logical_and(t1, t2):
     """
     Compute the truth value of t1 AND t2 element-wise.
@@ -307,3 +330,4 @@ def logical_xor(t1, t2):
     tensor([ False, False,  True])
     """
     return operations.__binary_op(torch.logical_xor, t1, t2)
+

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -184,7 +184,6 @@ def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
     """
     Parameters:
     -----------
-
     x, y : tensor
         Input tensors to compare.
     rtol : float
@@ -196,7 +195,6 @@ def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
 
     Returns:
     --------
-
     isclose : boolean tensor of where a and b are equal within the given tolerance.
         If both x and y are scalars, returns a single boolean value.
     """

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -342,19 +342,11 @@ def __sanitize_close_input(x, y):
     # If only one of the tensors is distributed, unsplit/gather it
     if x.split is not None and y.split is None:
         t1 = manipulations.resplit(x, axis=None)
-        t2 = y.copy()
+        return t1, y
 
-    elif x.split is None and y.split is not None:
-        t1 = x.copy()
-        t2 = manipulations.resplit(y, axis=None)
-
-    # If both x and y are split, but along different axes, y is redistributed to be split along the same axis as x
-    # TODO: needs broadcasting first depending on shapes
-    elif x.split is not None and y.split is not None and x.split != y.split:
-        t1 = x.copy()
+    elif x.split != y.split:
         t2 = manipulations.resplit(y, axis=x.split)
+        return x, t2
 
     else:
         return x, y
-
-    return t1, t2

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -355,7 +355,6 @@ def __sanitize_close_input(x, y):
         t2 = manipulations.resplit(y, axis=x.split)
 
     else:
-        t1 = x.copy()
-        t2 = y.copy()
+        return x, y
 
     return t1, t2

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -9,7 +9,16 @@ from . import dndarray
 from . import stride_tricks
 from . import types
 
-__all__ = ["all", "allclose", "any", "isclose", "logical_and", "logical_not", "logical_or", "logical_xor"]
+__all__ = [
+    "all",
+    "allclose",
+    "any",
+    "isclose",
+    "logical_and",
+    "logical_not",
+    "logical_or",
+    "logical_xor",
+]
 
 
 def all(x, axis=None, out=None, keepdim=None):
@@ -174,7 +183,7 @@ def any(x, axis=None, out=None, keepdim=False):
 def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
     """
     Parameters:
-    -----------	
+    -----------
 
     x, y : tensor
         Input tensors to compare.
@@ -185,14 +194,14 @@ def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
     equal_nan : bool
         Whether to compare NaN’s as equal. If True, NaN’s in x will be considered equal to NaN’s in y in the output array.
 
-    Returns:	
+    Returns:
     --------
 
-    isclose : boolean tensor of where a and b are equal within the given tolerance. 
+    isclose : boolean tensor of where a and b are equal within the given tolerance.
         If both x and y are scalars, returns a single boolean value.
     """
     t1, t2 = _sanitize_close_input(x, y)
-    
+
     # no sanitation for shapes of x and y needed, torch.isclose raises relevant errors
     _local_isclose = torch.isclose(t1._DNDarray__array, t2._DNDarray__array, rtol, atol, equal_nan)
 
@@ -347,7 +356,7 @@ def _sanitize_close_input(x, y):
         t2 = manipulations.resplit(y, axis=None)
 
     # If both x and y are split, but along different axes, y is redistributed to be split along the same axis as x
-    #TODO: needs broadcasting first depending on shapes
+    # TODO: needs broadcasting first depending on shapes
     elif (x.split is not None) and (y.split is not None) and (x.split != y.split):
         t1 = x.copy()
         t2 = manipulations.resplit(y, axis=x.split)

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -244,6 +244,9 @@ class TestLogical(unittest.TestCase):
         self.assertTrue(ht.isclose(c, e)[0][0].item())
         self.assertTrue(e.isclose(c)[-1][-1].item())
 
+        # test scalar input
+        self.assertIsInstance(ht.isclose(2.0, 2.00005), bool)
+
         with self.assertRaises(TypeError):
             ht.isclose(a, (2, 2, 2, 2))
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -229,12 +229,12 @@ class TestLogical(unittest.TestCase):
         rank = ht.communication.MPI_WORLD.rank
         a = ht.float32([[2, 2], [2, 2]], device=ht_device)
         b = ht.float32([[2.00005, 2.00005], [2.00005, 2.00005]], device=ht_device)
-        c = ht.zeros((4*size, 6), split=0, device=ht_device)
-        d = ht.zeros((4*size, 6), split=1, device=ht_device)
-        e = ht.zeros((4*size, 6), device=ht_device)
+        c = ht.zeros((4 * size, 6), split=0, device=ht_device)
+        d = ht.zeros((4 * size, 6), split=1, device=ht_device)
+        e = ht.zeros((4 * size, 6), device=ht_device)
 
         self.assertIsInstance(ht.isclose(a, b), ht.DNDarray)
-        self.assertTrue(ht.isclose(a, b).shape == (2,2))
+        self.assertTrue(ht.isclose(a, b).shape == (2, 2))
         self.assertFalse(ht.isclose(a, b)[0][0].item())
         self.assertTrue(ht.isclose(a, b, atol=1e-04)[0][1].item())
         self.assertTrue(ht.isclose(a, b, rtol=1e-04)[1][0].item())
@@ -251,7 +251,6 @@ class TestLogical(unittest.TestCase):
             ht.isclose(a, "?")
         with self.assertRaises(TypeError):
             ht.isclose("?", a)
-
 
     def test_logical_and(self):
         first_tensor = ht.array([[True, True], [False, False]])

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -185,6 +185,7 @@ class TestLogical(unittest.TestCase):
             ht.allclose(a, "?")
         with self.assertRaises(TypeError):
             ht.allclose("?", a)
+        print("DEBUGGING: test_allclose done")
 
     def test_any(self):
         # float values, minor axis
@@ -253,6 +254,7 @@ class TestLogical(unittest.TestCase):
             ht.isclose(a, "?")
         with self.assertRaises(TypeError):
             ht.isclose("?", a)
+        print("DEBUGGING: test_isclose done")
 
     def test_logical_and(self):
         first_tensor = ht.array([[True, True], [False, False]])

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -226,7 +226,6 @@ class TestLogical(unittest.TestCase):
 
     def test_isclose(self):
         size = ht.communication.MPI_WORLD.size
-        rank = ht.communication.MPI_WORLD.rank
         a = ht.float32([[2, 2], [2, 2]], device=ht_device)
         b = ht.float32([[2.00005, 2.00005], [2.00005, 2.00005]], device=ht_device)
         c = ht.zeros((4 * size, 6), split=0, device=ht_device)

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -224,6 +224,35 @@ class TestLogical(unittest.TestCase):
         self.assertEqual(any_tensor.dtype, ht.bool)
         self.assertTrue(ht.equal(any_tensor, res))
 
+    def test_isclose(self):
+        size = ht.communication.MPI_WORLD.size
+        rank = ht.communication.MPI_WORLD.rank
+        a = ht.float32([[2, 2], [2, 2]], device=ht_device)
+        b = ht.float32([[2.00005, 2.00005], [2.00005, 2.00005]], device=ht_device)
+        c = ht.zeros((4*size, 6), split=0, device=ht_device)
+        d = ht.zeros((4*size, 6), split=1, device=ht_device)
+        e = ht.zeros((4*size, 6), device=ht_device)
+
+        self.assertIsInstance(ht.isclose(a, b), ht.DNDarray)
+        self.assertTrue(ht.isclose(a, b).shape == (2,2))
+        self.assertFalse(ht.isclose(a, b)[0][0].item())
+        self.assertTrue(ht.isclose(a, b, atol=1e-04)[0][1].item())
+        self.assertTrue(ht.isclose(a, b, rtol=1e-04)[1][0].item())
+        self.assertTrue(ht.isclose(a, 2)[0][1].item())
+        self.assertTrue(ht.isclose(a, 2.0)[0][0].item())
+        self.assertTrue(ht.isclose(2, a)[1][1].item())
+        self.assertTrue(ht.isclose(c, d).shape == (4 * size, 6))
+        self.assertTrue(ht.isclose(c, e)[0][0].item())
+        self.assertTrue(e.isclose(c)[-1][-1].item())
+
+        with self.assertRaises(TypeError):
+            ht.isclose(a, (2, 2, 2, 2))
+        with self.assertRaises(TypeError):
+            ht.isclose(a, "?")
+        with self.assertRaises(TypeError):
+            ht.isclose("?", a)
+
+
     def test_logical_and(self):
         first_tensor = ht.array([[True, True], [False, False]])
         second_tensor = ht.array([[True, False], [True, False]])

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -185,7 +185,6 @@ class TestLogical(unittest.TestCase):
             ht.allclose(a, "?")
         with self.assertRaises(TypeError):
             ht.allclose("?", a)
-        print("DEBUGGING: test_allclose done")
 
     def test_any(self):
         # float values, minor axis
@@ -254,7 +253,6 @@ class TestLogical(unittest.TestCase):
             ht.isclose(a, "?")
         with self.assertRaises(TypeError):
             ht.isclose("?", a)
-        print("DEBUGGING: test_isclose done")
 
     def test_logical_and(self):
         first_tensor = ht.array([[True, True], [False, False]])


### PR DESCRIPTION
## Description

numpy.isclose() gets called by naive_bayes.GaussianNB . This is the heat version that works on distributed tensors as well. Returns a boolean tensor or (if the input is scalar) a single boolean value.



Issue/s resolved: #451 

## Changes proposed:
- Added isclose() to module logical, and as a method to DNDarray
- Moved sanitation of input values/tensors out of logical.allclose() into a helper function logical._sanitize_close_input(). Both allclose and isclose now call _sanitize_close_input()

## Known issues! 
#457  logical._sanitate_close_input should check shapes, and broadcast before redistributing
#458 get logical.isclose to work with unbalanced tensors

## Type of change

Remove irrelevant options:
- New feature (non-breaking change which adds functionality)
- Documentation update

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)

#### Does this change modify the behaviour of other functions? If so, which?
 no
