### PR TITLE
bugfix for matmul bug (split 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [#558](https://github.com/helmholtz-analytics/heat/pull/558) Support for PyTorch 1.5.0 added
 - [#562](https://github.com/helmholtz-analytics/heat/pull/562) Bugfix: split semantics of ht.squeeze()
 - [#567](https://github.com/helmholtz-analytics/heat/pull/567) Bugfix: split differences for setitem are now assumed to be correctly given, error will come from torch upon the setting of the value
+- [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
 
 # v0.3.0
 

--- a/heat/core/linalg/solver.py
+++ b/heat/core/linalg/solver.py
@@ -62,7 +62,6 @@ def cg(A, b, x0, out=None):
                 out = x
                 return out
             return x
-
         p = r + ((rsnew / rsold) * p)
         rsold = rsnew
 


### PR DESCRIPTION
Matmul had a bug for when kB (the inner blocking dimension is 1, when this was the case, it would do a second loop which would re-add previous results to the result array.

## Description

matmul of 2 vectors is handled as an early out
in split 10 case for matmul, the remainder handling does not run if kB is equal to 0

Issue/s resolved: #570 

## Changes proposed:
- see description

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
