### PR TITLE
float32 are now consistent default data types in factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#519](https://github.com/helmholtz-analytics/heat/pull/519) Bugfix: distributed slicing with empty list or scalar as input; distributed nonzero() of empty (local) tensor.
 - [#521](https://github.com/helmholtz-analytics/heat/pull/521) Add documentation for the generic reduce_op in Heat's core
 - [#522](https://github.com/helmholtz-analytics/heat/pull/522) Added CUDA-aware MPI detection for MVAPICH, MPICH and ParaStation.
+- [#526](https://github.com/helmholtz-analytics/heat/pull/526) float32 is now consistent default dtype for factories.
 
 # v0.3.0
 

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -237,7 +237,7 @@ def __kundu_transform(values):
     return (torch.log(-torch.log(1 - values ** 0.0775)) - 1.0821) * __KUNDU_INVERSE
 
 
-def rand(*args, dtype=types.float64, split=None, device=None, comm=None):
+def rand(*args, dtype=types.float32, split=None, device=None, comm=None):
     """
     Random values in a given shape.
 
@@ -249,7 +249,7 @@ def rand(*args, dtype=types.float64, split=None, device=None, comm=None):
         The dimensions of the returned array, should all be positive. If no argument is given a single random samples is
         generated.
     dtype: ht.types, optional
-        The datatype of the returned values. Has to be one of [ht.float32, ht.float64]. Default is ht.float64.
+        The datatype of the returned values. Has to be one of [ht.float32, ht.float64]. Default is ht.float32.
     split: int, optional
         The axis along which the array is split and distributed, defaults to None (no distribution).
     device : str or None, optional
@@ -349,7 +349,7 @@ def randint(low, high=None, size=None, dtype=None, split=None, device=None, comm
 
     # sanitize the data type
     if dtype is None:
-        dtype = types.int64
+        dtype = types.int32
     dtype = types.canonical_heat_type(dtype)
     if dtype not in [types.int64, types.int32]:
         raise ValueError("Unsupported dtype for randint")
@@ -374,7 +374,7 @@ def randint(low, high=None, size=None, dtype=None, split=None, device=None, comm
     return dndarray.DNDarray(values, shape, dtype, split, device, comm)
 
 
-def randn(*args, dtype=types.float64, split=None, device=None, comm=None):
+def randn(*args, dtype=types.float32, split=None, device=None, comm=None):
     """
     Returns a tensor filled with random numbers from a standard normal distribution with zero mean and variance of one.
 
@@ -383,7 +383,7 @@ def randn(*args, dtype=types.float64, split=None, device=None, comm=None):
     d0, d1, …, dn : int, optional
         The dimensions of the returned array, should be all positive.
     dtype: ht.types, optional
-        The datatype of the returned values. Has to be one of [ht.float32, ht.float64]. Default is ht.float64.
+        The datatype of the returned values. Has to be one of [ht.float32, ht.float64]. Default is ht.float32.
     split: int, optional
         The axis along which the array is split and distributed, defaults to None (no distribution).
     device : str or None, optional

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -241,7 +241,7 @@ class TestCommunication(unittest.TestCase):
 
         # contiguous data, different gather axis
         data = ht.ones((7, 2), dtype=ht.float64, device=ht_device)
-        output = ht.random.randn(7, 2 * ht.MPI_WORLD.size, device=ht_device)
+        output = ht.random.randn(7, 2 * ht.MPI_WORLD.size, dtype=ht.float64, device=ht_device)
 
         # ensure prior invariants
         self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -961,7 +961,7 @@ class TestCommunication(unittest.TestCase):
 
             # contiguous data, different gather axis
             data = ht.ones((7, 2), dtype=ht.float64, device=ht_device)
-            output = ht.random.randn(7, 2 * ht.MPI_WORLD.size, device=ht_device)
+            output = ht.random.randn(7, 2 * ht.MPI_WORLD.size, dtype=ht.float64, device=ht_device)
 
             # ensure prior invariants
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1491,7 +1491,7 @@ class TestCommunication(unittest.TestCase):
         try:
             # contiguous data
             data = ht.ones((1, 5), dtype=ht.float64, device=ht_device)
-            output = ht.random.randn(ht.MPI_WORLD.size, 5, device=ht_device)
+            output = ht.random.randn(ht.MPI_WORLD.size, 5, dtype=ht.float64, device=ht_device)
 
             # ensure prior invariants
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1506,13 +1506,13 @@ class TestCommunication(unittest.TestCase):
                 self.assertTrue(
                     (
                         output._DNDarray__array
-                        == torch.ones((ht.MPI_WORLD.size, 5), dtype=torch.float32, device=device)
+                        == torch.ones((ht.MPI_WORLD.size, 5), dtype=torch.float64, device=device)
                     ).all()
                 )
 
             # contiguous data, different gather axis
             data = ht.ones((5, 2), dtype=ht.float64, device=ht_device)
-            output = ht.random.randn(5, 2 * ht.MPI_WORLD.size, device=ht_device)
+            output = ht.random.randn(5, 2 * ht.MPI_WORLD.size, dtype=ht.float64, device=ht_device)
 
             # ensure prior invariants
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1528,14 +1528,14 @@ class TestCommunication(unittest.TestCase):
                     (
                         output._DNDarray__array
                         == torch.ones(
-                            (5, 2 * ht.MPI_WORLD.size), dtype=torch.float32, device=device
+                            (5, 2 * ht.MPI_WORLD.size), dtype=torch.float64, device=device
                         )
                     ).all()
                 )
 
             # non-contiguous data
             data = ht.ones((3, 5), dtype=ht.float64, device=ht_device).T
-            output = ht.random.randn(5, 3 * ht.MPI_WORLD.size, device=ht_device)
+            output = ht.random.randn(5, 3 * ht.MPI_WORLD.size, dtype=ht.float64, device=ht_device)
 
             # ensure prior invariants
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -1551,14 +1551,14 @@ class TestCommunication(unittest.TestCase):
                     (
                         output._DNDarray__array
                         == torch.ones(
-                            (5, 3 * ht.MPI_WORLD.size), dtype=torch.float32, device=device
+                            (5, 3 * ht.MPI_WORLD.size), dtype=torch.float64, device=device
                         )
                     ).all()
                 )
 
             # non-contiguous output, different gather axis
             data = ht.ones((5, 3), dtype=ht.float64, device=ht_device)
-            output = ht.random.randn(3 * ht.MPI_WORLD.size, 5, device=ht_device).T
+            output = ht.random.randn(3 * ht.MPI_WORLD.size, 5, dtype=ht.float64, device=ht_device).T
 
             # ensure prior invariants
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1574,7 +1574,7 @@ class TestCommunication(unittest.TestCase):
                     (
                         output._DNDarray__array
                         == torch.ones(
-                            (5, 3 * ht.MPI_WORLD.size), dtype=torch.float32, device=device
+                            (5, 3 * ht.MPI_WORLD.size), dtype=torch.float64, device=device
                         )
                     ).all()
                 )

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1003,8 +1003,8 @@ class TestManipulations(BasicTest):
         # 4D local tensor, no axis
         result = ht.squeeze(data)
         self.assertIsInstance(result, ht.DNDarray)
