### PR TITLE
Features rot90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndims property in dndarray
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
+- [#582](https://github.com/helmholtz-analytics/heat/pull/582) New feature: rot90
 
 
 # v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
 - [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
+- [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndims property in dndarray
 
 
 # v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
 - [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
-- [#582](https://github.com/helmholtz-analytics/heat/pull/582) New feature: rot90()
+- [#583](https://github.com/helmholtz-analytics/heat/pull/583) New feature: rot90()
 
 
 # v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
 - [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndims property in dndarray
+- [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
 
 
 # v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Pending Additions
 
 - [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
-- [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
-- [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndims property in dndarray
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
-- [#582](https://github.com/helmholtz-analytics/heat/pull/582) New feature: rot90
+- [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
+- [#582](https://github.com/helmholtz-analytics/heat/pull/582) New feature: rot90()
 
 
 # v0.4.0

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -120,7 +120,7 @@ class DNDarray:
         return len(self.__gshape)
 
     @property
-    def ndims(self):
+    def ndim(self):
         """
 
         Returns

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -133,17 +133,6 @@ class DNDarray:
         return len(self.__gshape)
 
     @property
-    def ndim(self):
-        """
-
-        Returns
-        -------
-        number_of_dimensions : int
-            the number of dimensions of the DNDarray
-        """
-        return self.numdims
-
-    @property
     def size(self):
         """
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -120,6 +120,17 @@ class DNDarray:
         return len(self.__gshape)
 
     @property
+    def ndims(self):
+        """
+
+        Returns
+        -------
+        number_of_dimensions : int
+            the number of dimensions of the DNDarray
+        """
+        return self.numdims
+
+    @property
     def size(self):
         """
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -9,6 +9,7 @@ from . import factories
 from . import stride_tricks
 from . import tiling
 from . import types
+from. import linalg
 
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "hstack",
     "reshape",
     "resplit",
+    "rot90",
     "sort",
     "squeeze",
     "unique",
@@ -934,6 +936,83 @@ def reshape(a, shape, axis=None):
     data = data.reshape(local_shape)
 
     return factories.array(data, dtype=a.dtype, is_split=axis, device=a.device, comm=a.comm)
+
+
+def rot90(m, k=1, axes=(0,1)):
+    """
+    Rotate an array by 90 degrees in the plane specified by axes.
+    Rotation direction is from the first towards the second axis.
+    Parameters
+    ----------
+    m : array_like
+        Array of two or more dimensions.
+    k : integer
+        Number of times the array is rotated by 90 degrees.
+    axes: (2,) array_like
+        The array is rotated in the plane defined by the axes.
+        Axes must be different.
+        .. versionadded:: 1.12.0
+    
+    Returns
+    -------
+    y : ndarray
+        A rotated view of `m`.
+
+    Notes
+    -----
+    rot90(m, k=1, axes=(1,0)) is the reverse of rot90(m, k=1, axes=(0,1))
+    rot90(m, k=1, axes=(1,0)) is equivalent to rot90(m, k=-1, axes=(0,1))
+    
+    Examples
+    --------
+    >>> m = np.array([[1,2],[3,4]], int)
+    >>> m
+    array([[1, 2],
+           [3, 4]])
+    >>> np.rot90(m)
+    array([[2, 4],
+           [1, 3]])
+    >>> np.rot90(m, 2)
+    array([[4, 3],
+           [2, 1]])
+    >>> m = np.arange(8).reshape((2,2,2))
+    >>> np.rot90(m, 1, (1,2))
+    array([[[1, 3],
+            [0, 2]],
+           [[5, 7],
+            [4, 6]]])
+    """
+    axes = tuple(axes)
+    if len(axes) != 2:
+        raise ValueError("len(axes) must be 2.")
+
+    if not isinstance(m, dndarray.DNDarray):
+        raise TypeError("expected m to be a ht.DNDarray, but was {}".format(type(m)))
+
+    if axes[0] == axes[1] or np.absolute(axes[0] - axes[1]) == m.ndim:
+        raise ValueError("Axes must be different.")
+
+    if (axes[0] >= m.ndim or axes[0] < -m.ndim
+        or axes[1] >= m.ndim or axes[1] < -m.ndim):
+        raise ValueError("Axes={} out of range for array of ndim={}."
+            .format(axes, m.ndim))
+
+    k %= 4
+
+    if k == 0:
+        return m[:]
+    if k == 2:
+        return flip(flip(m, axes[0]), axes[1])
+
+    axes_list = np.arange(0, m.ndim).tolist()
+    (axes_list[axes[0]], axes_list[axes[1]]) = (axes_list[axes[1]],
+                                                axes_list[axes[0]])
+
+    if k == 1:
+        return linalg.transpose(flip(m,axes[1]), axes_list)
+    else:
+        # k == 3
+        return flip(linalg.transpose(m, axes_list), axes[1])
 
 
 def sort(a, axis=None, descending=False, out=None):

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1039,7 +1039,7 @@ def rot90(m, k=1, axes=(0, 1)):
         # k == 3
         return flip(linalg.transpose(m, axes_list), axes[1])
 
-      
+
 def shape(a):
     """
     Returns the shape of a DNDarray `a`.

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -944,18 +944,17 @@ def rot90(m, k=1, axes=(0,1)):
     Rotation direction is from the first towards the second axis.
     Parameters
     ----------
-    m : array_like
+    m : DNDarray
         Array of two or more dimensions.
     k : integer
         Number of times the array is rotated by 90 degrees.
-    axes: (2,) array_like
+    axes: (2,) integer
         The array is rotated in the plane defined by the axes.
         Axes must be different.
-        .. versionadded:: 1.12.0
     
     Returns
     -------
-    y : ndarray
+    y : DNDarray
         A rotated view of `m`.
 
     Notes
@@ -965,22 +964,22 @@ def rot90(m, k=1, axes=(0,1)):
     
     Examples
     --------
-    >>> m = np.array([[1,2],[3,4]], int)
+    >>> m = ht.array([[1,2],[3,4]], dtype=ht.int)
     >>> m
-    array([[1, 2],
-           [3, 4]])
-    >>> np.rot90(m)
-    array([[2, 4],
-           [1, 3]])
-    >>> np.rot90(m, 2)
-    array([[4, 3],
-           [2, 1]])
-    >>> m = np.arange(8).reshape((2,2,2))
-    >>> np.rot90(m, 1, (1,2))
-    array([[[1, 3],
-            [0, 2]],
-           [[5, 7],
-            [4, 6]]])
+    tensor([[1, 2],
+            [3, 4]], dtype=torch.int32)
+    >>> ht.rot90(m)
+    tensor([[2, 4],
+            [1, 3]], dtype=torch.int32)
+    >>> ht.rot90(m, 2)
+    tensor([[4, 3],
+            [2, 1]], dtype=torch.int32)
+    >>> m = ht.arange(8).reshape((2,2,2))
+    >>> ht.rot90(m, 1, (1,2))
+    tensor([[[1, 3],
+             [0, 2]],
+            [[5, 7],
+             [4, 6]]], dtype=torch.int32)
     """
     axes = tuple(axes)
     if len(axes) != 2:

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -967,12 +967,15 @@ def rot90(m, k=1, axes=(0, 1)):
     Raises
     ------
     TypeError
-        If first parameter is not a :class:DNDarray
-        If parameter ``k`` is not castable to integer
+        If first parameter is not a :class:DNDarray.
+    TypeError
+        If parameter ``k`` is not castable to integer.
     ValueError
-        If ``len(axis)!=2``
-        If the axes are the same
-        If axes are out of range
+        If ``len(axis)!=2``.
+    ValueError
+        If the axes are the same.
+    ValueError
+        If axes are out of range.
 
     Examples
     --------

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -6,10 +6,10 @@ from .communication import MPI
 
 from . import dndarray
 from . import factories
+from . import linalg
 from . import stride_tricks
 from . import tiling
 from . import types
-from . import linalg
 
 
 __all__ = [
@@ -942,6 +942,7 @@ def rot90(m, k=1, axes=(0, 1)):
     """
     Rotate an array by 90 degrees in the plane specified by axes.
     Rotation direction is from the first towards the second axis.
+
     Parameters
     ----------
     m : DNDarray
@@ -954,8 +955,7 @@ def rot90(m, k=1, axes=(0, 1)):
 
     Returns
     -------
-    y : DNDarray
-        A rotated view of `m`.
+    DNDarray
 
     Notes
     -----
@@ -963,6 +963,16 @@ def rot90(m, k=1, axes=(0, 1)):
     rot90(m, k=1, axes=(1,0)) is equivalent to rot90(m, k=-1, axes=(0,1))
 
     May change the split axis on distributed tensors
+
+    Raises
+    ------
+    TypeError
+        If first parameter is not a :class:DNDarray
+        If parameter ``k`` is not castable to integer
+    ValueError
+        If ``len(axis)!=2``
+        If the axes are the same
+        If axes are out of range
 
     Examples
     --------
@@ -1001,10 +1011,15 @@ def rot90(m, k=1, axes=(0, 1)):
             torch.rot90(m._DNDarray__array, k, axes), dtype=m.dtype, device=m.device, comm=m.comm
         )
 
+    try:
+        k = int(k)
+    except (TypeError, ValueError):
+        raise TypeError("Unknown type, must be castable to integer")
+
     k %= 4
 
     if k == 0:
-        return m[:]
+        return m.copy()
     if k == 2:
         return flip(flip(m, axes[0]), axes[1])
 

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1102,6 +1102,8 @@ class TestManipulations(BasicTest):
             ht.rot90(ht.zeros((2, 2)), 1, (0, -2))
         with self.assertRaises(ValueError):
             ht.rot90(ht.zeros((2, 2)), 1, (0, 3))
+        with self.assertRaises(TypeError):
+            ht.rot90(ht.zeros((2, 3)), "k", (0, 1))
 
     def test_sort(self):
         size = ht.MPI_WORLD.size

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1068,6 +1068,7 @@ class TestManipulations(BasicTest):
 
         a = ht.resplit(m, 0)
 
+        self.assertTrue(ht.equal(ht.rot90(a, 0), a))
         self.assertTrue(ht.equal(ht.rot90(a), ht.resplit(ht.rot90(m), 1)))
         self.assertTrue(ht.equal(ht.rot90(a, 2), ht.resplit(ht.rot90(m, 2), 0)))
         self.assertTrue(ht.equal(ht.rot90(a, 3, (1, 2)), ht.resplit(ht.rot90(m, 3, (1, 2)), 0)))
@@ -1075,12 +1076,14 @@ class TestManipulations(BasicTest):
         m = ht.arange(size ** 3, dtype=ht.float).reshape((size, size, size))
         a = ht.resplit(m, 1)
 
+        self.assertTrue(ht.equal(ht.rot90(a, 0), a))
         self.assertTrue(ht.equal(ht.rot90(a), ht.resplit(ht.rot90(m), 0)))
         self.assertTrue(ht.equal(ht.rot90(a, 2), ht.resplit(ht.rot90(m, 2), 1)))
         self.assertTrue(ht.equal(ht.rot90(a, 3, (1, 2)), ht.resplit(ht.rot90(m, 3, (1, 2)), 2)))
 
         a = ht.resplit(m, 2)
 
+        self.assertTrue(ht.equal(ht.rot90(a, 0), a))
         self.assertTrue(ht.equal(ht.rot90(a), ht.resplit(ht.rot90(m), 2)))
         self.assertTrue(ht.equal(ht.rot90(a, 2), ht.resplit(ht.rot90(m, 2), 2)))
         self.assertTrue(ht.equal(ht.rot90(a, 3, (1, 2)), ht.resplit(ht.rot90(m, 3, (1, 2)), 1)))

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1058,6 +1058,48 @@ class TestManipulations(BasicTest):
         with self.assertRaises(TypeError):
             ht.reshape(ht.zeros((4, 3)), "(5, 7)")
 
+    def test_rot90(self):
+        size = ht.MPI_WORLD.size
+        m = ht.arange(size ** 3, dtype=ht.int).reshape((size, size, size))
+
+        self.assertTrue(ht.equal(ht.rot90(m, 0), m))
+        self.assertTrue(ht.equal(ht.rot90(m, 4), m))
+        self.assertTrue(ht.equal(ht.rot90(ht.rot90(m, 1), 1, (1, 0)), m))
+
+        a = ht.resplit(m, 0)
+
+        self.assertTrue(ht.equal(ht.rot90(a), ht.resplit(ht.rot90(m), 1)))
+        self.assertTrue(ht.equal(ht.rot90(a, 2), ht.resplit(ht.rot90(m, 2), 0)))
+        self.assertTrue(ht.equal(ht.rot90(a, 3, (1, 2)), ht.resplit(ht.rot90(m, 3, (1, 2)), 0)))
+
+        m = ht.arange(size ** 3, dtype=ht.float).reshape((size, size, size))
+        a = ht.resplit(m, 1)
+
+        self.assertTrue(ht.equal(ht.rot90(a), ht.resplit(ht.rot90(m), 0)))
+        self.assertTrue(ht.equal(ht.rot90(a, 2), ht.resplit(ht.rot90(m, 2), 1)))
+        self.assertTrue(ht.equal(ht.rot90(a, 3, (1, 2)), ht.resplit(ht.rot90(m, 3, (1, 2)), 2)))
+
+        a = ht.resplit(m, 2)
+
+        self.assertTrue(ht.equal(ht.rot90(a), ht.resplit(ht.rot90(m), 2)))
+        self.assertTrue(ht.equal(ht.rot90(a, 2), ht.resplit(ht.rot90(m, 2), 2)))
+        self.assertTrue(ht.equal(ht.rot90(a, 3, (1, 2)), ht.resplit(ht.rot90(m, 3, (1, 2)), 1)))
+
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.ones((2, 3)), 1, (0, 1, 2))
+        with self.assertRaises(TypeError):
+            ht.rot90(torch.tensor((2, 3)))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (0, 0))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (-3, 1))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (4, 1))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (0, -2))
+        with self.assertRaises(ValueError):
+            ht.rot90(ht.zeros((2, 2)), 1, (0, 3))
+
     def test_sort(self):
         size = ht.MPI_WORLD.size
         rank = ht.MPI_WORLD.rank


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #555 

Introduces rot90. Rotate an array on a specified plane. May change the split axis if it is in the rotation plane similar to transpose.

## Changes proposed:
- add rot90()

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

New feature

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
