### PR TITLE
Added CUDA-aware MPI support detection for MVAPICH, MPICH and ParaStationMPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#499](https://github.com/helmholtz-analytics/heat/pull/499) Bugfix: MPI datatype mapping: `torch.int16` now maps to `MPI.SHORT` instead of `MPI.SHORT_INT`
 - [#515] (https://github.com/helmholtz-analytics/heat/pull/515) ht.var() now returns the unadjusted sample variance by default, Bessel's correction can be applied by setting ddof=1.
 - [#519] (https://github.com/helmholtz-analytics/heat/pull/519) Bugfix: distributed slicing with empty list or scalar as input; distributed nonzero() of empty (local) tensor.
+- [#522] (https://github.com/helmholtz-analytics/heat/pull/522) Added CUDA-aware MPI detection for MVAPICH, MPICH and ParaStation.
 
 # v0.3.0
 

--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -13,11 +13,11 @@ if "openmpi" in os.environ.get("MPI_SUFFIX", "").lower():
     buffer = subprocess.check_output(["ompi_info", "--parsable", "--all"])
     CUDA_AWARE_MPI = b"mpi_built_with_cuda_support:value:true" in buffer
 # MVAPICH
-CUDA_AWARE_MPI = CUDA_AWARE_MPI and os.environ.get("MV2_USE_CUDA") == "1"
+CUDA_AWARE_MPI = CUDA_AWARE_MPI or os.environ.get("MV2_USE_CUDA") == "1"
 # MPICH
-CUDA_AWARE_MPI = CUDA_AWARE_MPI and os.environ.get("MPIR_CVAR_ENABLE_HCOLL") == "1"
+CUDA_AWARE_MPI = CUDA_AWARE_MPI or os.environ.get("MPIR_CVAR_ENABLE_HCOLL") == "1"
 # ParaStationMPI
-CUDA_AWARE_MPI = CUDA_AWARE_MPI and os.environ.get("PSP_CUDA") == "1"
+CUDA_AWARE_MPI = CUDA_AWARE_MPI or os.environ.get("PSP_CUDA") == "1"
 
 
 class Communication:

--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -7,12 +7,17 @@ import torch
 
 from .stride_tricks import sanitize_axis
 
+CUDA_AWARE_MPI = False
 # check whether OpenMPI support CUDA-aware MPI
 if "openmpi" in os.environ.get("MPI_SUFFIX", "").lower():
     buffer = subprocess.check_output(["ompi_info", "--parsable", "--all"])
     CUDA_AWARE_MPI = b"mpi_built_with_cuda_support:value:true" in buffer
-else:
-    CUDA_AWARE_MPI = False
+# MVAPICH
+CUDA_AWARE_MPI = CUDA_AWARE_MPI and os.environ.get("MV2_USE_CUDA") == "1"
+# MPICH
+CUDA_AWARE_MPI = CUDA_AWARE_MPI and os.environ.get("MPIR_CVAR_ENABLE_HCOLL") == "1"
+# ParaStationMPI
+CUDA_AWARE_MPI = CUDA_AWARE_MPI and os.environ.get("PSP_CUDA") == "1"
 
 
 class Communication:

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -590,7 +590,6 @@ class finfo:
 
     >>> info.eps
     1.1920928955078125e-07
-
     """
 
     def __new__(cls, dtype):
@@ -641,7 +640,6 @@ class iinfo:
     >>> info = ht.types.finfo(ht.int32)
     >>> info.bits
     32
-
     """
 
     def __new__(cls, dtype):


### PR DESCRIPTION
## Description

Added support for CUDA-aware MPI for the other three supporting MPI platforms - MVAPICH, MPICH and ParaStationMPI.

NOTE: if your MPI installation is compiled with CUDA-aware MPI support it may still not use it by default. For most of them a specific environment variable needs to be set our code checks for.

Issue/s resolved: #438

## Type of change

Remove irrelevant options:
- New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
