### PR TITLE
Features/514 var std numpylike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#483](https://github.com/helmholtz-analytics/heat/pull/483) Bugfix: DNDarray.cpu() changes heat device to cpu
 - Update documentation theme to "Read the Docs"
 - [#499](https://github.com/helmholtz-analytics/heat/pull/499) Bugfix: MPI datatype mapping: `torch.int16` now maps to `MPI.SHORT` instead of `MPI.SHORT_INT`
+- [#515] (https://github.com/helmholtz-analytics/heat/pull/515) ht.var(), ht.std() numpy-compliant (ddof=0)
 
 # v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [#483](https://github.com/helmholtz-analytics/heat/pull/483) Bugfix: DNDarray.cpu() changes heat device to cpu
 - Update documentation theme to "Read the Docs"
 - [#499](https://github.com/helmholtz-analytics/heat/pull/499) Bugfix: MPI datatype mapping: `torch.int16` now maps to `MPI.SHORT` instead of `MPI.SHORT_INT`
-- [#515] (https://github.com/helmholtz-analytics/heat/pull/515) ht.var(), ht.std() numpy-compliant (ddof=0)
+- [#515] (https://github.com/helmholtz-analytics/heat/pull/515) ht.var() now returns the unadjusted sample variance by default, Bessel's correction can be applied by setting ddof=1.
 
 # v0.3.0
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -3399,6 +3399,15 @@ class DNDarray:
             represents the number of elements. Default: ddof=0. If ddof=1, the Bessel correction will be applied.
             Setting ddof > 1 raises a NotImplementedError.
 
+        Notes on ddof (from numpy)
+        --------------------------
+        The variance is the average of the squared deviations from the mean, i.e., var = mean(abs(x - x.mean())**2).
+        The mean is normally calculated as x.sum() / N, where N = len(x). If, however, ddof is specified, the divisor
+        N - ddof is used instead. In standard statistical practice, ddof=1 provides an unbiased estimator of the
+        variance of a hypothetical infinite population. ddof=0 provides a maximum likelihood estimate of the variance
+        for normally distributed variables.
+
+
         Examples
         --------
         >>> a = ht.random.randn(1,3)

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -3037,7 +3037,7 @@ class DNDarray:
         """
         return manipulations.squeeze(self, axis)
 
-    def std(self, axis=None, bessel=True):
+    def std(self, axis=None, ddof=0):
         """
         Calculates and returns the standard deviation of a tensor with the bessel correction
         If a axis is given, the variance will be taken in that direction.
@@ -3050,36 +3050,37 @@ class DNDarray:
             axis which the mean is taken in.
             Default: None -> std of all data calculated
             NOTE -> if multidemensional var is implemented in pytorch, this can be an iterable. Only thing which muse be changed is the raise
-        bessel : Bool
-            Default: True
-            use the bessel correction when calculating the varaince/std
-            toggle between unbiased and biased calculation of the std
+        ddof : int, optional
+            Delta Degrees of Freedom: the denominator implicitely used in the calculation is N - ddof, where N
+            represents the number of elements. Default: ddof=0. If ddof=1, the Bessel correction will be applied.
+            Setting ddof > 1 raises a NotImplementedError.
+
 
         Examples
         --------
         >>> a = ht.random.randn(1,3)
         >>> a
         tensor([[ 0.3421,  0.5736, -2.2377]])
-        >>> ht.std(a)
-        tensor(1.5606)
+        >>> a.std()
+        tensor(1.2742)
         >>> a = ht.random.randn(4,4)
         >>> a
         tensor([[-1.0206,  0.3229,  1.1800,  1.5471],
                 [ 0.2732, -0.0965, -0.1087, -1.3805],
                 [ 0.2647,  0.5998, -0.1635, -0.0848],
                 [ 0.0343,  0.1618, -0.8064, -0.1031]])
-        >>> ht.std(a, 0)
+        >>> ht.std(a, 0, ddof=1)
         tensor([0.6157, 0.2918, 0.8324, 1.1996])
-        >>> ht.std(a, 1)
+        >>> ht.std(a, 1, ddof=1)
         tensor([1.1405, 0.7236, 0.3506, 0.4324])
-        >>> ht.std(a, 1, bessel=False)
+        >>> ht.std(a, 1)
         tensor([0.9877, 0.6267, 0.3037, 0.3745])
 
         Returns
         -------
         ht.DNDarray containing the std/s, if split, then split in the same direction as x.
         """
-        return statistics.std(self, axis, bessel=bessel)
+        return statistics.std(self, axis, ddof=ddof)
 
     def __str__(self, *args):
         # TODO: document me
@@ -3380,7 +3381,7 @@ class DNDarray:
         """
         return manipulations.unique(self, sorted, return_inverse, axis)
 
-    def var(self, axis=None, bessel=True):
+    def var(self, axis=None, ddof=0):
         """
         Calculates and returns the variance of a tensor.
         If a axis is given, the variance will be taken in that direction.
@@ -3393,18 +3394,18 @@ class DNDarray:
             axis which the variance is taken in.
             Default: None -> var of all data calculated
             NOTE -> if multidemensional var is implemented in pytorch, this can be an iterable. Only thing which muse be changed is the raise
-        bessel : Bool
-            Default: True
-            use the bessel correction when calculating the varaince/std
-            toggle between unbiased and biased calculation of the std
+        ddof : int, optional
+            Delta Degrees of Freedom: the denominator implicitely used in the calculation is N - ddof, where N
+            represents the number of elements. Default: ddof=0. If ddof=1, the Bessel correction will be applied.
+            Setting ddof > 1 raises a NotImplementedError.
 
         Examples
         --------
         >>> a = ht.random.randn(1,3)
         >>> a
         tensor([[-1.9755,  0.3522,  0.4751]])
-        >>> ht.var(a)
-        tensor(1.9065)
+        >>> a.var()
+        tensor(1.2710)
 
         >>> a = ht.random.randn(4,4)
         >>> a
@@ -3412,20 +3413,18 @@ class DNDarray:
                 [ 0.5886,  0.5712,  0.4582,  0.5323],
                 [ 1.9754,  1.2958,  0.5957,  0.0418],
                 [ 0.8196, -1.2911, -0.2026,  0.6212]])
-        >>> ht.var(a, 1)
+        >>> ht.var(a, 1, ddof=1)
         tensor([1.3092, 0.0034, 0.7061, 0.9217])
+        >>> ht.var(a, 0, ddof=1)
+        tensor([1.3624, 3.2563, 0.1447, 1.2042])
         >>> ht.var(a, 0)
-        tensor([1.3624, 3.2563, 0.1447, 1.2042])
-        >>> ht.var(a, 0, bessel=True)
-        tensor([1.3624, 3.2563, 0.1447, 1.2042])
-        >>> ht.var(a, 0, bessel=False)
         tensor([1.0218, 2.4422, 0.1085, 0.9032])
 
         Returns
         -------
         ht.DNDarray containing the var/s, if split, then split in the same direction as x.
         """
-        return statistics.var(self, axis, bessel=bessel)
+        return statistics.var(self, axis, ddof=ddof)
 
     def __xor__(self, other):
         """

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -3037,7 +3037,7 @@ class DNDarray:
         """
         return manipulations.squeeze(self, axis)
 
-    def std(self, axis=None, ddof=0):
+    def std(self, axis=None, ddof=0, **kwargs):
         """
         Calculates and returns the standard deviation of a tensor with the bessel correction
         If a axis is given, the variance will be taken in that direction.
@@ -3080,7 +3080,7 @@ class DNDarray:
         -------
         ht.DNDarray containing the std/s, if split, then split in the same direction as x.
         """
-        return statistics.std(self, axis, ddof=ddof)
+        return statistics.std(self, axis, ddof=ddof, **kwargs)
 
     def __str__(self, *args):
         # TODO: document me
@@ -3381,7 +3381,7 @@ class DNDarray:
         """
         return manipulations.unique(self, sorted, return_inverse, axis)
 
-    def var(self, axis=None, ddof=0):
+    def var(self, axis=None, ddof=0, **kwargs):
         """
         Calculates and returns the variance of a tensor.
         If a axis is given, the variance will be taken in that direction.
@@ -3424,7 +3424,7 @@ class DNDarray:
         -------
         ht.DNDarray containing the var/s, if split, then split in the same direction as x.
         """
-        return statistics.var(self, axis, ddof=ddof)
+        return statistics.var(self, axis, ddof=ddof, **kwargs)
 
     def __xor__(self, other):
         """

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -1160,7 +1160,7 @@ def var(x, axis=None, ddof=0, **kwargs):
         The dtype of x must be a float
     axis : None, Int, iterable, defaults to None
         Axis which the variance is taken in. Default None calculates variance of all data items.
-    ddof : int, optional
+    ddof : int, optional (see Notes)
         Delta Degrees of Freedom: the denominator implicitely used in the calculation is N - ddof, where N
         represents the number of elements. Default: ddof=0. If ddof=1, the Bessel correction will be applied.
         Setting ddof > 1 raises a NotImplementedError.
@@ -1177,6 +1177,14 @@ def var(x, axis=None, ddof=0, **kwargs):
         if axis = x.split, then variances.split = None
         if axis > split, then variances.split = x.split
         if axis < split, then variances.split = x.split - 1
+
+    Notes on ddof (from numpy)
+    --------------------------
+    The variance is the average of the squared deviations from the mean, i.e., var = mean(abs(x - x.mean())**2).
+    The mean is normally calculated as x.sum() / N, where N = len(x). If, however, ddof is specified, the divisor
+    N - ddof is used instead. In standard statistical practice, ddof=1 provides an unbiased estimator of the
+    variance of a hypothetical infinite population. ddof=0 provides a maximum likelihood estimate of the variance
+    for normally distributed variables.
 
     Examples
     --------

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -1112,9 +1112,10 @@ def std(x, axis=None, ddof=0):
         The dtype of x must be a float
     axis : None, Int, iterable, defaults to None
         Axis which the std is taken in. Default None calculates std of all data items.
-    bessel : bool, defaults to True
-        Use the bessel correction when calculating the variance/std. Toggles between unbiased and biased calculation of
-        the standard deviation.
+    ddof : int, optional
+        Delta Degrees of Freedom: the denominator implicitely used in the calculation is N - ddof, where N
+        represents the number of elements. Default: ddof=0. If ddof=1, the Bessel correction will be applied.
+        Setting ddof > 1 raises a NotImplementedError.
 
     Returns
     -------
@@ -1127,18 +1128,18 @@ def std(x, axis=None, ddof=0):
     >>> a
     tensor([[ 0.3421,  0.5736, -2.2377]])
     >>> ht.std(a)
-    tensor(1.5606)
+    tensor(1.2742)
     >>> a = ht.random.randn(4,4)
     >>> a
     tensor([[-1.0206,  0.3229,  1.1800,  1.5471],
             [ 0.2732, -0.0965, -0.1087, -1.3805],
             [ 0.2647,  0.5998, -0.1635, -0.0848],
             [ 0.0343,  0.1618, -0.8064, -0.1031]])
-    >>> ht.std(a, 0)
+    >>> ht.std(a, 0, ddof=1)
     tensor([0.6157, 0.2918, 0.8324, 1.1996])
-    >>> ht.std(a, 1)
+    >>> ht.std(a, 1, ddof=1)
     tensor([1.1405, 0.7236, 0.3506, 0.4324])
-    >>> ht.std(a, 1, bessel=False)
+    >>> ht.std(a, 1)
     tensor([0.9877, 0.6267, 0.3037, 0.3745])
     """
     if not axis:
@@ -1160,7 +1161,7 @@ def var(x, axis=None, ddof=0):
     axis : None, Int, iterable, defaults to None
         Axis which the variance is taken in. Default None calculates variance of all data items.
     ddof : int, optional
-        Delta Degrees of Freedom: the divisor used in the calculation is N - ddof, where N
+        Delta Degrees of Freedom: the denominator implicitely used in the calculation is N - ddof, where N
         represents the number of elements. Default: ddof=0. If ddof=1, the Bessel correction will be applied.
         Setting ddof > 1 raises a NotImplementedError.
 
@@ -1183,6 +1184,8 @@ def var(x, axis=None, ddof=0):
     >>> a
     tensor([[-1.9755,  0.3522,  0.4751]])
     >>> ht.var(a)
+    tensor(1.2710)
+    >>> ht.var(a, ddof=1)
     tensor(1.9065)
 
     >>> a = ht.random.randn(4,4)
@@ -1195,9 +1198,9 @@ def var(x, axis=None, ddof=0):
     tensor([1.3092, 0.0034, 0.7061, 0.9217])
     >>> ht.var(a, 0)
     tensor([1.3624, 3.2563, 0.1447, 1.2042])
-    >>> ht.var(a, 0, bessel=True)
+    >>> ht.var(a, 0, ddof=1)
     tensor([1.3624, 3.2563, 0.1447, 1.2042])
-    >>> ht.var(a, 0, bessel=False)
+    >>> ht.var(a, 0, ddof=0)
     tensor([1.0218, 2.4422, 0.1085, 0.9032])
     """
 

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -1100,7 +1100,7 @@ def mpi_argmin(a, b, _):
 MPI_ARGMIN = MPI.Op.Create(mpi_argmin, commute=True)
 
 
-def std(x, axis=None, ddof=0):
+def std(x, axis=None, ddof=0, **kwargs):
     """
     Calculates and returns the standard deviation of a tensor with the bessel correction.
     If a axis is given, the variance will be taken in that direction.
@@ -1143,12 +1143,12 @@ def std(x, axis=None, ddof=0):
     tensor([0.9877, 0.6267, 0.3037, 0.3745])
     """
     if not axis:
-        return np.sqrt(var(x, axis, ddof))
+        return np.sqrt(var(x, axis, ddof, **kwargs))
     else:
-        return exponential.sqrt(var(x, axis, ddof), out=None)
+        return exponential.sqrt(var(x, axis, ddof, **kwargs), out=None)
 
 
-def var(x, axis=None, ddof=0):
+def var(x, axis=None, ddof=0, **kwargs):
     """
     Calculates and returns the variance of a tensor. If an axis is given, the variance will be
     taken in that direction.
@@ -1211,7 +1211,10 @@ def var(x, axis=None, ddof=0):
     elif ddof < 0:
         raise ValueError("Expected ddof=0 or ddof=1, got {}".format(ddof))
     else:
-        bessel = bool(ddof)
+        if kwargs.get("bessel"):
+            bessel = kwargs.get("bessel")
+        else:
+            bessel = bool(ddof)
 
     def reduce_vars_elementwise(output_shape_i):
         """
@@ -1232,7 +1235,7 @@ def var(x, axis=None, ddof=0):
 
         if x.lshape[x.split] != 0:
             mu = torch.mean(x._DNDarray__array, dim=axis)
-            var = torch.var(x._DNDarray__array, dim=axis, unbiased=bool(ddof))
+            var = torch.var(x._DNDarray__array, dim=axis, unbiased=bessel)
         else:
             mu = factories.zeros(output_shape_i, dtype=x.dtype, device=x.device)
             var = factories.zeros(output_shape_i, dtype=x.dtype, device=x.device)

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -1100,7 +1100,7 @@ def mpi_argmin(a, b, _):
 MPI_ARGMIN = MPI.Op.Create(mpi_argmin, commute=True)
 
 
-def std(x, axis=None, bessel=True):
+def std(x, axis=None, ddof=0):
     """
     Calculates and returns the standard deviation of a tensor with the bessel correction.
     If a axis is given, the variance will be taken in that direction.
@@ -1142,12 +1142,12 @@ def std(x, axis=None, bessel=True):
     tensor([0.9877, 0.6267, 0.3037, 0.3745])
     """
     if not axis:
-        return np.sqrt(var(x, axis, bessel))
+        return np.sqrt(var(x, axis, ddof))
     else:
-        return exponential.sqrt(var(x, axis, bessel), out=None)
+        return exponential.sqrt(var(x, axis, ddof), out=None)
 
 
-def var(x, axis=None, bessel=True):
+def var(x, axis=None, ddof=0):
     """
     Calculates and returns the variance of a tensor. If an axis is given, the variance will be
     taken in that direction.
@@ -1159,10 +1159,10 @@ def var(x, axis=None, bessel=True):
         The dtype of x must be a float
     axis : None, Int, iterable, defaults to None
         Axis which the variance is taken in. Default None calculates variance of all data items.
-    bessel : bool, defaults to True
-        Use the bessel correction when calculating the variance/std.
-        Toggles between unbiased and biased calculation of
-        the variance.
+    ddof : int, optional
+        Delta Degrees of Freedom: the divisor used in the calculation is N - ddof, where N
+        represents the number of elements. Default: ddof=0. If ddof=1, the Bessel correction will be applied.
+        Setting ddof > 1 raises a NotImplementedError.
 
     Returns
     -------
@@ -1200,8 +1200,15 @@ def var(x, axis=None, bessel=True):
     >>> ht.var(a, 0, bessel=False)
     tensor([1.0218, 2.4422, 0.1085, 0.9032])
     """
-    if not isinstance(bessel, bool):
-        raise TypeError("bessel must be a boolean, currently is {}".format(type(bessel)))
+
+    if not isinstance(ddof, int):
+        raise TypeError("ddof must be integer, is {}".format(type(ddof)))
+    elif ddof > 1:
+        raise NotImplementedError("Not implemented for ddof > 1.")
+    elif ddof < 0:
+        raise ValueError("Expected ddof=0 or ddof=1, got {}".format(ddof))
+    else:
+        bessel = bool(ddof)
 
     def reduce_vars_elementwise(output_shape_i):
         """
@@ -1222,7 +1229,7 @@ def var(x, axis=None, bessel=True):
 
         if x.lshape[x.split] != 0:
             mu = torch.mean(x._DNDarray__array, dim=axis)
-            var = torch.var(x._DNDarray__array, dim=axis, unbiased=bessel)
+            var = torch.var(x._DNDarray__array, dim=axis, unbiased=bool(ddof))
         else:
             mu = factories.zeros(output_shape_i, dtype=x.dtype, device=x.device)
             var = factories.zeros(output_shape_i, dtype=x.dtype, device=x.device)

--- a/heat/core/tests/test_indexing.py
+++ b/heat/core/tests/test_indexing.py
@@ -78,7 +78,6 @@ class TestIndexing(unittest.TestCase):
             [[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=0, device=ht_device
         )
         wh = ht.where(a < 4.0, a, -1)
-        print(wh._DNDarray__array.dtype)
         self.assertTrue(ht.all(wh[ht.nonzero(a >= 4)], -1))
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -892,7 +892,7 @@ class TestStatistics(unittest.TestCase):
         # test raises
         x = ht.zeros((2, 3, 4), device=ht_device)
         with self.assertRaises(TypeError):
-            ht.std(x, axis=0, bessel=1)
+            ht.std(x, axis=0, ddof=1.0)
         with self.assertRaises(ValueError):
             ht.std(x, axis=10)
         with self.assertRaises(TypeError):
@@ -923,7 +923,7 @@ class TestStatistics(unittest.TestCase):
             ht.mean(x, axis=torch.Tensor([0, 0]))
 
         a = ht.arange(1, 5, device=ht_device)
-        self.assertEqual(a.var(), 1.666666666666666)
+        self.assertEqual(a.var(ddof=1), 1.666666666666666)
 
         # ones
         dimensions = []
@@ -933,7 +933,7 @@ class TestStatistics(unittest.TestCase):
             hold.append(None)
             for split in hold:  # loop over the number of dimensions of the test array
                 z = ht.ones(dimensions, split=split, device=ht_device)
-                res = z.var(bessel=False)
+                res = z.var(ddof=0)
                 total_dims_list = list(z.shape)
                 self.assertTrue((res == 0).all())
                 # loop over the different single dimensions for var
@@ -980,4 +980,4 @@ class TestStatistics(unittest.TestCase):
         # values for the iris dataset var measured by libreoffice calc
         for sp in [None, 0, 1]:
             iris = ht.load("heat/datasets/data/iris.csv", sep=";", split=sp, device=ht_device)
-            self.assertTrue(ht.allclose(ht.var(iris, bessel=True), 3.90318519755147))
+            self.assertTrue(ht.allclose(ht.var(iris, ddof=1), 3.90318519755147))

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -889,6 +889,11 @@ class TestStatistics(unittest.TestCase):
             ht.minimum(random_volume_1, random_volume_2, out=output)
 
     def test_std(self):
+        # test basics
+        a = ht.arange(1, 5, device=ht_device)
+        self.assertAlmostEqual(a.std(), 1.118034)
+        self.assertAlmostEqual(a.std(bessel=True), 1.2909944)
+
         # test raises
         x = ht.zeros((2, 3, 4), device=ht_device)
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -897,6 +897,10 @@ class TestStatistics(unittest.TestCase):
             ht.std(x, axis=10)
         with self.assertRaises(TypeError):
             ht.std(x, axis="01")
+        with self.assertRaises(NotImplementedError):
+            ht.std(x, ddof=2)
+        with self.assertRaises(ValueError):
+            ht.std(x, ddof=-2)
 
         # the rest of the tests are covered by var
 

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -919,6 +919,10 @@ class TestStatistics(unittest.TestCase):
             ht.var(x, axis=(0, "10"))
         with self.assertRaises(ValueError):
             ht.var(x, axis=(0, 0))
+        with self.assertRaises(NotImplementedError):
+            ht.var(x, ddof=2)
+        with self.assertRaises(ValueError):
+            ht.var(x, ddof=-2)
         with self.assertRaises(ValueError):
             ht.mean(x, axis=torch.Tensor([0, 0]))
 
@@ -980,4 +984,4 @@ class TestStatistics(unittest.TestCase):
         # values for the iris dataset var measured by libreoffice calc
         for sp in [None, 0, 1]:
             iris = ht.load("heat/datasets/data/iris.csv", sep=";", split=sp, device=ht_device)
-            self.assertTrue(ht.allclose(ht.var(iris, ddof=1), 3.90318519755147))
+            self.assertTrue(ht.allclose(ht.var(iris, bessel=True), 3.90318519755147))


### PR DESCRIPTION
## Description
Working on #490 led me to opening several cans of worms and resulted in a rather messy PR (#508). I'm going to withdraw #508 and submit the main changes separately.

With this PR I'm making ht.var() and ht.std() numpy-compliant. 

Issue/s resolved: #514 and partly #490 (because the numpy default is biased variance (no Bessel correction), ht.var() of a tensor of 1 element now returns 0 instead of nan).

## Changes proposed:
- kwarg `bessel` has been replaced by `ddof`, can be 0 or 1;
- Default is `ddof=0` like for numpy (equivalent to `unbiased=False` for torch and `bessel=False` for the current heat implementation).
- argument `bessel` (bool) can still be passed so scripts shouldn't break, but remember the default is now no Bessel correction

## Type of change

Remove irrelevant options:
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
functions that call var() or std() relying on unbiased variance will yield the wrong result (default is now biased variance, ddof=0). 
