### PR TITLE
lasso examples

### DIFF
--- a/examples/lasso/demo.py
+++ b/examples/lasso/demo.py
@@ -21,7 +21,7 @@ y = ht.load_hdf5("../../heat/datasets/data/diabetes.h5", dataset="y", split=0)
 X = X / ht.sqrt((ht.mean(X ** 2, axis=0)))
 
 # HeAT lasso instance
-estimator = lasso.HeatLasso(max_iter=100)
+estimator = lasso.Lasso(max_iter=100)
 
 # List  lasso model parameters
 theta_list = list()
@@ -41,9 +41,8 @@ theta_lasso = np.stack(theta_list).T
 # Stack into numpy array
 theta_lasso = np.stack(theta_list).T[1:, :]
 
-
 # plot lasso paths
-plt.subplot(3, 1, 1)
+# plt.subplot(3, 1, 1)
 plotfkt.plot_lasso_path(
     lamda, theta_lasso, diabetes.feature_names, title="Lasso Paths - HeAT implementation"
 )
@@ -52,74 +51,6 @@ if X.is_distributed():
     distributed = X.comm.rank
 else:
     distributed = False
-
-# Now the same stuff in numpy
-X = diabetes.data.astype("float32")
-y = diabetes.target.astype("float32")
-
-m, _ = X.shape
-X = np.concatenate((np.ones((m, 1)).astype("float32"), X), axis=1)
-
-# normalize dataset
-X = X / np.sqrt((np.mean(X ** 2, axis=0)))
-
-# Numpy lasso instance
-estimator = lasso.NumpyLasso(max_iter=100)
-
-# List  lasso model parameters
-theta_list = list()
-
-# Range of lambda values
-lamda = np.logspace(0, 4, 10) / 10
-
-# compute the lasso path
-for l in lamda:
-    estimator.lam = l
-    estimator.fit(X, y)
-    theta_list.append(estimator.theta.flatten())
-
-# Stack estimated model parameters into one numpy array
-theta_lasso = np.stack(theta_list).T
-
-# Stack into numpy array
-theta_lasso = np.stack(theta_list).T[1:, :]
-
-# plot lasso paths
-plt.subplot(3, 1, 2)
-plotfkt.plot_lasso_path(
-    lamda, theta_lasso, diabetes.feature_names, title="Lasso Paths - Numpy implementation"
-)
-
-# Now the same stuff again in PyTorch
-X = torch.tensor(X)
-y = torch.tensor(y)
-
-# HeAT lasso instance
-estimator = lasso.PytorchLasso(max_iter=100)
-
-# List lasso model parameters
-theta_list = list()
-
-# Range of lambda values
-lamda = np.logspace(0, 4, 10) / 10
-
-# compute the lasso path
-for l in lamda:
-    estimator.lam = l
-    estimator.fit(X, y)
-    theta_list.append(estimator.theta.numpy().flatten())
-
-# Stack estimated model parameters into one numpy array
-theta_lasso = np.stack(theta_list).T
-
-# Stack into numpy array
-theta_lasso = np.stack(theta_list).T[1:, :]
-
-# plot lasso paths
-plt.subplot(3, 1, 3)
-plotfkt.plot_lasso_path(
-    lamda, theta_lasso, diabetes.feature_names, title="Lasso Paths - PyTorch implementation"
-)
 
 # plot only with first rank
 if distributed is False:

--- a/examples/lasso/demo.py
+++ b/examples/lasso/demo.py
@@ -42,7 +42,6 @@ theta_lasso = np.stack(theta_list).T
 theta_lasso = np.stack(theta_list).T[1:, :]
 
 # plot lasso paths
-# plt.subplot(3, 1, 1)
 plotfkt.plot_lasso_path(
     lamda, theta_lasso, diabetes.feature_names, title="Lasso Paths - HeAT implementation"
 )

--- a/heat/regression/lasso.py
+++ b/heat/regression/lasso.py
@@ -116,17 +116,26 @@ class Lasso(ht.RegressionMixin, ht.BaseEstimator):
         # Get number of model parameters
         _, n = X.shape
 
+        if len(y.shape) == 1:
+            y = ht.expand_dims(y, axis=1)
+
         # Initialize model parameters
         theta = ht.zeros((n, 1), dtype=float, device=X.device)
 
         # Looping until max number of iterations or convergence
         for i in range(self.max_iter):
