### PR TITLE
Typecastion Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [#454](https://github.com/helmholtz-analytics/heat/issues/454) Update lasso example
 - [#470](https://github.com/helmholtz-analytics/heat/pull/470) Enhancement: Accelerate distance calculations in kmeans clustering by introduction of new module spatial.distance
+- [#473](https://github.com/helmholtz-analytics/heat/pull/473) `ht.array` now typecasts the local torch tensors if the torch tensors given are not the torch version of the specified dtype + unit test updates
 
 
 # v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - [#454](https://github.com/helmholtz-analytics/heat/issues/454) Update lasso example
 - [#470](https://github.com/helmholtz-analytics/heat/pull/470) Enhancement: Accelerate distance calculations in kmeans clustering by introduction of new module spatial.distance
-- [#473](https://github.com/helmholtz-analytics/heat/pull/473) `ht.array` now typecasts the local torch tensors if the torch tensors given are not the torch version of the specified dtype + unit test updates
+- [#478](https://github.com/helmholtz-analytics/heat/pull/478) `ht.array` now typecasts the local torch tensors if the torch tensors given are not the torch version of the specified dtype + unit test updates
 
 
 # v0.2.2

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -303,6 +303,10 @@ def array(
     # infer dtype from obj if not explicitly given
     if dtype is None:
         dtype = types.canonical_heat_type(obj.dtype)
+    else:
+        torch_dtype = dtype.torch_type()
+        if obj.dtype != torch_dtype:
+            obj = obj.type(torch_dtype)
 
     # sanitize minimum number of dimensions
     if not isinstance(ndmin, int):

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -822,12 +822,12 @@ class TestManipulations(BasicTest):
         result, result_indices = ht.sort(data, axis=0, descending=True)
         expected, exp_indices = torch.sort(tensor, dim=0, descending=True)
         self.assertTrue(torch.equal(result._DNDarray__array, expected))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices.int()))
 
         result, result_indices = ht.sort(data, axis=1, descending=True)
         expected, exp_indices = torch.sort(tensor, dim=1, descending=True)
         self.assertTrue(torch.equal(result._DNDarray__array, expected))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices.int()))
 
         data = ht.array(tensor, split=0, device=ht_device)
 
@@ -835,14 +835,14 @@ class TestManipulations(BasicTest):
         exp_indices = torch.tensor([[rank] * size], device=device)
         result, result_indices = ht.sort(data, descending=True, axis=0)
         self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices.int()))
 
         exp_axis_one, exp_indices = (
             torch.arange(size, device=device).reshape(1, size).sort(dim=1, descending=True)
         )
         result, result_indices = ht.sort(data, descending=True, axis=1)
         self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices.int()))
 
         result1 = ht.sort(data, axis=1, descending=True)
         result2 = ht.sort(data, descending=True)
@@ -857,12 +857,12 @@ class TestManipulations(BasicTest):
         self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
         # comparison value is only true on CPU
         if result_indices._DNDarray__array.is_cuda is False:
-            self.assertTrue(torch.equal(result_indices._DNDarray__array, indices_axis_zero))
+            self.assertTrue(torch.equal(result_indices._DNDarray__array, indices_axis_zero.int()))
 
         exp_axis_one = torch.tensor(size - rank - 1, device=device).repeat(size).reshape(size, 1)
         result, result_indices = ht.sort(data, descending=True, axis=1)
         self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_axis_one))
+        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_axis_one.int()))
 
         tensor = torch.tensor(
             [
@@ -1079,7 +1079,7 @@ class TestManipulations(BasicTest):
         self.assertEqual(inv.split, None)
         self.assertEqual(inv.dtype, data_split_none.dtype)
         self.assertEqual(inv.device, data_split_none.device)
-        self.assertTrue(torch.equal(inv._DNDarray__array, exp_inv))
+        self.assertTrue(torch.equal(inv._DNDarray__array, exp_inv.int()))
 
         data_split_zero = ht.array(torch_array, split=0, device=ht_device)
         res, inv = ht.unique(data_split_zero, return_inverse=True, sorted=True)


### PR DESCRIPTION


## Description
Fixed Typecasting if factories.array is handed a different dtype than the obj.dtype is

Issue/s resolved: #477

## Changes proposed:
- Addidtion to factories.array function

## Type of change

Remove irrelevant options:
- Bug fix (non-breaking change which fixes an issue)


## Due Diligence

- [ ] All split configurations tested
- [x ] Multiple dtypes tested in relavent functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
 no
