### PR TITLE
made output of __binary_op a HeAT  tensor containing always a PyTorch…

### DIFF
--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -161,6 +161,9 @@ def __binary_op(operation, t1, t2):
             t1._DNDarray__array.type(promoted_type), t2._DNDarray__array.type(promoted_type)
         )
 
+    if not isinstance(result, torch.Tensor):
+        result = torch.tensor(result)
+
     return dndarray.DNDarray(
         result, output_shape, types.heat_type_of(result), output_split, output_device, output_comm
     )

--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -70,9 +70,7 @@ def equal(t1, t2):
     False
     """
     result_tensor = operations.__binary_op(torch.equal, t1, t2)
-    result_value = result_tensor._DNDarray__array
-    if isinstance(result_value, torch.Tensor):
-        result_value = True
+    result_value = result_tensor._DNDarray__array.item()
 
     return result_tensor.comm.allreduce(result_value, MPI.LAND)
 

--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -70,7 +70,11 @@ def equal(t1, t2):
     False
     """
     result_tensor = operations.__binary_op(torch.equal, t1, t2)
-    result_value = result_tensor._DNDarray__array.item()
+
+    if result_tensor._DNDarray__array.numel() == 1:
+        result_value = result_tensor._DNDarray__array.item()
+    else:
+        result_value = True
 
     return result_tensor.comm.allreduce(result_value, MPI.LAND)
 


### PR DESCRIPTION
This pull request solves bug #509 and + bug #512.

#509: The output array in "__binary_op" (Line: Line 164 in operations.py) is checked to be a PyTorch tensor. If not it will cast to it.

#512: The side-effect checking in  the function "equal" function (Line: 73 in relational.py)  have been replaced by a explicit comparision.