### PR TITLE
removed raise in setitem for differening split axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#558](https://github.com/helmholtz-analytics/heat/pull/558) `sanitize_memory_layout` assumes default memory layout of the input tensor
 - [#558](https://github.com/helmholtz-analytics/heat/pull/558) Support for PyTorch 1.5.0 added
 - [#562](https://github.com/helmholtz-analytics/heat/pull/562) Bugfix: split semantics of ht.squeeze()
+- [#567](https://github.com/helmholtz-analytics/heat/pull/567) Bugfix: split differences for setitem are now assumed to be correctly given, error will come from torch upon the setting of the value
 
 # v0.3.0
 

--- a/examples/lasso/demo.py
+++ b/examples/lasso/demo.py
@@ -30,8 +30,8 @@ theta_list = list()
 lamda = np.logspace(0, 4, 10) / 10
 
 # compute the lasso path
-for l in lamda:
-    estimator.lam = l
+for la in lamda:
+    estimator.lam = la
     estimator.fit(X, y)
     theta_list.append(estimator.theta.numpy().flatten())
 

--- a/heat/core/base.py
+++ b/heat/core/base.py
@@ -76,8 +76,9 @@ class BaseEstimator:
         for key, value in params.items():
             if key not in parameter_names:
                 raise ValueError(
-                    "Invalid parameter %s for estimator %s. Check the list of available parameters "
-                    "with `estimator.get_params().keys()`.".format(key, self)
+                    "Invalid parameter %s for estimator %s. Check the list of available parameters with `estimator.get_params().keys()`.".format(
+                        key, self
+                    )
                 )
 
             if isinstance(value, dict):

--- a/heat/core/base.py
+++ b/heat/core/base.py
@@ -76,7 +76,7 @@ class BaseEstimator:
         for key, value in params.items():
             if key not in parameter_names:
                 raise ValueError(
-                    "Invalid parameter %s for estimator %s. Check the list of available parameters with `estimator.get_params().keys()`.".format(
+                    "Invalid parameter {} for estimator {}. Check the list of available parameters with `estimator.get_params().keys()`.".format(
                         key, self
                     )
                 )

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -3058,6 +3058,12 @@ class DNDarray:
         Nothing
             The specified element/s (key) of self is set with the value
 
+        Notes
+        -----
+        If a DNDarray is given as the value to be set then the split axes are assumed to be equal.
+            If they are not, PyTorch will raise an error when the values are attempted to be set
+            on the local array
+
         Examples
         --------
         (2 processes)
@@ -3103,7 +3109,7 @@ class DNDarray:
                     ):
                         value = factories.array(value, split=self[key].split)
                     self.__setter(key, value)
-            elif isinstance(key, (tuple, list, torch.Tensor)):
+            elif isinstance(key, (tuple, torch.Tensor)):
                 if isinstance(key[self.split], slice):
                     key = list(key)
                     overlap = list(

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1392,7 +1392,6 @@ class DNDarray:
             key = tuple(x.item() for x in key)
 
         if not self.is_distributed():
-
             if not self.comm.size == 1:
                 if isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
                     # this will return a 1D array as the shape cannot be determined automatically
@@ -1427,7 +1426,6 @@ class DNDarray:
                     )
 
         else:
-
             _, _, chunk_slice = self.comm.chunk(self.shape, self.split)
             chunk_start = chunk_slice[self.split].start
             chunk_end = chunk_slice[self.split].stop
@@ -1601,7 +1599,6 @@ class DNDarray:
                     gout[e] = self.comm.allreduce(gout[e], MPI.SUM)
                 else:
                     gout[e] = self.comm.allreduce(gout[e], MPI.MAX)
-
             return DNDarray(
                 arr.type(l_dtype),
                 gout if isinstance(gout, tuple) else tuple(gout),
@@ -3086,12 +3083,8 @@ class DNDarray:
             else:
                 self.__setter(key, value)
         else:
-            if (
-                isinstance(value, DNDarray)
-                and value.split is not None
-                and value.split != self.split
-            ):
-                raise RuntimeError("split axis of array and the target value are not equal")
+            # raise RuntimeError("split axis of array and the target value are not equal") removed
+            # this will occur if the local shapes do not match
             _, _, chunk_slice = self.comm.chunk(self.shape, self.split)
             chunk_start = chunk_slice[self.split].start
             chunk_end = chunk_slice[self.split].stop

--- a/heat/core/io.py
+++ b/heat/core/io.py
@@ -590,8 +590,8 @@ def load_csv(
             # Determine the number of columns that each line consists of
             if len(line_starts) > 1:
                 columns = 1
-                for l in r[line_starts[0] : line_starts[1]]:
-                    if chr(l) == sep:
+                for li in r[line_starts[0] : line_starts[1]]:
+                    if chr(li) == sep:
                         columns += 1
             else:
                 columns = 0

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -846,7 +846,7 @@ def __merge_moments(m1, m2, bessel=True):
     """
     if len(m1) != len(m2):
         raise ValueError(
-            "m1 and m2 must be same length, currently {} and {}".format(len(m1, len(m2)))
+            "m1 and m2 must be same length, currently {} and {}".format(len(m1), len(m2))
         )
     n1, n2 = m1[-1], m2[-1]
     mu1, mu2 = m1[-2], m2[-2]

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -396,9 +396,9 @@ class TestFactories(unittest.TestCase):
         def get_offset(tensor_array):
             x, y = tensor_array.shape
             for k in range(x):
-                for l in range(y):
-                    if tensor_array[k][l] == 1:
-                        return k, l
+                for li in range(y):
+                    if tensor_array[k][li] == 1:
+                        return k, li
             return x, y
 
         shape = 5


### PR DESCRIPTION
## Description

Bug fix for issue #566 a raise was removed to allow for the setting of an array in the form of  `x[i] = y` where both `x` and `y` are multidimensional and both are split. The raise was removed entirely because the object `x[i]` is created during runtime and not previously, thus the split axis tested at the beginning of the setitem routing had the split of `x` and not `x[i]`. to determine the split of `x[i]` requires significant overhead (using getitem routine). if the splits do not match a Runtime error will be raised as the local shapes of the PyTorch tensors will not match. A note is made in the docs.

Issue/s resolved: #566 

## Changes proposed:
- removal of the raise in setitem for differening split axes

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
yes, anything which uses the setitem routine
