### PR TITLE
Features/35 fliplr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.6"
+  - "3.7"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.7"
+  - "3.6"
 
 services:
   - docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Pending Additions
 
 - [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
+- [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
 
 
 # v0.4.0

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -18,6 +18,7 @@ __all__ = [
     "expand_dims",
     "flatten",
     "flip",
+    "fliplr",
     "flipud",
     "hstack",
     "reshape",
@@ -700,6 +701,35 @@ def flip(a, axis=None):
     res.balance_()  # after swapping, first processes may be empty
     req.Wait()
     return res
+
+
+def fliplr(a):
+    """
+        Flip array in the left/right direction. If a.ndim > 2, flip along dimension 1.
+
+        Parameters
+        ----------
+        a: ht.DNDarray
+            Input array to be flipped, must be at least 2-D
+
+        Returns
+        -------
+        res: ht.DNDarray
+            The flipped array.
+
+        Examples
+        --------
+        >>> a = ht.array([[0,1],[2,3]])
+        >>> ht.fliplr(a)
+        tensor([[1, 0],
+                [3, 2]])
+
+        >>> b = ht.array([[0,1,2],[3,4,5]], split=0)
+        >>> ht.fliplr(b)
+        (1/2) tensor([[2, 1, 0]])
+        (2/2) tensor([[5, 4, 3]])
+    """
+    return flip(a, 1)
 
 
 def flipud(a):

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -827,6 +827,45 @@ class TestManipulations(BasicTest):
         )
         self.assertTrue(ht.equal(ht.flip(a, [1, 2]), r_a))
 
+    def test_fliplr(self):
+        b = ht.array([[1, 2], [3, 4]], device=ht_device)
+        r_b = ht.array([[2, 1], [4, 3]], device=ht_device)
+        self.assertTrue(ht.equal(ht.fliplr(b), r_b))
+
+        # splitted
+        c = ht.array(
+            [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[8, 9], [10, 11]], [[12, 13], [14, 15]]],
+            split=0,
+            device=ht_device,
+        )
+        r_c = ht.array(
+            [[[2, 3], [0, 1]], [[6, 7], [4, 5]], [[10, 11], [8, 9]], [[14, 15], [12, 13]]],
+            split=0,
+            device=ht_device,
+        )
+        self.assertTrue(ht.equal(ht.fliplr(c), r_c))
+
+        c = ht.array(
+            [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[8, 9], [10, 11]], [[12, 13], [14, 15]]],
+            split=1,
+            device=ht_device,
+            dtype=ht.float32,
+        )
+        self.assertTrue(ht.equal(ht.resplit(ht.fliplr(c), 0), r_c))
+
+        c = ht.array(
+            [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[8, 9], [10, 11]], [[12, 13], [14, 15]]],
+            split=2,
+            device=ht_device,
+            dtype=ht.int8,
+        )
+        self.assertTrue(ht.equal(ht.resplit(ht.fliplr(c), 0), r_c))
+
+        # test exception
+        a = ht.arange(10, device=ht_device)
+        with self.assertRaises(IndexError):
+            ht.fliplr(a)
+
     def test_flipud(self):
         a = ht.array([1, 2], device=ht_device)
         r_a = ht.array([2, 1], device=ht_device)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

- Added function `ht.fliplr()`, corresponding to `ht.flip(a, 1)`.
- Implemented tests, including for `a.ndim < 2`

Issue/s resolved: #35 

## Changes proposed:
-
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
