### PR TITLE
eye checks if either position is above the lshape of the tensor, if s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#521](https://github.com/helmholtz-analytics/heat/pull/521) Add documentation for the generic reduce_op in Heat's core
 - [#522](https://github.com/helmholtz-analytics/heat/pull/522) Added CUDA-aware MPI detection for MVAPICH, MPICH and ParaStation.
 - [#526](https://github.com/helmholtz-analytics/heat/pull/526) float32 is now consistent default dtype for factories.
+- [#534](https://github.com/helmholtz-analytics/heat/pull/534) `eye()` supports all 2D split combinations and matrix configurations.
 
 # v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@
 - [#499](https://github.com/helmholtz-analytics/heat/pull/499) Bugfix: MPI datatype mapping: `torch.int16` now maps to `MPI.SHORT` instead of `MPI.SHORT_INT`
 - [#507](https://github.com/helmholtz-analytics/heat/pull/507) Bugfix: sanitize_axis changes axis of 0-dim scalars to None
 - [#515](https://github.com/helmholtz-analytics/heat/pull/515) ht.var() now returns the unadjusted sample variance by default, Bessel's correction can be applied by setting ddof=1.
-- [#518](https://github.com/helmholtz-analytics/heat/pull/518) Implemenation of Spectral Clustering
-- [#518](https://github.com/helmholtz-analytics/heat/pull/518) Implemenation of Spectral Clustering.
+- [#518](https://github.com/helmholtz-analytics/heat/pull/518) Implementation of Spectral Clustering.
 - [#519](https://github.com/helmholtz-analytics/heat/pull/519) Bugfix: distributed slicing with empty list or scalar as input; distributed nonzero() of empty (local) tensor.
 - [#521](https://github.com/helmholtz-analytics/heat/pull/521) Add documentation for the generic reduce_op in Heat's core
 - [#522](https://github.com/helmholtz-analytics/heat/pull/522) Added CUDA-aware MPI detection for MVAPICH, MPICH and ParaStation.

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -463,6 +463,7 @@ def empty_like(a, dtype=None, split=None, device=None, comm=None, order="C"):
 
 def eye(shape, dtype=types.float32, split=None, device=None, comm=None, order="C"):
     """
+
     Returns a new 2-D tensor with ones on the diagonal and zeroes elsewhere.
 
     Parameters
@@ -521,6 +522,9 @@ def eye(shape, dtype=types.float32, split=None, device=None, comm=None, order="C
     for i in range(min(lshape)):
         pos_x = i if split == 0 else i + offset
         pos_y = i if split == 1 else i + offset
+        # print(pos_x, pos_y)
+        if pos_x >= lshape[0] or pos_y >= lshape[1]:
+            break
         data[pos_x][pos_y] = 1
 
     data = memory.sanitize_memory_layout(data, order=order)

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -424,6 +424,13 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(eye.shape, shape)
         self.assertEqual(eye.split, None)
 
+        shape = (21, 10)
+        eye = ht.eye(shape, split=1, dtype=ht.float32, device=ht_device)
+        self.assertIsInstance(eye, ht.DNDarray)
+        self.assertEqual(eye.dtype, ht.float32)
+        self.assertEqual(eye.shape, shape)
+        self.assertEqual(eye.split, 1)
+
         offset_x, offset_y = get_offset(eye._DNDarray__array)
         self.assertGreaterEqual(offset_x, 0)
         self.assertGreaterEqual(offset_y, 0)

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -424,7 +424,7 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(eye.shape, shape)
         self.assertEqual(eye.split, None)
 
-        shape = (21, 10)
+        shape = (11, 100)
         eye = ht.eye(shape, split=1, dtype=ht.float32, device=ht_device)
         self.assertIsInstance(eye, ht.DNDarray)
         self.assertEqual(eye.dtype, ht.float32)

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -424,13 +424,6 @@ class TestFactories(unittest.TestCase):
         self.assertEqual(eye.shape, shape)
         self.assertEqual(eye.split, None)
 
-        shape = (11, 100)
-        eye = ht.eye(shape, split=1, dtype=ht.float32, device=ht_device)
-        self.assertIsInstance(eye, ht.DNDarray)
-        self.assertEqual(eye.dtype, ht.float32)
-        self.assertEqual(eye.shape, shape)
-        self.assertEqual(eye.split, 1)
-
         offset_x, offset_y = get_offset(eye._DNDarray__array)
         self.assertGreaterEqual(offset_x, 0)
         self.assertGreaterEqual(offset_y, 0)
@@ -455,6 +448,13 @@ class TestFactories(unittest.TestCase):
             for j in range(y):
                 expected = 1 if i - offset_x is j - offset_y else 0
                 self.assertEqual(eye._DNDarray__array[i][j], expected)
+
+        shape = (11, 30)
+        eye = ht.eye(shape, split=1, dtype=ht.float32, device=ht_device)
+        self.assertIsInstance(eye, ht.DNDarray)
+        self.assertEqual(eye.dtype, ht.float32)
+        self.assertEqual(eye.shape, shape)
+        self.assertEqual(eye.split, 1)
 
     def test_full(self):
         # simple tensor


### PR DESCRIPTION
## Description

`ht.eye` now will not throw an error for split=1 with gshape[0] < gshape[1]. e.g it supports uneven matrices.

Issue/s resolved: #528 

## Changes proposed:
- added if condition in the setting of values in `eye()`

## Type of change

Remove irrelevant options:
- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