+
             theta_old = theta.copy()
 
             # Looping through each coordinate
             for j in range(n):
-                y_est = (X @ theta)[:, 0]
-                rho = (X[:, j] * (y - y_est + theta[j].copy() * X[:, j])).mean()
+
+                X_j = ht.array(X._DNDarray__array[:, j : j + 1], is_split=0)
+
+                y_est = X @ theta
+                theta_j = theta._DNDarray__array[j].item()
+
+                rho = (X_j * (y - y_est + theta_j * X_j)).mean()
 
                 # Intercept parameter theta[0] not be regularized
                 if j == 0:
@@ -153,4 +162,4 @@ class Lasso(ht.RegressionMixin, ht.BaseEstimator):
         X : HeAT tensor, shape (n_samples, n_features)
             Input data.
         """
-        return (X @ self.__theta)[:, 0]
+        return X @ self.__theta

--- a/heat/regression/lasso.py
+++ b/heat/regression/lasso.py
@@ -116,8 +116,10 @@ class Lasso(ht.RegressionMixin, ht.BaseEstimator):
         # Get number of model parameters
         _, n = X.shape
 
-        assert len(y.shape) <= 2, "y.shape needs to be 1 or 2 dimensional"
-        assert len(X.shape) == 2, "X.shape needs to be 2 dimensional"
+        if y.numdims > 2:
+            raise ValueError("y.numdims must <= 2, currently: {}".format(y.numdims))
+        if X.numdims != 2:
+            raise ValueError("X.numdims must == 2, currently: {}".format(X.numdims))
 
         if len(y.shape) == 1:
             y = ht.expand_dims(y, axis=1)

--- a/heat/regression/lasso.py
+++ b/heat/regression/lasso.py
@@ -116,6 +116,9 @@ class Lasso(ht.RegressionMixin, ht.BaseEstimator):
         # Get number of model parameters
         _, n = X.shape
 
+        assert len(y.shape) <= 2, "y.shape needs to be 1 or 2 dimensional"
+        assert len(X.shape) == 2, "X.shape needs to be 2 dimensional"
+
         if len(y.shape) == 1:
             y = ht.expand_dims(y, axis=1)
 

--- a/heat/regression/tests/test_lasso.py
+++ b/heat/regression/tests/test_lasso.py
@@ -83,3 +83,8 @@ class TestLasso(unittest.TestCase):
             # check whether the results are correct
             self.assertIsInstance(yest, ht.DNDarray)
             self.assertEqual(yest.shape, (m, 1))
+
+            with self.assertRaises(ValueError):
+                estimator.fit(X, ht.zeros((3, 3, 3)))
+            with self.assertRaises(ValueError):
+                estimator.fit(ht.zeros((3, 3, 3)), y)

--- a/heat/regression/tests/test_lasso.py
+++ b/heat/regression/tests/test_lasso.py
@@ -46,11 +46,13 @@ class TestLasso(unittest.TestCase):
                 os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"),
                 dataset="x",
                 device=ht_device,
+                split=0,
             )
             y = ht.load_hdf5(
                 os.path.join(os.getcwd(), "heat/datasets/data/diabetes.h5"),
                 dataset="y",
                 device=ht_device,
+                split=0,
             )
 
             # normalize dataset
@@ -80,4 +82,4 @@ class TestLasso(unittest.TestCase):
 
             # check whether the results are correct
             self.assertIsInstance(yest, ht.DNDarray)
-            self.assertEqual(yest.shape, (m,))
+            self.assertEqual(yest.shape, (m, 1))

--- a/heat/regression/tests/test_lasso.py
+++ b/heat/regression/tests/test_lasso.py
@@ -87,4 +87,4 @@ class TestLasso(unittest.TestCase):
             with self.assertRaises(ValueError):
                 estimator.fit(X, ht.zeros((3, 3, 3)))
             with self.assertRaises(ValueError):
-                estimator.fit(ht.zeros((3, 3, 3)), y)
+                estimator.fit(ht.zeros((3, 3, 3)), ht.zeros((3, 3)))


### PR DESCRIPTION
## Description

This PR removes PyTorch and Numpy examples from example/lasso/demo.py

Issue/s resolved: #528

## Changes proposed:
Removed PyTorch and Numpy Lasso examples

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
