### PR TITLE
removed legacy code in binary op for type promotion, updated cov and …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@
 - [#536](https://github.com/helmholtz-analytics/heat/pull/536) Getting rid of the docs folder
 - [#558](https://github.com/helmholtz-analytics/heat/pull/558) `sanitize_memory_layout` assumes default memory layout of the input tensor
 - [#558](https://github.com/helmholtz-analytics/heat/pull/558) Support for PyTorch 1.5.0 added
-- [#562](https://github.com/helmholtz-analytics/heat/pull/562) Bugfix: split semantics of ht.squeeze()
-- [#567](https://github.com/helmholtz-analytics/heat/pull/567) Bugfix: split differences for setitem are now assumed to be correctly given, error will come from torch upon the setting of the value
+- [#562](https://github.com/helmholtz-analytics/heat/pull/562) Bugfix: split semantics of `ht.squeeze()`
+- [#567](https://github.com/helmholtz-analytics/heat/pull/567) Bugfix: split differences for `setitem` are now assumed to be correctly given, error will come from torch upon the setting of the value
+- [#558](https://github.com/helmholtz-analytics/heat/pull/558) Binary operations use proper type casting
+- [#558](https://github.com/helmholtz-analytics/heat/pull/558) `where` and `cov` convert ints to floats when given as parameters
 
 # v0.3.0
 

--- a/README.md
+++ b/README.md
@@ -104,5 +104,9 @@ Acknowledgements
 ----------------
 
 *This work is supported by the [Helmholtz Association Initiative and
-Networking](https://www.helmholtz.de/en/about_us/the_association/initiating_and_networking/)
-Fund under project number ZT-I-0003.*
+Networking Fund](https://www.helmholtz.de/en/about_us/the_association/initiating_and_networking/)
+under project number ZT-I-0003.*
+
+*This work is supported by the [Helmholtz Association Initiative and
+Networking Fund](https://www.helmholtz.de/en/about_us/the_association/initiating_and_networking/)
+under the Helmholtz AI platform grant.*

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -135,6 +135,10 @@ def where(cond, x=None, y=None):
     if isinstance(x, (dndarray.DNDarray, int, float)) and isinstance(
         y, (dndarray.DNDarray, int, float)
     ):
+        if isinstance(y, int):
+            y = float(y)
+        if isinstance(x, int):
+            x = float(x)
         return (cond == 0) * y + cond * x
     elif x is None and y is None:
         return nonzero(cond)

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -139,7 +139,7 @@ def where(cond, x=None, y=None):
             y = float(y)
         if isinstance(x, int):
             x = float(x)
-        return (cond == 0) * y + cond * x
+        return cond.dtype((cond == 0)) * y + cond * x
     elif x is None and y is None:
         return nonzero(cond)
     else:

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -97,7 +97,7 @@ def where(cond, x=None, y=None):
     ----------
     cond: DNDarray
         condition of interest, where true yield x otherwise yield y
-    x, y: DNDarray, int, or float
+    x, y: DNDarray, int, float
         Values from which to choose. x, y and condition need to be broadcastable to some shape.
 
     Returns
@@ -135,8 +135,7 @@ def where(cond, x=None, y=None):
     if isinstance(x, (dndarray.DNDarray, int, float)) and isinstance(
         y, (dndarray.DNDarray, int, float)
     ):
-        cond = types.float(cond, device=cond.device)
-        return types.float(cond == 0, device=cond.device) * y + cond * x
+        return (cond == 0) * y + cond * x
     elif x is None and y is None:
         return nonzero(cond)
     else:

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -134,10 +134,6 @@ def __binary_op(operation, t1, t2):
             raise TypeError(
                 "Only tensors and numeric scalars are supported, but input was {}".format(type(t2))
             )
-
-        if t2.dtype != t1.dtype:
-            t2 = t2.astype(t1.dtype)
-
     else:
         raise NotImplementedError("Not implemented for non scalar")
 

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -406,9 +406,11 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None):
 
     if ddof is None:
         if bias == 0:
-            ddof = 1
+            ddof = 1.0
         else:
-            ddof = 0
+            ddof = 0.0
+    elif isinstance(ddof, int):
+        ddof = float(ddof)
 
     if y is not None:
         if not isinstance(y, dndarray.DNDarray):

--- a/heat/core/tests/test_indexing.py
+++ b/heat/core/tests/test_indexing.py
@@ -61,7 +61,7 @@ class TestIndexing(unittest.TestCase):
         res = ht.array(
             [[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=None, device=ht_device
         )
-        wh = ht.where(a < 4.0, a, -1.0)
+        wh = ht.where(a < 4.0, a, -1)
         self.assertTrue(
             ht.equal(
                 a[ht.nonzero(a < 4)],
@@ -77,7 +77,7 @@ class TestIndexing(unittest.TestCase):
         res = ht.array(
             [[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=0, device=ht_device
         )
-        wh = ht.where(a < 4.0, a, -1.0)
+        wh = ht.where(a < 4.0, a, -1)
         self.assertTrue(ht.all(wh[ht.nonzero(a >= 4)], -1))
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))

--- a/heat/core/tests/test_indexing.py
+++ b/heat/core/tests/test_indexing.py
@@ -77,7 +77,7 @@ class TestIndexing(unittest.TestCase):
         res = ht.array(
             [[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=0, device=ht_device
         )
-        wh = ht.where(a < 4.0, a, -1)
+        wh = ht.where(a < 4.0, a, -1.0)
         self.assertTrue(ht.all(wh[ht.nonzero(a >= 4)], -1))
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))
@@ -88,7 +88,7 @@ class TestIndexing(unittest.TestCase):
         res = ht.array(
             [[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=1, device=ht_device
         )
-        wh = ht.where(a < 4.0, a, -1)
+        wh = ht.where(a < 4.0, a, -1.0)
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))
         self.assertEqual(wh.dtype, ht.float)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -213,9 +213,8 @@ class TestStatistics(unittest.TestCase):
 
         htdata = ht.load("heat/datasets/data/iris.csv", sep=";", split=0, device=ht_device)
         ht_cov = ht.cov(htdata[:, 0], htdata[:, 1:3], rowvar=False)
-        self.assertTrue(
-            ht.allclose(ht.array(np_cov, dtype=ht.float, device=ht_device) - ht_cov, 0, atol=1e-4)
-        )
+        comp = ht.array(np_cov, dtype=ht.float, device=ht_device)
+        self.assertTrue(ht.allclose(comp - ht_cov, 0, atol=1e-4))
 
         np_cov = np.cov(data, rowvar=False)
         ht_cov = ht.cov(htdata, rowvar=False)

--- a/heat/core/tests/test_trigonometrics.py
+++ b/heat/core/tests/test_trigonometrics.py
@@ -18,114 +18,6 @@ if os.environ.get("DEVICE") == "lgpu" and torch.cuda.is_available():
 
 
 class TestTrigonometrics(unittest.TestCase):
-    def test_rad2deg(self):
-        # base elements
-        elements = [0.0, 0.2, 0.6, 0.9, 1.2, 2.7, 3.14]
-        comparison = (
-            180.0 * torch.tensor(elements, dtype=torch.float64, device=device) / 3.141592653589793
-        )
-
-        # rad2deg with float32
-        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
-        float32_rad2deg = ht.rad2deg(float32_tensor)
-        self.assertIsInstance(float32_rad2deg, ht.DNDarray)
-        self.assertEqual(float32_rad2deg.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_rad2deg._DNDarray__array.double(), comparison))
-
-        # rad2deg with float64
-        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
-        float64_rad2deg = ht.rad2deg(float64_tensor)
-        self.assertIsInstance(float64_rad2deg, ht.DNDarray)
-        self.assertEqual(float64_rad2deg.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_rad2deg._DNDarray__array.double(), comparison))
-
-        # check exceptions
-        with self.assertRaises(TypeError):
-            ht.rad2deg([1, 2, 3])
-        with self.assertRaises(TypeError):
-            ht.rad2deg("hello world")
-
-    def test_degrees(self):
-        # base elements
-        elements = [0.0, 0.2, 0.6, 0.9, 1.2, 2.7, 3.14]
-        comparison = (
-            180.0 * torch.tensor(elements, dtype=torch.float64, device=device) / 3.141592653589793
-        )
-
-        # degrees with float32
-        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
-        float32_degrees = ht.degrees(float32_tensor)
-        self.assertIsInstance(float32_degrees, ht.DNDarray)
-        self.assertEqual(float32_degrees.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_degrees._DNDarray__array.double(), comparison))
-
-        # degrees with float64
-        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
-        float64_degrees = ht.degrees(float64_tensor)
-        self.assertIsInstance(float64_degrees, ht.DNDarray)
-        self.assertEqual(float64_degrees.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_degrees._DNDarray__array.double(), comparison))
-
-        # check exceptions
-        with self.assertRaises(TypeError):
-            ht.degrees([1, 2, 3])
-        with self.assertRaises(TypeError):
-            ht.degrees("hello world")
-
-    def test_deg2rad(self):
-        # base elements
-        elements = [0.0, 20.0, 45.0, 78.0, 94.0, 120.0, 180.0, 270.0, 311.0]
-        comparison = (
-            3.141592653589793 * torch.tensor(elements, dtype=torch.float64, device=device) / 180.0
-        )
-
-        # deg2rad with float32
-        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
-        float32_deg2rad = ht.deg2rad(float32_tensor)
-        self.assertIsInstance(float32_deg2rad, ht.DNDarray)
-        self.assertEqual(float32_deg2rad.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_deg2rad._DNDarray__array.double(), comparison))
-
-        # deg2rad with float64
-        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
-        float64_deg2rad = ht.deg2rad(float64_tensor)
-        self.assertIsInstance(float64_deg2rad, ht.DNDarray)
-        self.assertEqual(float64_deg2rad.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_deg2rad._DNDarray__array.double(), comparison))
-
-        # check exceptions
-        with self.assertRaises(TypeError):
-            ht.deg2rad([1, 2, 3])
-        with self.assertRaises(TypeError):
-            ht.deg2rad("hello world")
-
-    def test_radians(self):
-        # base elements
-        elements = [0.0, 20.0, 45.0, 78.0, 94.0, 120.0, 180.0, 270.0, 311.0]
-        comparison = (
-            3.141592653589793 * torch.tensor(elements, dtype=torch.float64, device=device) / 180.0
-        )
-
-        # radians with float32
-        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
-        float32_radians = ht.radians(float32_tensor)
-        self.assertIsInstance(float32_radians, ht.DNDarray)
-        self.assertEqual(float32_radians.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_radians._DNDarray__array.double(), comparison))
-
-        # radians with float64
-        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
-        float64_radians = ht.radians(float64_tensor)
-        self.assertIsInstance(float64_radians, ht.DNDarray)
-        self.assertEqual(float64_radians.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_radians._DNDarray__array.double(), comparison))
-
-        # check exceptions
-        with self.assertRaises(TypeError):
-            ht.radians([1, 2, 3])
-        with self.assertRaises(TypeError):
-            ht.radians("hello world")
-
     def test_arctan(self):
         # base elements
         elements = 30
@@ -201,7 +93,7 @@ class TestTrigonometrics(unittest.TestCase):
         int16_y = ht.array([-1, -1, +1, +1], dtype=ht.int16)
 
         int16_comparison = ht.array([-135.0, -45.0, 45.0, 135.0], dtype=ht.float32)
-        int16_arctan2 = ht.arctan2(int16_y, int16_x) * 180 / ht.pi
+        int16_arctan2 = ht.arctan2(int16_y, int16_x) * 180.0 / ht.pi
 
         self.assertIsInstance(int16_arctan2, ht.DNDarray)
         self.assertEqual(int16_arctan2.dtype, ht.float32)
@@ -270,6 +162,60 @@ class TestTrigonometrics(unittest.TestCase):
             ht.arccos([1, 2, 3])
         with self.assertRaises(TypeError):
             ht.arccos("hello world")
+
+    def test_degrees(self):
+        # base elements
+        elements = [0.0, 0.2, 0.6, 0.9, 1.2, 2.7, 3.14]
+        comparison = (
+            180.0 * torch.tensor(elements, dtype=torch.float64, device=device) / 3.141592653589793
+        )
+
+        # degrees with float32
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
+        float32_degrees = ht.degrees(float32_tensor)
+        self.assertIsInstance(float32_degrees, ht.DNDarray)
+        self.assertEqual(float32_degrees.dtype, ht.float32)
+        self.assertTrue(torch.allclose(float32_degrees._DNDarray__array.double(), comparison))
+
+        # degrees with float64
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
+        float64_degrees = ht.degrees(float64_tensor)
+        self.assertIsInstance(float64_degrees, ht.DNDarray)
+        self.assertEqual(float64_degrees.dtype, ht.float64)
+        self.assertTrue(torch.allclose(float64_degrees._DNDarray__array.double(), comparison))
+
+        # check exceptions
+        with self.assertRaises(TypeError):
+            ht.degrees([1, 2, 3])
+        with self.assertRaises(TypeError):
+            ht.degrees("hello world")
+
+    def test_deg2rad(self):
+        # base elements
+        elements = [0.0, 20.0, 45.0, 78.0, 94.0, 120.0, 180.0, 270.0, 311.0]
+        comparison = (
+            3.141592653589793 * torch.tensor(elements, dtype=torch.float64, device=device) / 180.0
+        )
+
+        # deg2rad with float32
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
+        float32_deg2rad = ht.deg2rad(float32_tensor)
+        self.assertIsInstance(float32_deg2rad, ht.DNDarray)
+        self.assertEqual(float32_deg2rad.dtype, ht.float32)
+        self.assertTrue(torch.allclose(float32_deg2rad._DNDarray__array.double(), comparison))
+
+        # deg2rad with float64
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
+        float64_deg2rad = ht.deg2rad(float64_tensor)
+        self.assertIsInstance(float64_deg2rad, ht.DNDarray)
+        self.assertEqual(float64_deg2rad.dtype, ht.float64)
+        self.assertTrue(torch.allclose(float64_deg2rad._DNDarray__array.double(), comparison))
+
+        # check exceptions
+        with self.assertRaises(TypeError):
+            ht.deg2rad([1, 2, 3])
+        with self.assertRaises(TypeError):
+            ht.deg2rad("hello world")
 
     def test_cos(self):
         # base elements
@@ -348,6 +294,60 @@ class TestTrigonometrics(unittest.TestCase):
             ht.cosh([1, 2, 3])
         with self.assertRaises(TypeError):
             ht.cosh("hello world")
+
+    def test_rad2deg(self):
+        # base elements
+        elements = [0.0, 0.2, 0.6, 0.9, 1.2, 2.7, 3.14]
+        comparison = (
+            180.0 * torch.tensor(elements, dtype=torch.float64, device=device) / 3.141592653589793
+        )
+
+        # rad2deg with float32
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
+        float32_rad2deg = ht.rad2deg(float32_tensor)
+        self.assertIsInstance(float32_rad2deg, ht.DNDarray)
+        self.assertEqual(float32_rad2deg.dtype, ht.float32)
+        self.assertTrue(torch.allclose(float32_rad2deg._DNDarray__array.double(), comparison))
+
+        # rad2deg with float64
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
+        float64_rad2deg = ht.rad2deg(float64_tensor)
+        self.assertIsInstance(float64_rad2deg, ht.DNDarray)
+        self.assertEqual(float64_rad2deg.dtype, ht.float64)
+        self.assertTrue(torch.allclose(float64_rad2deg._DNDarray__array.double(), comparison))
+
+        # check exceptions
+        with self.assertRaises(TypeError):
+            ht.rad2deg([1, 2, 3])
+        with self.assertRaises(TypeError):
+            ht.rad2deg("hello world")
+
+    def test_radians(self):
+        # base elements
+        elements = [0.0, 20.0, 45.0, 78.0, 94.0, 120.0, 180.0, 270.0, 311.0]
+        comparison = (
+            3.141592653589793 * torch.tensor(elements, dtype=torch.float64, device=device) / 180.0
+        )
+
+        # radians with float32
+        float32_tensor = ht.array(elements, dtype=ht.float32, device=ht_device)
+        float32_radians = ht.radians(float32_tensor)
+        self.assertIsInstance(float32_radians, ht.DNDarray)
+        self.assertEqual(float32_radians.dtype, ht.float32)
+        self.assertTrue(torch.allclose(float32_radians._DNDarray__array.double(), comparison))
+
+        # radians with float64
+        float64_tensor = ht.array(elements, dtype=ht.float64, device=ht_device)
+        float64_radians = ht.radians(float64_tensor)
+        self.assertIsInstance(float64_radians, ht.DNDarray)
+        self.assertEqual(float64_radians.dtype, ht.float64)
+        self.assertTrue(torch.allclose(float64_radians._DNDarray__array.double(), comparison))
+
+        # check exceptions
+        with self.assertRaises(TypeError):
+            ht.radians([1, 2, 3])
+        with self.assertRaises(TypeError):
+            ht.radians("hello world")
 
     def test_sin(self):
         # base elements

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -409,6 +409,19 @@ __safe_cast = [
     [False, False, False, False, False, False, False, True],  # float64
 ]
 
+# intuitive cast table
+__intuitive_cast = [
+    # bool  uint8  int8   int16  int32  int64  float32 float64
+    [True, True, True, True, True, True, True, True],  # bool
+    [False, True, False, True, True, True, True, True],  # uint8
+    [False, False, True, True, True, True, True, True],  # int8
+    [False, False, False, True, True, True, True, True],  # int16
+    [False, False, False, False, True, True, True, True],  # int32
+    [False, False, False, False, False, True, False, True],  # int64
+    [False, False, False, False, False, False, True, True],  # float32
+    [False, False, False, False, False, False, False, True],  # float64
+]
+
 
 # same kind table
 __same_kind = [
@@ -425,7 +438,7 @@ __same_kind = [
 
 
 # static list of possible casting methods
-__cast_kinds = ["no", "safe", "same_kind", "unsafe"]
+__cast_kinds = ["no", "safe", "same_kind", "unsafe", "intuitive"]
 
 
 def can_cast(from_, to, casting="safe"):
@@ -509,6 +522,9 @@ def can_cast(from_, to, casting="safe"):
     can_safe_cast = __safe_cast[typecode_from][typecode_to]
     if casting == "safe":
         return can_safe_cast
+    can_intuitive_cast = __intuitive_cast[typecode_from][typecode_to]
+    if casting == "intuitive":
+        return can_intuitive_cast
     return can_safe_cast or __same_kind[typecode_from][typecode_to]
 
 


### PR DESCRIPTION
…where to use flaots not ints

## Description

removed legacy code problem for binary op in favor of proper type promotion. 

Issue/s resolved: #574 

## Changes proposed:
- binary op uses type promotion instead of manual setting (legacy)
- where and cov use floats instead of ints by default. (type conversion from int is to float64 in python)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
