### PR TITLE
Features/555 rot90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
+- [#582](https://github.com/helmholtz-analytics/heat/pull/582) New feature: rot90
 
 
 # v0.4.0

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -914,18 +914,17 @@ def rot90(m, k=1, axes=(0,1)):
     Rotation direction is from the first towards the second axis.
     Parameters
     ----------
-    m : array_like
+    m : DNDarray
         Array of two or more dimensions.
     k : integer
         Number of times the array is rotated by 90 degrees.
-    axes: (2,) array_like
+    axes: (2,) integer
         The array is rotated in the plane defined by the axes.
         Axes must be different.
-        .. versionadded:: 1.12.0
     
     Returns
     -------
-    y : ndarray
+    y : DNDarray
         A rotated view of `m`.
 
     Notes
@@ -935,22 +934,22 @@ def rot90(m, k=1, axes=(0,1)):
     
     Examples
     --------
-    >>> m = np.array([[1,2],[3,4]], int)
+    >>> m = ht.array([[1,2],[3,4]], dtype=ht.int)
     >>> m
-    array([[1, 2],
-           [3, 4]])
-    >>> np.rot90(m)
-    array([[2, 4],
-           [1, 3]])
-    >>> np.rot90(m, 2)
-    array([[4, 3],
-           [2, 1]])
-    >>> m = np.arange(8).reshape((2,2,2))
-    >>> np.rot90(m, 1, (1,2))
-    array([[[1, 3],
-            [0, 2]],
-           [[5, 7],
-            [4, 6]]])
+    tensor([[1, 2],
+            [3, 4]], dtype=torch.int32)
+    >>> ht.rot90(m)
+    tensor([[2, 4],
+            [1, 3]], dtype=torch.int32)
+    >>> ht.rot90(m, 2)
+    tensor([[4, 3],
+            [2, 1]], dtype=torch.int32)
+    >>> m = ht.arange(8).reshape((2,2,2))
+    >>> ht.rot90(m, 1, (1,2))
+    tensor([[[1, 3],
+             [0, 2]],
+            [[5, 7],
+             [4, 6]]], dtype=torch.int32)
     """
     axes = tuple(axes)
     if len(axes) != 2:

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -9,6 +9,7 @@ from . import factories
 from . import stride_tricks
 from . import tiling
 from . import types
+from. import linalg
 
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "hstack",
     "reshape",
     "resplit",
+    "rot90",
     "sort",
     "squeeze",
     "unique",
@@ -904,6 +906,83 @@ def reshape(a, shape, axis=None):
     data = data.reshape(local_shape)
 
     return factories.array(data, dtype=a.dtype, is_split=axis, device=a.device, comm=a.comm)
+
+
+def rot90(m, k=1, axes=(0,1)):
+    """
+    Rotate an array by 90 degrees in the plane specified by axes.
+    Rotation direction is from the first towards the second axis.
+    Parameters
+    ----------
+    m : array_like
+        Array of two or more dimensions.
+    k : integer
+        Number of times the array is rotated by 90 degrees.
+    axes: (2,) array_like
+        The array is rotated in the plane defined by the axes.
+        Axes must be different.
+        .. versionadded:: 1.12.0
+    
+    Returns
+    -------
+    y : ndarray
+        A rotated view of `m`.
+
+    Notes
+    -----
+    rot90(m, k=1, axes=(1,0)) is the reverse of rot90(m, k=1, axes=(0,1))
+    rot90(m, k=1, axes=(1,0)) is equivalent to rot90(m, k=-1, axes=(0,1))
+    
+    Examples
+    --------
+    >>> m = np.array([[1,2],[3,4]], int)
+    >>> m
+    array([[1, 2],
+           [3, 4]])
+    >>> np.rot90(m)
+    array([[2, 4],
+           [1, 3]])
+    >>> np.rot90(m, 2)
+    array([[4, 3],
+           [2, 1]])
+    >>> m = np.arange(8).reshape((2,2,2))
+    >>> np.rot90(m, 1, (1,2))
+    array([[[1, 3],
+            [0, 2]],
+           [[5, 7],
+            [4, 6]]])
+    """
+    axes = tuple(axes)
+    if len(axes) != 2:
+        raise ValueError("len(axes) must be 2.")
+
+    if not isinstance(m, dndarray.DNDarray):
+        raise TypeError("expected m to be a ht.DNDarray, but was {}".format(type(m)))
+
+    if axes[0] == axes[1] or np.absolute(axes[0] - axes[1]) == m.ndim:
+        raise ValueError("Axes must be different.")
+
+    if (axes[0] >= m.ndim or axes[0] < -m.ndim
+        or axes[1] >= m.ndim or axes[1] < -m.ndim):
+        raise ValueError("Axes={} out of range for array of ndim={}."
+            .format(axes, m.ndim))
+
+    k %= 4
+
+    if k == 0:
+        return m[:]
+    if k == 2:
+        return flip(flip(m, axes[0]), axes[1])
+
+    axes_list = np.arange(0, m.ndim).tolist()
+    (axes_list[axes[0]], axes_list[axes[1]]) = (axes_list[axes[1]],
+                                                axes_list[axes[0]])
+
+    if k == 1:
+        return linalg.transpose(flip(m,axes[1]), axes_list)
+    else:
+        # k == 3
+        return flip(linalg.transpose(m, axes_list), axes[1])
 
 
 def sort(a, axis=None, descending=False, out=None):

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -9,7 +9,7 @@ from . import factories
 from . import stride_tricks
 from . import tiling
 from . import types
-from. import linalg
+from . import linalg
 
 
 __all__ = [
@@ -908,7 +908,7 @@ def reshape(a, shape, axis=None):
     return factories.array(data, dtype=a.dtype, is_split=axis, device=a.device, comm=a.comm)
 
 
-def rot90(m, k=1, axes=(0,1)):
+def rot90(m, k=1, axes=(0, 1)):
     """
     Rotate an array by 90 degrees in the plane specified by axes.
     Rotation direction is from the first towards the second axis.
@@ -918,10 +918,10 @@ def rot90(m, k=1, axes=(0,1)):
         Array of two or more dimensions.
     k : integer
         Number of times the array is rotated by 90 degrees.
-    axes: (2,) integer
+    axes: (2,) int list or tuple
         The array is rotated in the plane defined by the axes.
         Axes must be different.
-    
+
     Returns
     -------
     y : DNDarray
@@ -931,7 +931,9 @@ def rot90(m, k=1, axes=(0,1)):
     -----
     rot90(m, k=1, axes=(1,0)) is the reverse of rot90(m, k=1, axes=(0,1))
     rot90(m, k=1, axes=(1,0)) is equivalent to rot90(m, k=-1, axes=(0,1))
-    
+
+    May change the split axis on distributed tensors
+
     Examples
     --------
     >>> m = ht.array([[1,2],[3,4]], dtype=ht.int)
@@ -961,10 +963,13 @@ def rot90(m, k=1, axes=(0,1)):
     if axes[0] == axes[1] or np.absolute(axes[0] - axes[1]) == m.ndim:
         raise ValueError("Axes must be different.")
 
-    if (axes[0] >= m.ndim or axes[0] < -m.ndim
-        or axes[1] >= m.ndim or axes[1] < -m.ndim):
-        raise ValueError("Axes={} out of range for array of ndim={}."
-            .format(axes, m.ndim))
+    if axes[0] >= m.ndim or axes[0] < -m.ndim or axes[1] >= m.ndim or axes[1] < -m.ndim:
+        raise ValueError("Axes={} out of range for array of ndim={}.".format(axes, m.ndim))
+
+    if m.split is None:
+        return factories.array(
+            torch.rot90(m._DNDarray__array, k, axes), dtype=m.dtype, device=m.device, comm=m.comm
+        )
 
     k %= 4
 
@@ -974,11 +979,10 @@ def rot90(m, k=1, axes=(0,1)):
         return flip(flip(m, axes[0]), axes[1])
 
     axes_list = np.arange(0, m.ndim).tolist()
-    (axes_list[axes[0]], axes_list[axes[1]]) = (axes_list[axes[1]],
-                                                axes_list[axes[0]])
+    (axes_list[axes[0]], axes_list[axes[1]]) = (axes_list[axes[1]], axes_list[axes[0]])
 
     if k == 1:
-        return linalg.transpose(flip(m,axes[1]), axes_list)
+        return linalg.transpose(flip(m, axes[1]), axes_list)
     else:
         # k == 3
         return flip(linalg.transpose(m, axes_list), axes[1])

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1019,6 +1019,48 @@ class TestManipulations(BasicTest):
         with self.assertRaises(TypeError):
             ht.reshape(ht.zeros((4, 3)), "(5, 7)")
 
+    def test_rot90(self):
+        size = ht.MPI_WORLD.size
+        m = ht.arange(size ** 3, dtype=ht.int).reshape((size, size, size))
+
+        self.assertTrue(ht.equal(ht.rot90(m, 0), m))
+        self.assertTrue(ht.equal(ht.rot90(m, 4), m))
+        self.assertTrue(ht.equal(ht.rot90(ht.rot90(m, 1), 1, (1, 0)), m))
+
+        a = ht.resplit(m, 0)
+
+        self.assertTrue(ht.equal(ht.rot90(a), ht.resplit(ht.rot90(m), 1)))
+        self.assertTrue(ht.equal(ht.rot90(a, 2), ht.resplit(ht.rot90(m, 2), 0)))
+        self.assertTrue(ht.equal(ht.rot90(a, 3, (1, 2)), ht.resplit(ht.rot90(m, 3, (1, 2)), 0)))
+
+        m = ht.arange(size ** 3, dtype=ht.float).reshape((size, size, size))
+        a = ht.resplit(m, 1)
+
+        self.assertTrue(ht.equal(ht.rot90(a), ht.resplit(ht.rot90(m), 0)))
+        self.assertTrue(ht.equal(ht.rot90(a, 2), ht.resplit(ht.rot90(m, 2), 1)))
+        self.assertTrue(ht.equal(ht.rot90(a, 3, (1, 2)), ht.resplit(ht.rot90(m, 3, (1, 2)), 2)))
+
+        a = ht.resplit(m, 2)
+
+        self.assertTrue(ht.equal(ht.rot90(a), ht.resplit(ht.rot90(m), 2)))
+        self.assertTrue(ht.equal(ht.rot90(a, 2), ht.resplit(ht.rot90(m, 2), 2)))
+        self.assertTrue(ht.equal(ht.rot90(a, 3, (1, 2)), ht.resplit(ht.rot90(m, 3, (1, 2)), 1)))
+
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.ones((2, 3)), 1, (0, 1, 2))
+        with self.assertRaises(TypeError):
+            ht.rot90(torch.tensor((2, 3)))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (0, 0))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (-3, 1))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (4, 1))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (0, -2))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (0, 3))
+
     def test_sort(self):
         size = ht.MPI_WORLD.size
         rank = ht.MPI_WORLD.rank


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #555 

Introduces rot90. Rotate an array on a specified plane. May change the split axis if it is in the rotation plane similar to transpose.

## Changes proposed:
- add rot90 function

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

New feature

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