-        self.assertEqual(result.dtype, ht.float64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(result.dtype, ht.float32)
+        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
@@ -1013,8 +1013,8 @@ class TestManipulations(BasicTest):
         # 4D local tensor, major axis
         result = ht.squeeze(data, axis=0)
         self.assertIsInstance(result, ht.DNDarray)
-        self.assertEqual(result.dtype, ht.float64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(result.dtype, ht.float32)
+        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
         self.assertEqual(result.shape, (4, 5, 1))
         self.assertEqual(result.lshape, (4, 5, 1))
         self.assertEqual(result.split, None)
@@ -1023,8 +1023,8 @@ class TestManipulations(BasicTest):
         # 4D local tensor, minor axis
         result = ht.squeeze(data, axis=-1)
         self.assertIsInstance(result, ht.DNDarray)
-        self.assertEqual(result.dtype, ht.float64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(result.dtype, ht.float32)
+        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
         self.assertEqual(result.shape, (1, 4, 5))
         self.assertEqual(result.lshape, (1, 4, 5))
         self.assertEqual(result.split, None)
@@ -1033,8 +1033,8 @@ class TestManipulations(BasicTest):
         # 4D local tensor, tuple axis
         result = data.squeeze(axis=(0, -1))
         self.assertIsInstance(result, ht.DNDarray)
-        self.assertEqual(result.dtype, ht.float64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(result.dtype, ht.float32)
+        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -26,30 +26,28 @@ class TestRandom(unittest.TestCase):
         # Resetting seed works
         seed = 12345
         ht.random.seed(seed)
-        a = ht.random.rand(2, 5, 7, 3, split=0, comm=ht.MPI_WORLD, device=ht_device)
-        self.assertEqual(a.dtype, ht.float64)
-        self.assertEqual(a._DNDarray__array.dtype, torch.float64)
-        b = ht.random.rand(2, 5, 7, 3, split=0, comm=ht.MPI_WORLD, device=ht_device)
+        a = ht.random.rand(2, 5, 7, 3, split=0, device=ht_device)
+        self.assertEqual(a.dtype, ht.float32)
+        self.assertEqual(a._DNDarray__array.dtype, torch.float32)
+        b = ht.random.rand(2, 5, 7, 3, split=0, device=ht_device)
         self.assertFalse(ht.equal(a, b))
         ht.random.seed(seed)
-        c = ht.random.rand(
-            2, 5, 7, 3, dtype=ht.float64, split=0, comm=ht.MPI_WORLD, device=ht_device
-        )
+        c = ht.random.rand(2, 5, 7, 3, dtype=ht.float32, split=0, device=ht_device)
         self.assertTrue(ht.equal(a, c))
 
         # Random numbers with overflow
         ht.random.set_state(("Threefry", seed, 0xFFFFFFFFFFFFFFF0))
-        a = ht.random.rand(2, 3, 4, 5, split=0, comm=ht.MPI_WORLD, device=ht_device)
+        a = ht.random.rand(2, 3, 4, 5, split=0, device=ht_device)
         ht.random.set_state(("Threefry", seed, 0x10000000000000000))
-        b = ht.random.rand(2, 44, split=0, comm=ht.MPI_WORLD, device=ht_device)
+        b = ht.random.rand(2, 44, split=0, device=ht_device)
         a = a.numpy().flatten()
         b = b.numpy().flatten()
-        self.assertEqual(a.dtype, np.float64)
+        self.assertEqual(a.dtype, np.float32)
         self.assertTrue(np.array_equal(a[32:], b))
 
         # Check that random numbers don't repeat after first overflow
         seed = 12345
-        ht.random.set_state(("Threefry", seed, 0x10000000000000000))
+        ht.random.set_state(("Threefry", seed, 0x100000000))
         a = ht.random.rand(2, 44, device=ht_device)
         ht.random.seed(seed)
         b = ht.random.rand(2, 44, device=ht_device)
@@ -66,9 +64,9 @@ class TestRandom(unittest.TestCase):
 
         # different split axis with resetting seed
         ht.random.seed(seed)
-        a = ht.random.rand(3, 5, 2, 9, split=3, comm=ht.MPI_WORLD, device=ht_device)
+        a = ht.random.rand(3, 5, 2, 9, split=3, device=ht_device)
         ht.random.seed(seed)
-        c = ht.random.rand(3, 5, 2, 9, split=3, comm=ht.MPI_WORLD, device=ht_device)
+        c = ht.random.rand(3, 5, 2, 9, split=3, device=ht_device)
         self.assertTrue(ht.equal(a, c))
 
         # Random values are in correct order
@@ -82,22 +80,24 @@ class TestRandom(unittest.TestCase):
 
         # On different shape and split the same random values are used
         ht.random.seed(seed)
-        a = ht.random.rand(3, 5, 2, 9, split=3, comm=ht.MPI_WORLD, device=ht_device)
+        a = ht.random.rand(3, 5, 2, 9, split=3, device=ht_device)
         ht.random.seed(seed)
-        b = ht.random.rand(30, 9, split=1, comm=ht.MPI_WORLD, device=ht_device)
+        b = ht.random.rand(30, 9, split=1, device=ht_device)
         a = np.sort(a.numpy().flatten())
         b = np.sort(b.numpy().flatten())
         self.assertTrue(np.array_equal(a, b))
 
         # One large array does not have two similar values
-        a = ht.random.rand(11, 15, 3, 7, split=2, comm=ht.MPI_WORLD, device=ht_device)
+        a = ht.random.rand(11, 15, 3, 7, split=2, device=ht_device)
         a = a.numpy()
         _, counts = np.unique(a, return_counts=True)
         # Assert that no value appears more than once
         self.assertTrue((counts == 1).all())
 
         # Two large arrays that were created after each other don't share any values
-        b = ht.random.rand(14, 7, 3, 12, 18, 42, split=5, comm=ht.MPI_WORLD, device=ht_device)
+        b = ht.random.rand(
+            14, 7, 3, 12, 18, 42, split=5, comm=ht.MPI_WORLD, dtype=ht.float64, device=ht_device
+        )
         c = np.concatenate((a.flatten(), b.numpy().flatten()))
         _, counts = np.unique(c, return_counts=True)
         self.assertTrue((counts == 1).all())
@@ -120,32 +120,28 @@ class TestRandom(unittest.TestCase):
 
         # To big arrays cant be created
         with self.assertRaises(ValueError):
-            ht.random.randn(0xFFFFFFFFFFFFFFFF * 2 + 1, comm=ht.MPI_WORLD, device=ht_device)
+            ht.random.randn(0xFFFFFFFFFFFFFFFF * 2 + 1, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.random.rand(3, 2, -2, 5, split=1, comm=ht.MPI_WORLD, device=ht_device)
+            ht.random.rand(3, 2, -2, 5, split=1, device=ht_device)
         with self.assertRaises(ValueError):
-            ht.random.randn(12, 43, dtype=ht.int32, split=0, comm=ht.MPI_WORLD, device=ht_device)
+            ht.random.randn(12, 43, dtype=ht.int32, split=0, device=ht_device)
 
         # 32 Bit tests
         ht.random.seed(9876)
         shape = (13, 43, 13, 23)
-        a = ht.random.rand(*shape, dtype=ht.float32, split=0, comm=ht.MPI_WORLD, device=ht_device)
+        a = ht.random.rand(*shape, dtype=ht.float32, split=0, device=ht_device)
         self.assertEqual(a.dtype, ht.float32)
         self.assertEqual(a._DNDarray__array.dtype, torch.float32)
 
         ht.random.seed(9876)
-        b = ht.random.rand(np.prod(shape), dtype=ht.float32, comm=ht.MPI_WORLD, device=ht_device)
+        b = ht.random.rand(np.prod(shape), dtype=ht.float32, device=ht_device)
         a = a.numpy().flatten()
         b = b._DNDarray__array.cpu().numpy()
         self.assertTrue(np.array_equal(a, b))
         self.assertEqual(a.dtype, np.float32)
 
-        a = ht.random.rand(
-            21, 16, 17, 21, dtype=ht.float32, split=2, comm=ht.MPI_WORLD, device=ht_device
-        )
-        b = ht.random.rand(
-            15, 11, 19, 31, dtype=ht.float32, split=0, comm=ht.MPI_WORLD, device=ht_device
-        )
+        a = ht.random.rand(21, 16, 17, 21, dtype=ht.float32, split=2, device=ht_device)
+        b = ht.random.rand(15, 11, 19, 31, dtype=ht.float32, split=0, device=ht_device)
         a = a.numpy().flatten()
         b = b.numpy().flatten()
         c = np.concatenate((a, b))
@@ -160,62 +156,58 @@ class TestRandom(unittest.TestCase):
         self.assertTrue(((0 <= c) & (c < 1)).all())
 
         ht.random.seed(11111)
-        a = ht.random.rand(
-            12, 32, 44, split=1, dtype=ht.float32, comm=ht.MPI_WORLD, device=ht_device
-        ).numpy()
+        a = ht.random.rand(12, 32, 44, split=1, dtype=ht.float32, device=ht_device).numpy()
         # Overflow reached
         ht.random.set_state(("Threefry", 11111, 0x10000000000000000))
-        b = ht.random.rand(
-            12, 32, 44, split=1, dtype=ht.float32, comm=ht.MPI_WORLD, device=ht_device
-        ).numpy()
+        b = ht.random.rand(12, 32, 44, split=1, dtype=ht.float32, device=ht_device).numpy()
         self.assertTrue(np.array_equal(a, b))
 
         ht.random.set_state(("Threefry", 11111, 0x100000000))
-        c = ht.random.rand(
-            12, 32, 44, split=1, dtype=ht.float32, comm=ht.MPI_WORLD, device=ht_device
-        ).numpy()
+        c = ht.random.rand(12, 32, 44, split=1, dtype=ht.float32, device=ht_device).numpy()
         self.assertFalse(np.array_equal(a, c))
         self.assertFalse(np.array_equal(b, c))
 
     def test_randint(self):
         # Checked that the random values are in the correct range
-        a = ht.random.randint(low=0, high=10, size=(10, 10), device=ht_device)
+        a = ht.random.randint(low=0, high=10, size=(10, 10), dtype=ht.int64, device=ht_device)
         self.assertEqual(a.dtype, ht.int64)
         a = a.numpy()
         self.assertTrue(((0 <= a) & (a < 10)).all())
 
-        a = ht.random.randint(low=100000, high=150000, size=(31, 25, 11), split=2)
+        a = ht.random.randint(low=100000, high=150000, size=(31, 25, 11), dtype=ht.int64, split=2)
         a = a.numpy()
         self.assertTrue(((100000 <= a) & (a < 150000)).all())
 
         # For the range [0, 1) only the value 0 is allowed
-        a = ht.random.randint(1, size=(10,), split=0, device=ht_device)
+        a = ht.random.randint(1, size=(10,), split=0, dtype=ht.int64, device=ht_device)
         b = ht.zeros((10,), dtype=ht.int64, split=0, device=ht_device)
         self.assertTrue(ht.equal(a, b))
 
         # Two arrays with the same seed and same number of elements have the same random values
         ht.random.seed(13579)
         shape = (15, 13, 9, 21, 65)
-        a = ht.random.randint(15, 100, size=shape, split=0, device=ht_device)
+        a = ht.random.randint(15, 100, size=shape, split=0, dtype=ht.int64, device=ht_device)
         a = a.numpy().flatten()
 
         ht.random.seed(13579)
         elements = np.prod(shape)
-        b = ht.random.randint(low=15, high=100, size=(elements,), device=ht_device)
+        b = ht.random.randint(low=15, high=100, size=(elements,), dtype=ht.int64, device=ht_device)
         b = b.numpy()
         self.assertTrue(np.array_equal(a, b))
 
         # Two arrays with the same seed and shape have identical values
         ht.random.seed(13579)
-        a = ht.random.randint(10000, size=shape, split=2, device=ht_device)
+        a = ht.random.randint(10000, size=shape, split=2, dtype=ht.int64, device=ht_device)
         a = a.numpy()
 
         ht.random.seed(13579)
-        b = ht.random.randint(low=0, high=10000, size=shape, split=2, device=ht_device)
+        b = ht.random.randint(
+            low=0, high=10000, size=shape, split=2, dtype=ht.int64, device=ht_device
+        )
         b = b.numpy()
 
         ht.random.seed(13579)
-        c = ht.random.randint(low=0, high=10000, device=ht_device)
+        c = ht.random.randint(low=0, high=10000, dtype=ht.int64, device=ht_device)
         self.assertTrue(np.equal(b[0, 0, 0, 0, 0], c))
 
         self.assertTrue(np.array_equal(a, b))
@@ -237,13 +229,9 @@ class TestRandom(unittest.TestCase):
 
         # int32 tests
         ht.random.seed(4545)
-        a = ht.random.randint(
-            50, 1000, size=(13, 45), dtype=ht.int32, split=0, comm=ht.MPI_WORLD, device=ht_device
-        )
+        a = ht.random.randint(50, 1000, size=(13, 45), dtype=ht.int32, split=0, device=ht_device)
         ht.random.set_state(("Threefry", 4545, 0x10000000000000000))
-        b = ht.random.randint(
-            50, 1000, size=(13, 45), dtype=ht.int32, split=0, comm=ht.MPI_WORLD, device=ht_device
-        )
+        b = ht.random.randint(50, 1000, size=(13, 45), dtype=ht.int32, split=0, device=ht_device)
 
         self.assertEqual(a.dtype, ht.int32)
         self.assertEqual(a._DNDarray__array.dtype, torch.int32)
@@ -255,9 +243,7 @@ class TestRandom(unittest.TestCase):
         self.assertTrue(((50 <= a) & (a < 1000)).all())
         self.assertTrue(((50 <= b) & (b < 1000)).all())
 
-        c = ht.random.randint(
-            50, 1000, size=(13, 45), dtype=ht.int32, split=0, comm=ht.MPI_WORLD, device=ht_device
-        )
+        c = ht.random.randint(50, 1000, size=(13, 45), dtype=ht.int32, split=0, device=ht_device)
         c = c.numpy()
         self.assertFalse(np.array_equal(a, c))
         self.assertFalse(np.array_equal(b, c))
@@ -286,7 +272,7 @@ class TestRandom(unittest.TestCase):
         # Test that the random values have the correct distribution
         ht.random.seed(54321)
         shape = (5, 10, 13, 23, 15, 20)
-        a = ht.random.randn(*shape, split=0, device=ht_device)
+        a = ht.random.randn(*shape, split=0, dtype=ht.float64, device=ht_device)
         self.assertEqual(a.dtype, ht.float64)
         a = a.numpy()
         mean = np.mean(a)
@@ -299,13 +285,13 @@ class TestRandom(unittest.TestCase):
         # Compare to a second array with a different shape but same number of elements and same seed
         ht.random.seed(54321)
         elements = np.prod(shape)
-        b = ht.random.randn(elements, split=0, device=ht_device)
+        b = ht.random.randn(elements, split=0, dtype=ht.float64, device=ht_device)
         b = b.numpy()
         a = a.flatten()
         self.assertTrue(np.allclose(a, b))
 
         # Creating the same array two times without resetting seed results in different elements
-        c = ht.random.randn(elements, split=0, device=ht_device)
+        c = ht.random.randn(elements, split=0, dtype=ht.float64, device=ht_device)
         c = c.numpy()
         self.assertEqual(c.shape, b.shape)
         self.assertFalse(np.allclose(b, c))
@@ -317,9 +303,9 @@ class TestRandom(unittest.TestCase):
 
         # Two arrays are the same for same seed and split-axis != 0
         ht.random.seed(12345)
-        a = ht.random.randn(*shape, split=5, device=ht_device)
+        a = ht.random.randn(*shape, split=5, dtype=ht.float64, device=ht_device)
         ht.random.seed(12345)
-        b = ht.random.randn(*shape, split=5, device=ht_device)
+        b = ht.random.randn(*shape, split=5, dtype=ht.float64, device=ht_device)
         self.assertTrue(ht.equal(a, b))
         a = a.numpy()
         b = b.numpy()
@@ -327,9 +313,7 @@ class TestRandom(unittest.TestCase):
 
         # Tests with float32
         ht.random.seed(54321)
-        a = ht.random.randn(
-            30, 30, 30, dtype=ht.float32, split=2, comm=ht.MPI_WORLD, device=ht_device
-        )
+        a = ht.random.randn(30, 30, 30, dtype=ht.float32, split=2, device=ht_device)
         self.assertEqual(a.dtype, ht.float32)
         self.assertEqual(a._DNDarray__array[0, 0, 0].dtype, torch.float32)
         a = a.numpy()
@@ -342,14 +326,10 @@ class TestRandom(unittest.TestCase):
         self.assertTrue(0.99 < std < 1.01)
 
         ht.random.set_state(("Threefry", 54321, 0x10000000000000000))
-        b = ht.random.randn(
-            30, 30, 30, dtype=ht.float32, split=2, comm=ht.MPI_WORLD, device=ht_device
-        ).numpy()
+        b = ht.random.randn(30, 30, 30, dtype=ht.float32, split=2, device=ht_device).numpy()
         self.assertTrue(np.allclose(a, b))
 
-        c = ht.random.randn(
-            30, 30, 30, dtype=ht.float32, split=2, comm=ht.MPI_WORLD, device=ht_device
-        ).numpy()
+        c = ht.random.randn(30, 30, 30, dtype=ht.float32, split=2, device=ht_device).numpy()
         self.assertFalse(np.allclose(a, c))
         self.assertFalse(np.allclose(b, c))
 

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -363,8 +363,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(avg_volume, ht.DNDarray)
         self.assertEqual(avg_volume.shape, (3,))
         self.assertEqual(avg_volume.lshape[0], random_volume.lshape[0])
-        self.assertEqual(avg_volume.dtype, ht.float64)
-        self.assertEqual(avg_volume._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(avg_volume.dtype, ht.float32)
+        self.assertEqual(avg_volume._DNDarray__array.dtype, torch.float32)
         self.assertEqual(avg_volume.split, 0)
 
         # check weighted average over all float elements of split 5d tensor, along split axis
@@ -376,8 +376,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(avg_5d, ht.DNDarray)
         self.assertEqual(avg_5d.gshape, (2, 3, 4, 5))
         self.assertLessEqual(avg_5d.lshape[1], 3)
-        self.assertEqual(avg_5d.dtype, ht.float64)
-        self.assertEqual(avg_5d._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(avg_5d.dtype, ht.float32)
+        self.assertEqual(avg_5d._DNDarray__array.dtype, torch.float32)
         self.assertEqual(avg_5d.split, None)
 
         # check exceptions
@@ -462,8 +462,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(maximum_volume, ht.DNDarray)
         self.assertEqual(maximum_volume.shape, (3, 3))
         self.assertEqual(maximum_volume.lshape, (3, 3))
-        self.assertEqual(maximum_volume.dtype, ht.float64)
-        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(maximum_volume.dtype, ht.float32)
+        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float32)
         self.assertEqual(maximum_volume.split, None)
 
         # check max over all float elements of split 3d tensor, tuple axis
@@ -473,8 +473,8 @@ class TestStatistics(unittest.TestCase):
 
         self.assertIsInstance(maximum_volume, ht.DNDarray)
         self.assertEqual(maximum_volume.shape, (3 * size,))
-        self.assertEqual(maximum_volume.dtype, ht.float64)
-        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(maximum_volume.dtype, ht.float32)
+        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float32)
         self.assertEqual(maximum_volume.split, 0)
         self.assertTrue((maximum_volume == alt_maximum_volume).all())
 
@@ -485,8 +485,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(maximum_5d, ht.DNDarray)
         self.assertEqual(maximum_5d.shape, (1 * size, 3, 4, 5))
         self.assertLessEqual(maximum_5d.lshape[1], 3)
-        self.assertEqual(maximum_5d.dtype, ht.float64)
-        self.assertEqual(maximum_5d._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(maximum_5d.dtype, ht.float32)
+        self.assertEqual(maximum_5d._DNDarray__array.dtype, torch.float32)
         self.assertEqual(maximum_5d.split, 0)
 
         # Calculating max with empty local vectors works
@@ -535,8 +535,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(maximum_volume, ht.DNDarray)
         self.assertEqual(maximum_volume.shape, (size * 12, 3, 3))
         self.assertEqual(maximum_volume.lshape, (size * 12, 3, 3))
-        self.assertEqual(maximum_volume.dtype, ht.float64)
-        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(maximum_volume.dtype, ht.float32)
+        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float32)
         self.assertEqual(maximum_volume.split, random_volume_1.split)
 
         # check maximum over float elements of split 3d tensors with different split axis
@@ -551,8 +551,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(maximum_volume_splitdiff, ht.DNDarray)
         self.assertEqual(maximum_volume_splitdiff.shape, (size * 3, size * 3, 4))
         self.assertEqual(maximum_volume_splitdiff.lshape, (size * 3, size * 3, 4))
-        self.assertEqual(maximum_volume_splitdiff.dtype, ht.float64)
-        self.assertEqual(maximum_volume_splitdiff._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(maximum_volume_splitdiff.dtype, ht.float32)
+        self.assertEqual(maximum_volume_splitdiff._DNDarray__array.dtype, torch.float32)
         self.assertEqual(maximum_volume_splitdiff.split, 0)
 
         random_volume_1_splitdiff = ht.random.randn(
@@ -589,8 +589,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(output, ht.DNDarray)
         self.assertEqual(output.shape, (ht.MPI_WORLD.size * 12, 3, 3))
         self.assertEqual(output.lshape, (ht.MPI_WORLD.size * 12, 3, 3))
-        self.assertEqual(output.dtype, ht.float64)
-        self.assertEqual(output._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(output.dtype, ht.float32)
+        self.assertEqual(output._DNDarray__array.dtype, torch.float32)
         self.assertEqual(output.split, random_volume_1.split)
 
         # check exceptions
@@ -742,8 +742,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(minimum_volume, ht.DNDarray)
         self.assertEqual(minimum_volume.shape, (3, 3))
         self.assertEqual(minimum_volume.lshape, (3, 3))
-        self.assertEqual(minimum_volume.dtype, ht.float64)
-        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(minimum_volume.dtype, ht.float32)
+        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float32)
         self.assertEqual(minimum_volume.split, None)
 
         # check min over all float elements of split 3d tensor, tuple axis
@@ -753,8 +753,8 @@ class TestStatistics(unittest.TestCase):
 
         self.assertIsInstance(minimum_volume, ht.DNDarray)
         self.assertEqual(minimum_volume.shape, (3 * size,))
-        self.assertEqual(minimum_volume.dtype, ht.float64)
-        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(minimum_volume.dtype, ht.float32)
+        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float32)
         self.assertEqual(minimum_volume.split, 0)
         self.assertTrue((minimum_volume == alt_minimum_volume).all())
 
@@ -765,8 +765,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(minimum_5d, ht.DNDarray)
         self.assertEqual(minimum_5d.shape, (1 * size, 3, 4, 5))
         self.assertLessEqual(minimum_5d.lshape[1], 3)
-        self.assertEqual(minimum_5d.dtype, ht.float64)
-        self.assertEqual(minimum_5d._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(minimum_5d.dtype, ht.float32)
+        self.assertEqual(minimum_5d._DNDarray__array.dtype, torch.float32)
         self.assertEqual(minimum_5d.split, 0)
 
         # Calculating min with empty local vectors works
@@ -816,8 +816,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(minimum_volume, ht.DNDarray)
         self.assertEqual(minimum_volume.shape, (size * 12, 3, 3))
         self.assertEqual(minimum_volume.lshape, (size * 12, 3, 3))
-        self.assertEqual(minimum_volume.dtype, ht.float64)
-        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(minimum_volume.dtype, ht.float32)
+        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float32)
         self.assertEqual(minimum_volume.split, random_volume_1.split)
 
         # check minimum over float elements of split 3d tensors with different split axis
@@ -832,8 +832,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(minimum_volume_splitdiff, ht.DNDarray)
         self.assertEqual(minimum_volume_splitdiff.shape, (size * 3, size * 3, 4))
         self.assertEqual(minimum_volume_splitdiff.lshape, (size * 3, size * 3, 4))
-        self.assertEqual(minimum_volume_splitdiff.dtype, ht.float64)
-        self.assertEqual(minimum_volume_splitdiff._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(minimum_volume_splitdiff.dtype, ht.float32)
+        self.assertEqual(minimum_volume_splitdiff._DNDarray__array.dtype, torch.float32)
         self.assertEqual(minimum_volume_splitdiff.split, 0)
 
         random_volume_1_splitdiff = ht.random.randn(
@@ -870,8 +870,8 @@ class TestStatistics(unittest.TestCase):
         self.assertIsInstance(output, ht.DNDarray)
         self.assertEqual(output.shape, (ht.MPI_WORLD.size * 12, 3, 3))
         self.assertEqual(output.lshape, (ht.MPI_WORLD.size * 12, 3, 3))
-        self.assertEqual(output.dtype, ht.float64)
-        self.assertEqual(output._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(output.dtype, ht.float32)
+        self.assertEqual(output._DNDarray__array.dtype, torch.float32)
         self.assertEqual(output.split, random_volume_1.split)
 
         # check exceptions

--- a/heat/regression/lasso/tests/test_lasso.py
+++ b/heat/regression/lasso/tests/test_lasso.py
@@ -75,8 +75,8 @@ if ht.io.supports_hdf5():
             )
 
             # Now the same stuff again in PyTorch
-            X = torch.tensor(X._DNDarray__array, device=device)
-            y = torch.tensor(y._DNDarray__array, device=device)
+            X = X._DNDarray__array.clone()
+            y = y._DNDarray__array.clone()
 
             # normalize dataset
             X = X / torch.sqrt((torch.mean(X ** 2, 0)))


### PR DESCRIPTION
## Description

All factories, including random now use ht.float32 as default dtype.

Issue/s resolved: #491

## Type of change

Remove irrelevant options:
- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
