### PR TITLE
Bug/591 slicing memory issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 - [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
 - [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
-
+- [#594](https://github.com/helmholtz-analytics/heat/pull/594) New feature: Advanced indexing
+- [#594](https://github.com/helmholtz-analytics/heat/pull/594) Bugfix: getitem and setitem memory consumption heavily reduced
 
 # v0.4.0
 

--- a/heat/core/arithmetics.py
+++ b/heat/core/arithmetics.py
@@ -319,7 +319,7 @@ def diff(a, n=1, axis=-1):
             axis_slice[axis] = slice(1, None, None)
             axis_slice_end = [slice(None)] * len(ret.shape)
             axis_slice_end[axis] = slice(None, -1, None)
-            ret = ret[axis_slice] - ret[axis_slice_end]
+            ret = ret[tuple(axis_slice)] - ret[tuple(axis_slice_end)]
         return ret
 
     size = a.comm.size
@@ -364,9 +364,9 @@ def diff(a, n=1, axis=-1):
                 recv_data.reshape(ret.lloc[axis_slice_end].shape) - ret.lloc[axis_slice_end]
             )
 
-    axis_slice_end = [slice(None)] * len(a.shape)
+    axis_slice_end = [slice(None, None, None)] * len(a.shape)
     axis_slice_end[axis] = slice(None, -1 * n, None)
-    ret = ret[axis_slice_end]  # slice of the last element on the array (nonsense data)
+    ret = ret[tuple(axis_slice_end)]  # slice off the last element on the array (nonsense data)
     ret.balance_()  # balance the array before returning
     return ret
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1401,80 +1401,54 @@ class DNDarray:
         (1/2) >>> tensor([0.])
         (2/2) >>> tensor([0., 0.])
         """
-        # print("start getitem")
+        # print('start getitem', key)
+        # print()
         l_dtype = self.dtype.torch_type()
-        if not isinstance(key, tuple):
+        kgshape_flag = False
+        if isinstance(key, DNDarray) and key.ndim == self.ndim:
+            lkey = [slice(None, None, None)] * self.ndim
+            kgshape_flag = True
+            kgshape = [0] * len(self.gshape)
+            if key.ndim > 1:
+                for i in range(key.ndim):
+                    kgshape[i] = key.gshape[i]
+                    lkey[i] = key._DNDarray__array[..., i]
+            else:
+                kgshape[0] = key.gshape[0]
+                lkey[0] = key._DNDarray__array
+            key = tuple(lkey)
+        elif not isinstance(key, tuple):
             h = [slice(None, None, None)] * self.ndim
-            # if isinstance(key, int):
-            # if key < 0:
-            #     print('here')
-            #     sl = [self.gshape[0] + key, self.gshape[0], 1]
-            #     h[0] = slice(sl[0], sl[1], sl[2])
-            # else:
-            #     h[0] = key
-            # else:
-            h[0] = key
+            if isinstance(key, DNDarray):
+                h[0] = key._DNDarray__array.tolist()
+            elif isinstance(key, torch.Tensor):
+                h[0] = key.tolist()
+            else:
+                h[0] = key
             key = tuple(h)
 
-        # key = manipulations.resplit(key, None)
-        # key = key._DNDarray__array.tolist()
-        #     print('here1')
-        #     key = tuple(x.item() for x in key)
-        # print('finished first loop')
-
-        # gout_full = None
-        # allred = False
-        # if not isinstance(key, (torch.Tensor, DNDarray, list)):
-        # lkey = list(key)
-        # if len(lkey) < len(self.gshape):
-        #     hkey = [slice(0, None)] * len(self.gshape)
-        #     for i in range(len(lkey)):
-        #         hkey[i] = lkey[i]
-        #     lkey = hkey
-
         gout_full = [None] * len(self.gshape)
+        key = list(key)
         for c, k in enumerate(key):
             if isinstance(k, slice):
                 new_slice = stride_tricks.sanitize_slice(k, self.gshape[c])
                 gout_full[c] = math.ceil((new_slice.stop - new_slice.start) / new_slice.step)
-            if isinstance(k, list):
+            elif isinstance(k, list):
                 gout_full[c] = len(k)
-            if isinstance(k, (DNDarray, torch.Tensor)):
-                gout_full[c] = k.shape[0]
-                # allred = True
+            elif isinstance(k, (DNDarray, torch.Tensor)):
+                gout_full[c] = k.shape[0] if not kgshape_flag else kgshape[c]
+            if isinstance(k, DNDarray):
+                key[c] = k._DNDarray__array
         if all([g == 1 for g in gout_full]):
             gout_full = [1]
         else:
             for i in range(len(gout_full) - 1, -1, -1):
                 if gout_full[i] is None:
                     del gout_full[i]
-        # if isinstance(key, (tuple, list)) and len(key) == len(self.gshape):
-        #     key = list(key) if isinstance(key, tuple) else key
-        # key = tuple(key)
-        # print(self.is_distributed(), key)
+
+        key = tuple(key)
         if not self.is_distributed():
             if not self.comm.size == 1:
-                # if isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
-                #     # this will return a 1D array as the shape cannot be determined automatically
-                #     arr = self.__array[key._DNDarray__array[..., 0], key._DNDarray__array[..., 1]]
-                #     return DNDarray(
-                #         arr, tuple(arr.shape), self.dtype, self.split, self.device, self.comm
-                #     )
-                # else:
-                #     # print('here2', key)
-                #     # if isinstance(key, tuple):
-                #     #     key = list(key)
-                #     #     for k in range(len(key)):
-                #     #         if isinstance(key[k], DNDarray):
-                #     #             key[k] = key[k]._DNDarray__array
-                #     # if isinstance(key, torch.Tensor):
-                #     #     key = key.tolist()
-                #     # print('k', key, type(key))
-                #     # print('here3', type(self.__array))
-                #     # key = key if not isinstance(key, list) else key
-                #     # print(self._DNDarray__array[key])
-                # print(key)
-
                 return factories.array(
                     self.__array[key],
                     dtype=self.dtype,
@@ -1482,39 +1456,19 @@ class DNDarray:
                     device=self.device,
                     comm=self.comm,
                 )
-                # # print('before ret', type(self.__array), self.__array.shape)
-                # lcl = self.__array[key]
-                # # print('after ret', lcl.shape)
-                # ret = DNDarray(
-                #     lcl,
-                #     tuple(lcl.shape),
-                #     self.dtype,
-                #     self.split,
-                #     self.device,
-                #     self.comm,
-                # )
-                # return ret
             else:
-                if isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
-                    # this will return a 1D array as the shape cannot be determined automatically
-                    arr = self.__array[key._DNDarray__array[..., 0], key._DNDarray__array[..., 1]]
-                    return DNDarray(arr, tuple(arr.shape), self.dtype, 0, self.device, self.comm)
-
+                gout = tuple(self.__array[key].shape)
+                if self.split is not None and self.split >= len(gout):
+                    new_split = len(gout) - 1 if len(gout) - 1 >= 0 else None
                 else:
-                    gout = tuple(self.__array[key].shape)
-                    if self.split is not None and self.split >= len(gout):
-                        new_split = len(gout) - 1 if len(gout) - 1 >= 0 else None
-                    else:
-                        new_split = self.split
+                    new_split = self.split
 
-                    return DNDarray(
-                        self.__array[key], gout, self.dtype, new_split, self.device, self.comm
-                    )
+                return DNDarray(
+                    self.__array[key], gout, self.dtype, new_split, self.device, self.comm
+                )
 
         else:
-            # print('k', key)
             rank = self.comm.rank
-            # lshape_map = self.create_lshape_map()
             ends = []
             for pr in range(self.comm.size):
                 _, _, e = self.comm.chunk(self.shape, self.split, rank=pr)
@@ -1524,287 +1478,98 @@ class DNDarray:
             chunk_starts = torch.tensor([0] + chunk_ends.tolist(), device=self.device.torch_device)
             chunk_start = chunk_starts[rank]
             chunk_end = chunk_ends[rank]
-            # _, _, chunk_slice = self.comm.chunk(self.shape, self.split)
-            # chunk_start = chunk_slice[self.split].start
-            # chunk_end = chunk_slice[self.split].stop
-            # print(chunk_start, chunk_end)
             arr = torch.Tensor()
-
-            # if a singular index is given and the tensor is split
-            if isinstance(key, int):
-                gout = [0] * (len(self.gshape) - 1)
-                if key < 0:
-                    key += self.ndim
-                # handle the reduction of the split to accommodate for the reduced dimension
-                if self.split >= len(gout):
-                    new_split = len(gout) - 1 if len(gout) - 1 > 0 else 0
-                elif self.split > 0:
-                    new_split = self.split - 1
-                else:
-                    new_split = self.split
-
-                # only need to adjust the key if split==0
-                if key in range(chunk_start, chunk_end) and self.split == 0:
-                    gout = list(self.__array[key - chunk_start].shape)
-                    arr = self.__array[key - chunk_start]
-                elif self.split != 0:
-                    _, _, chunk_slice2 = self.comm.chunk(self.shape, self.split)
-                    # need to test if the given axis is on the node and then get the shape
-                    if key in range(chunk_slice2[0].start, chunk_slice2[0].stop):
-                        arr = self.__array[key]
-                        gout = list(arr.shape)
-                else:  # arr is empty and gout is zeros
-                    warnings.warn(
-                        "This process (rank: {}) is without data after slicing, running the .balance_() function is recommended".format(
-                            self.comm.rank
-                        ),
-                        ResourceWarning,
-                    )
-
-            # todo: add elif for key -> list
-
-            # multi-argument gets are passed as tuples by python
-            elif isinstance(key, (tuple, list)):
-                gout = [0] * len(self.gshape)
-                # gout_new = list(self.gshape)
-                # handle the dimensional reduction for integers
-                ints = sum([isinstance(it, int) for it in key])
-                gout = gout[: len(gout) - ints]
-                if self.split >= len(gout):
-                    new_split = len(gout) - 1 if len(gout) - 1 > 0 else 0
-                else:
-                    new_split = self.split
-
-                # handle empty list
-                if len(key) == 0:
-                    # this will return an array of shape (0, ...)
-                    arr = self.__array[key]
-                    gout = list(arr.shape)
-                    # gout_new[0] = 0
-                # if a slice is given in the split direction
-                # below allows for the split given to contain Nones
-                # if the given axes are not splits (must be ints OR LISTS for python)
-                # this means the whole slice is on one node
-
-                if isinstance(key[self.split], (list, torch.Tensor, DNDarray)):
-                    # print(key)
-                    lkey = list(key)
-                    # for k in range(len(key)):
-                    gout_full = list(self.gshape)
-                    gout_full[self.split] = len(key[self.split])
-                    if isinstance(key[self.split], DNDarray):
-                        lkey[self.split] = key[self.split]._DNDarray__array
-                    inds = torch.tensor(
+            # all keys should be tuples here
+            gout = [0] * len(self.gshape)
+            # handle the dimensional reduction for integers
+            ints = sum([isinstance(it, int) for it in key])
+            gout = gout[: len(gout) - ints]
+            if self.split >= len(gout):
+                new_split = len(gout) - 1 if len(gout) - 1 > 0 else 0
+            else:
+                new_split = self.split
+            # handle empty list
+            if len(key) == 0:
+                # this will return an array of shape (0, ...)
+                arr = self.__array[key]
+                gout_full = list(arr.shape)
+            # if a slice is given in the split direction
+            # below allows for the split given to contain Nones
+            # if the given axes are not splits (must be ints OR LISTS for python)
+            # this means the whole slice is on one node
+            if isinstance(key[self.split], (list, torch.Tensor, DNDarray)):
+                lkey = list(key)
+                if isinstance(key[self.split], DNDarray):
+                    lkey[self.split] = key[self.split]._DNDarray__array
+                inds = (
+                    torch.tensor(
                         lkey[self.split], dtype=torch.long, device=self.device.torch_device
                     )
+                    if not isinstance(lkey[self.split], torch.Tensor)
+                    else lkey[self.split]
+                )
 
-                    loc_inds = torch.where((inds >= chunk_start) & (inds < chunk_end))
-                    if len(loc_inds) != 0:
-                        inds = inds[loc_inds] - chunk_start
-                        lkey[self.split] = inds
-                        arr = self.__array[tuple(lkey)]
-                        gout = list(arr.shape)
-                    # indices = key
-                    # if isinstance(key, list):
-                    #     pass
-                    # else:
-                    #     indices = key[self.split]
-                    # key = list(key)
-                    # if len(indices) == 0:
-                    #     arr = self.__array[key]
-                    #     gout = list(arr.shape)
-                    # else:
-                    #     indices = [
-                    #         index + self.gshape[self.split] if index < 0 else index
-                    #         for index in indices
-                    #     ]
-                    #     sorted_key_along_split = sorted(indices)
-                    #     if sorted_key_along_split[0] in range(
-                    #             chunk_start, chunk_end
-                    #     ) and sorted_key_along_split[-1] in range(chunk_start, chunk_end):
-                    #         indices = [index - chunk_start for index in indices]
-                    #         indices = torch.tensor(indices, dtype=torch.long, device=self.device.torch_device)
-                    #         # print(torch.tensor(indices))
-                    #         arr = self.__array[indices]
-                    #         gout = list(arr.shape)
-                elif isinstance(key[self.split], slice):
-                    key = list(key)
-                    key_start = key[self.split].start if key[self.split].start is not None else 0
-                    key_stop = (
-                        key[self.split].stop
-                        if key[self.split].stop is not None
-                        else self.gshape[self.split]
-                    )
-                    if key_stop < 0:
-                        key_stop = self.gshape[self.split] + key[self.split].stop
-                    key_step = key[self.split].step
-                    og_key_start = key_start
-                    st_pr = torch.where(key_start < chunk_ends)[0]
-                    st_pr = st_pr[0] if len(st_pr) > 0 else self.comm.size
-                    sp_pr = torch.where(key_stop >= chunk_starts)[0]
-                    sp_pr = sp_pr[-1] if len(sp_pr) > 0 else 0
-                    actives = list(range(st_pr, sp_pr + 1))
-                    if rank in actives:
-                        key_start = 0 if rank != actives[0] else key_start - chunk_starts[rank]
-                        key_stop = (
-                            ends[rank] if rank != actives[-1] else key_stop - chunk_starts[rank]
-                        )
-                        if key_step is not None and rank > actives[0]:
-                            offset = (chunk_ends[rank - 1] - og_key_start) % key_step
-                            if key_step > 2 and offset > 0:
-                                key_start += key_step - offset
-                            elif key_step == 2 and offset > 0:
-                                key_start += (chunk_ends[rank - 1] - og_key_start) % key_step
-                        if isinstance(key_start, torch.Tensor):
-                            key_start = key_start.item()
-                        if isinstance(key_stop, torch.Tensor):
-                            key_stop = key_stop.item()
-                        key[self.split] = slice(key_start, key_stop, key_step)
-                        arr = self.__array[tuple(key)]
-                        gout = list(arr.shape)
-
-                # new (not working ...) ===================================================
-                elif isinstance(key[self.split], int):
-                    key = list(key)
-                    key[self.split] = (
-                        key[self.split] + self.gshape[self.split]
-                        if key[self.split] < 0
-                        else key[self.split]
-                    )
-                    if key[self.split] in range(chunk_start, chunk_end):
-                        key[self.split] = key[self.split] - chunk_start
-                        arr = self.__array[tuple(key)]
-                        gout = list(arr.shape)
-                if 0 in arr.shape:
-                    # arr is empty
-                    # gout is all 0s and is the proper shape
-                    warnings.warn(
-                        "This process (rank: {}) is without data after slicing, running the .balance_() function is recommended".format(
-                            self.comm.rank
-                        ),
-                        ResourceWarning,
-                    )
-
-                # old ============================================================================
-                # else:
-                #     # if the given axes are not splits (must be ints OR LISTS for python)
-                #     # this means the whole slice is on one node
-                #     if isinstance(key, list):
-                #         indices = key
-                #     else:
-                #         indices = key[self.split]
-                #     key = list(key)
-                #     if isinstance(indices, list):
-                #         if len(indices) == 0:
-                #             arr = self.__array[key]
-                #             gout = list(arr.shape)
-                #         else:
-                #             indices = [
-                #                 index + self.gshape[self.split] if index < 0 else index
-                #                 for index in indices
-                #             ]
-                #             sorted_key_along_split = sorted(indices)
-                #             if sorted_key_along_split[0] in range(
-                #                     chunk_start, chunk_end
-                #             ) and sorted_key_along_split[-1] in range(chunk_start, chunk_end):
-                #                 indices = [index - chunk_start.item() for index in indices]
-                #                 arr = self.__array[indices]
-                #                 gout = list(arr.shape)
-                #
-                #     elif isinstance(key[self.split], int):
-                #         key[self.split] = (
-                #             key[self.split] + self.gshape[self.split]
-                #             if key[self.split] < 0
-                #             else key[self.split]
-                #         )
-                #         if key[self.split] in range(chunk_start, chunk_end):
-                #             key[self.split] = key[self.split] - chunk_start
-                #             arr = self.__array[tuple(key)]
-                #             gout = list(arr.shape)
-                #     if 0 in arr.shape:
-                #         # arr is empty
-                #         # gout is all 0s and is the proper shape
-                #         warnings.warn(
-                #             "This process (rank: {}) is without data after slicing, running the .balance_() function is recommended".format(
-                #                 self.comm.rank
-                #             ),
-                #             ResourceWarning,
-                #         )
-
-            # if the given axes are only a slice
-            elif isinstance(key, slice) and self.split == 0:
-                gout = [0] * len(self.gshape)
-                # reduce the dims if the slices are only one element in length
-                start = key.start if key.start is not None else 0
-                stop = key.stop if key.stop is not None else self.gshape[0]
-                step = key.step if key.step is not None else 1
-                if self.split >= len(gout):
-                    new_split = len(gout) - 1 if len(gout) - 1 > 0 else 0
-                else:
-                    new_split = self.split
-                og_key_start = start
-                st_pr = torch.where(start < chunk_ends)[0]
+                loc_inds = torch.where((inds >= chunk_start) & (inds < chunk_end))
+                if len(loc_inds[0]) != 0:
+                    inds = inds[loc_inds] - chunk_start
+                    lkey[self.split] = inds
+                    arr = self.__array[tuple(lkey)]
+            elif isinstance(key[self.split], slice):
+                key = list(key)
+                key_start = key[self.split].start if key[self.split].start is not None else 0
+                key_stop = (
+                    key[self.split].stop
+                    if key[self.split].stop is not None
+                    else self.gshape[self.split]
+                )
+                if key_stop < 0:
+                    key_stop = self.gshape[self.split] + key[self.split].stop
+                key_step = key[self.split].step
+                og_key_start = key_start
+                st_pr = torch.where(key_start < chunk_ends)[0]
                 st_pr = st_pr[0] if len(st_pr) > 0 else self.comm.size
-                sp_pr = torch.where(stop >= chunk_starts)[0]
+                sp_pr = torch.where(key_stop >= chunk_starts)[0]
                 sp_pr = sp_pr[-1] if len(sp_pr) > 0 else 0
                 actives = list(range(st_pr, sp_pr + 1))
                 if rank in actives:
-                    start = 0 if rank != actives[0] else start - chunk_starts[rank]
-                    stop = ends[rank] if rank != actives[-1] else stop - chunk_starts[rank]
-                    if step is not None and rank > actives[0]:
-                        offset = (chunk_ends[rank - 1] - og_key_start) % step
-                        if step > 2 and offset > 0:
-                            start += step - offset
-                        elif step == 2 and offset > 0:
-                            start += offset
-                    if isinstance(start, torch.Tensor):
-                        start = start.item()
-                    if isinstance(stop, torch.Tensor):
-                        stop = stop.item()
-                    key = slice(start, stop, step)
-                    arr = self.__array[key]
-                    gout = list(arr.shape)
-                else:
-                    warnings.warn(
-                        "This process (rank: {}) is without data after slicing, "
-                        "running the .balance_() function is recommended".format(self.comm.rank),
-                        ResourceWarning,
-                    )
-                    # arr is empty
-                    # gout is all 0s and is the proper shape
+                    key_start = 0 if rank != actives[0] else key_start - chunk_starts[rank]
+                    key_stop = ends[rank] if rank != actives[-1] else key_stop - chunk_starts[rank]
+                    if key_step is not None and rank > actives[0]:
+                        offset = (chunk_ends[rank - 1] - og_key_start) % key_step
+                        if key_step > 2 and offset > 0:
+                            key_start += key_step - offset
+                        elif key_step == 2 and offset > 0:
+                            key_start += (chunk_ends[rank - 1] - og_key_start) % key_step
+                    if isinstance(key_start, torch.Tensor):
+                        key_start = key_start.item()
+                    if isinstance(key_stop, torch.Tensor):
+                        key_stop = key_stop.item()
+                    key[self.split] = slice(key_start, key_stop, key_step)
+                    arr = self.__array[tuple(key)]
 
-            elif isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
-                # this is for a list of values
-                # it will return a 1D DNDarray of the elements on each node which are in the key (will be split in the 0th dimension
-                key.lloc[..., self.split] -= chunk_start
-                key_new = [key._DNDarray__array[..., i] for i in range(len(self.gshape))]
-                arr = self.__array[tuple(key_new)]
-                gout = list(arr.shape)
-                new_split = 0
+            elif isinstance(key[self.split], int):
+                key = list(key)
+                key[self.split] = (
+                    key[self.split] + self.gshape[self.split]
+                    if key[self.split] < 0
+                    else key[self.split]
+                )
+                if key[self.split] in range(chunk_start, chunk_end):
+                    key[self.split] = key[self.split] - chunk_start
+                    arr = self.__array[tuple(key)]
+            if 0 in arr.shape:
+                # arr is empty
+                # gout is all 0s and is the proper shape
+                warnings.warn(
+                    "This process (rank: {}) is without data after slicing, running the .balance_() function is recommended".format(
+                        self.comm.rank
+                    ),
+                    ResourceWarning,
+                )
 
-            else:  # handle other cases not accounted for (one is a slice is given and the split != 0)
-                gout = [0] * len(self.gshape)
-
-                if self.split >= len(gout):
-                    new_split = len(gout) - 1 if len(gout) - 1 > 0 else 0
-                else:
-                    new_split = self.split
-
-                gout = list(self.__array[key].shape)
-                arr = self.__array[key]
-
-            if gout_full is None:
-                print(gout)
-                for e, _ in enumerate(gout):
-                    if e == new_split:
-                        gout[e] = self.comm.allreduce(gout[e], MPI.SUM)
-                    else:
-                        gout[e] = self.comm.allreduce(gout[e], MPI.MAX)
-            else:
-                gout = gout_full
             return DNDarray(
                 arr.type(l_dtype),
-                gout if isinstance(gout, tuple) else tuple(gout),
+                gout_full if isinstance(gout_full, tuple) else tuple(gout_full),
                 self.dtype,
                 new_split,
                 self.device,
@@ -3285,32 +3050,22 @@ class DNDarray:
         (2/2) >>> tensor([[0., 1., 0., 0., 0.],
                           [0., 1., 0., 0., 0.]])
         """
-        if not isinstance(key, tuple):
+        if isinstance(key, DNDarray) and key.ndim == self.ndim:
+            lkey = [slice(None, None, None)] * self.ndim
+            for i in range(key.ndim):
+                lkey[i] = key._DNDarray__array[..., i]
+            key = tuple(lkey)
+        elif not isinstance(key, tuple):
             h = [slice(None, None, None)] * self.ndim
-            # if isinstance(key, int):
-            # if key < 0:
-            #     print('here')
-            #     sl = [self.gshape[0] + key, self.gshape[0], 1]
-            #     h[0] = slice(sl[0], sl[1], sl[2])
-            # else:
-            #     h[0] = key
-            # else:
             h[0] = key
             key = tuple(h)
-        # if isinstance(key, DNDarray) and key.gshape[-1] != len(self.gshape):
-        #     key = tuple(x.item() for x in key)
+
         if not self.is_distributed():
-            # if isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
-            #     # this is for a list of values
-            #     for i in range(key.gshape[0]):
-            #         self.__setter((key[i, 0].item(), key[i, 1].item()), value)
-            # else:
             self.__setter(key, value)
         else:
             # raise RuntimeError("split axis of array and the target value are not equal") removed
             # this will occur if the local shapes do not match
             rank = self.comm.rank
-            # lshape_map = self.create_lshape_map()
             ends = []
             for pr in range(self.comm.size):
                 _, _, e = self.comm.chunk(self.shape, self.split, rank=pr)
@@ -3322,21 +3077,7 @@ class DNDarray:
             chunk_start = chunk_slice[self.split].start
             chunk_end = chunk_slice[self.split].stop
 
-            if isinstance(key, int):
-                if key < 0:
-                    key += self.ndim
-                if self.split == 0:
-                    if key in range(chunk_start, chunk_end):
-                        self.__setter(key - chunk_start, value)
-                if self.split > 0:
-                    if (
-                        self[key].split is not None
-                        and isinstance(value, DNDarray)
-                        and value.split is None
-                    ):
-                        value = factories.array(value, split=self[key].split)
-                    self.__setter(key, value)
-            elif isinstance(key, (tuple, torch.Tensor)):
+            if isinstance(key, tuple):
                 if isinstance(key[self.split], slice):
                     key = list(key)
                     key_start = key[self.split].start if key[self.split].start is not None else 0
@@ -3375,46 +3116,21 @@ class DNDarray:
                             value_slice = [slice(None, None, None)] * value.ndim
                             step2 = key_step if key_step is not None else 1
                             key_start = chunk_starts[rank] - og_key_start
-                            # print(key_start, self.gshape, og_key_start)
                             key_stop = key_start + key_stop
-                            # todo: slice logic
                             slice_loc = (
                                 value.ndim - 1 if self.split > value.ndim - 1 else self.split
                             )
                             value_slice[slice_loc] = slice(
                                 key_start.item(), math.ceil(torch.true_divide(key_stop, step2)), 1
                             )
-                            # print(key_start, key_stop, step2, value_slice, value[tuple(value_slice)], chunk_start)
                             self.__setter(tuple(key), value[tuple(value_slice)])
                         else:
                             self.__setter(tuple(key), value)
 
-                    # # old ============================================================================================
-                    # key = list(key)
-                    # overlap = list(
-                    #     set(
-                    #         range(
-                    #             key[self.split].start if key[self.split].start is not None else 0,
-                    #             key[self.split].stop
-                    #             if key[self.split].stop is not None
-                    #             else self.gshape[self.split],
-                    #             key[self.split].step if key[self.split].step is not None else 1,
-                    #         )
-                    #     )
-                    #     & set(range(chunk_start, chunk_end))
-                    # )
-                    # if overlap:
-                    #     overlap.sort()
-                    #     hold = [x - chunk_start for x in overlap]
-                    #     key[self.split] = slice(min(hold), max(hold) + 1, key[self.split].step)
-                    #     try:
-                    #         self.__setter(tuple(key), value[overlap])
-                    #     except TypeError as te:
-                    #         if str(te) != "'int' object is not subscriptable":
-                    #             raise TypeError(te)
-                    #         self.__setter(tuple(key), value)
-                    #     except IndexError:
-                    #         self.__setter(tuple(key), value)
+                elif isinstance(key[self.split], torch.Tensor):
+                    key = list(key)
+                    key[self.split] -= chunk_start
+                    self.__setter(tuple(key), value)
 
                 elif key[self.split] in range(chunk_start, chunk_end):
                     key = list(key)
@@ -3426,21 +3142,6 @@ class DNDarray:
                     if self.gshape[self.split] + key[self.split] in range(chunk_start, chunk_end):
                         key[self.split] = key[self.split] + self.shape[self.split] - chunk_start
                         self.__setter(tuple(key), value)
-
-            elif isinstance(key, slice) and self.split == 0:
-                overlap = list(set(range(key.start, key.stop)) & set(range(chunk_start, chunk_end)))
-                if overlap:
-                    overlap.sort()
-                    hold = [x - chunk_start for x in overlap]
-                    key = slice(min(hold), max(hold) + 1, key.step)
-                    self.__setter(key, value)
-
-            elif isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
-                # this is the case with a list of indices to set
-                key = key.copy()
-                key.lloc[..., self.split] -= chunk_start
-                key_new = [key._DNDarray__array[..., i] for i in range(len(self.gshape))]
-                self.__setter(tuple(key_new), value)
             else:
                 self.__setter(key, value)
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1371,7 +1371,7 @@ class DNDarray:
 
         Parameters
         ----------
-        key : int, slice, tuple, list
+        key : int, slice, tuple, list, torch.Tensor, DNDarray
             indices to get from the tensor.
 
         Returns
@@ -1401,61 +1401,99 @@ class DNDarray:
         (1/2) >>> tensor([0.])
         (2/2) >>> tensor([0., 0.])
         """
-
+        # print("start getitem")
         l_dtype = self.dtype.torch_type()
-        if isinstance(key, DNDarray) and key.gshape[-1] != len(self.gshape):
-            key = tuple(x.item() for x in key)
+        if not isinstance(key, tuple):
+            h = [slice(None, None, None)] * self.ndim
+            # if isinstance(key, int):
+            # if key < 0:
+            #     print('here')
+            #     sl = [self.gshape[0] + key, self.gshape[0], 1]
+            #     h[0] = slice(sl[0], sl[1], sl[2])
+            # else:
+            #     h[0] = key
+            # else:
+            h[0] = key
+            key = tuple(h)
 
-        if not isinstance(key, (torch.Tensor, type(self), list)):
-            if isinstance(key, (int, slice)):
-                lkey = [key]
-            else:
-                lkey = list(key)
-            if len(lkey) < len(self.gshape):
-                hkey = [slice(0, None)] * len(self.gshape)
-                for i in range(len(lkey)):
-                    hkey[i] = lkey[i]
-                lkey = hkey
+        # key = manipulations.resplit(key, None)
+        # key = key._DNDarray__array.tolist()
+        #     print('here1')
+        #     key = tuple(x.item() for x in key)
+        # print('finished first loop')
 
-            gout_full = [None] * len(self.gshape)
-            for c, k in enumerate(lkey):
-                if isinstance(k, int):
-                    pass
-                elif isinstance(k, slice):
-                    new_slice = stride_tricks.sanitize_slice(k, self.gshape[c])
-                    gout_full[c] = math.ceil((new_slice.stop - new_slice.start) / new_slice.step)
-                else:
-                    raise TypeError(
-                        "wtf is happening here? types should be int or slice, not {}".format(
-                            type(k)
-                        )
-                    )
-            if all([g == 1 for g in gout_full]):
-                gout_full = [1]
-            else:
-                for i in range(len(gout_full) - 1, -1, -1):
-                    if gout_full[i] is None:
-                        del gout_full[i]
+        # gout_full = None
+        # allred = False
+        # if not isinstance(key, (torch.Tensor, DNDarray, list)):
+        # lkey = list(key)
+        # if len(lkey) < len(self.gshape):
+        #     hkey = [slice(0, None)] * len(self.gshape)
+        #     for i in range(len(lkey)):
+        #         hkey[i] = lkey[i]
+        #     lkey = hkey
+
+        gout_full = [None] * len(self.gshape)
+        for c, k in enumerate(key):
+            if isinstance(k, slice):
+                new_slice = stride_tricks.sanitize_slice(k, self.gshape[c])
+                gout_full[c] = math.ceil((new_slice.stop - new_slice.start) / new_slice.step)
+            if isinstance(k, list):
+                gout_full[c] = len(k)
+            if isinstance(k, (DNDarray, torch.Tensor)):
+                gout_full[c] = k.shape[0]
+                # allred = True
+        if all([g == 1 for g in gout_full]):
+            gout_full = [1]
         else:
-            gout_full = None
-
+            for i in range(len(gout_full) - 1, -1, -1):
+                if gout_full[i] is None:
+                    del gout_full[i]
+        # if isinstance(key, (tuple, list)) and len(key) == len(self.gshape):
+        #     key = list(key) if isinstance(key, tuple) else key
+        # key = tuple(key)
+        # print(self.is_distributed(), key)
         if not self.is_distributed():
             if not self.comm.size == 1:
-                if isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
-                    # this will return a 1D array as the shape cannot be determined automatically
-                    arr = self.__array[key._DNDarray__array[..., 0], key._DNDarray__array[..., 1]]
-                    return DNDarray(
-                        arr, tuple(arr.shape), self.dtype, self.split, self.device, self.comm
-                    )
-                else:
-                    return DNDarray(
-                        self.__array[key],
-                        tuple(self.__array[key].shape),
-                        self.dtype,
-                        self.split,
-                        self.device,
-                        self.comm,
-                    )
+                # if isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
+                #     # this will return a 1D array as the shape cannot be determined automatically
+                #     arr = self.__array[key._DNDarray__array[..., 0], key._DNDarray__array[..., 1]]
+                #     return DNDarray(
+                #         arr, tuple(arr.shape), self.dtype, self.split, self.device, self.comm
+                #     )
+                # else:
+                #     # print('here2', key)
+                #     # if isinstance(key, tuple):
+                #     #     key = list(key)
+                #     #     for k in range(len(key)):
+                #     #         if isinstance(key[k], DNDarray):
+                #     #             key[k] = key[k]._DNDarray__array
+                #     # if isinstance(key, torch.Tensor):
+                #     #     key = key.tolist()
+                #     # print('k', key, type(key))
+                #     # print('here3', type(self.__array))
+                #     # key = key if not isinstance(key, list) else key
+                #     # print(self._DNDarray__array[key])
+                # print(key)
+
+                return factories.array(
+                    self.__array[key],
+                    dtype=self.dtype,
+                    split=self.split,
+                    device=self.device,
+                    comm=self.comm,
+                )
+                # # print('before ret', type(self.__array), self.__array.shape)
+                # lcl = self.__array[key]
+                # # print('after ret', lcl.shape)
+                # ret = DNDarray(
+                #     lcl,
+                #     tuple(lcl.shape),
+                #     self.dtype,
+                #     self.split,
+                #     self.device,
+                #     self.comm,
+                # )
+                # return ret
             else:
                 if isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
                     # this will return a 1D array as the shape cannot be determined automatically
@@ -1474,6 +1512,7 @@ class DNDarray:
                     )
 
         else:
+            # print('k', key)
             rank = self.comm.rank
             # lshape_map = self.create_lshape_map()
             ends = []
@@ -1522,6 +1561,8 @@ class DNDarray:
                         ResourceWarning,
                     )
 
+            # todo: add elif for key -> list
+
             # multi-argument gets are passed as tuples by python
             elif isinstance(key, (tuple, list)):
                 gout = [0] * len(self.gshape)
@@ -1542,6 +1583,50 @@ class DNDarray:
                     # gout_new[0] = 0
                 # if a slice is given in the split direction
                 # below allows for the split given to contain Nones
+                # if the given axes are not splits (must be ints OR LISTS for python)
+                # this means the whole slice is on one node
+
+                if isinstance(key[self.split], (list, torch.Tensor, DNDarray)):
+                    # print(key)
+                    lkey = list(key)
+                    # for k in range(len(key)):
+                    gout_full = list(self.gshape)
+                    gout_full[self.split] = len(key[self.split])
+                    if isinstance(key[self.split], DNDarray):
+                        lkey[self.split] = key[self.split]._DNDarray__array
+                    inds = torch.tensor(
+                        lkey[self.split], dtype=torch.long, device=self.device.torch_device
+                    )
+
+                    loc_inds = torch.where((inds >= chunk_start) & (inds < chunk_end))
+                    if len(loc_inds) != 0:
+                        inds = inds[loc_inds] - chunk_start
+                        lkey[self.split] = inds
+                        arr = self.__array[tuple(lkey)]
+                        gout = list(arr.shape)
+                    # indices = key
+                    # if isinstance(key, list):
+                    #     pass
+                    # else:
+                    #     indices = key[self.split]
+                    # key = list(key)
+                    # if len(indices) == 0:
+                    #     arr = self.__array[key]
+                    #     gout = list(arr.shape)
+                    # else:
+                    #     indices = [
+                    #         index + self.gshape[self.split] if index < 0 else index
+                    #         for index in indices
+                    #     ]
+                    #     sorted_key_along_split = sorted(indices)
+                    #     if sorted_key_along_split[0] in range(
+                    #             chunk_start, chunk_end
+                    #     ) and sorted_key_along_split[-1] in range(chunk_start, chunk_end):
+                    #         indices = [index - chunk_start for index in indices]
+                    #         indices = torch.tensor(indices, dtype=torch.long, device=self.device.torch_device)
+                    #         # print(torch.tensor(indices))
+                    #         arr = self.__array[indices]
+                    #         gout = list(arr.shape)
                 elif isinstance(key[self.split], slice):
                     key = list(key)
                     key_start = key[self.split].start if key[self.split].start is not None else 0
@@ -1577,50 +1662,74 @@ class DNDarray:
                         key[self.split] = slice(key_start, key_stop, key_step)
                         arr = self.__array[tuple(key)]
                         gout = list(arr.shape)
-                else:
-                    # if the given axes are not splits (must be ints OR LISTS for python)
-                    # this means the whole slice is on one node
-                    if isinstance(key, list):
-                        indices = key
-                    else:
-                        indices = key[self.split]
-                    key = list(key)
-                    if isinstance(indices, list):
-                        if len(indices) == 0:
-                            arr = self.__array[key]
-                            gout = list(arr.shape)
-                        else:
-                            indices = [
-                                index + self.gshape[self.split] if index < 0 else index
-                                for index in indices
-                            ]
-                            sorted_key_along_split = sorted(indices)
-                            if sorted_key_along_split[0] in range(
-                                chunk_start, chunk_end
-                            ) and sorted_key_along_split[-1] in range(chunk_start, chunk_end):
-                                indices = [index - chunk_start for index in indices]
-                                arr = self.__array[indices]
-                                gout = list(arr.shape)
 
-                    elif isinstance(key[self.split], int):
-                        key[self.split] = (
-                            key[self.split] + self.gshape[self.split]
-                            if key[self.split] < 0
-                            else key[self.split]
-                        )
-                        if key[self.split] in range(chunk_start, chunk_end):
-                            key[self.split] = key[self.split] - chunk_start
-                            arr = self.__array[tuple(key)]
-                            gout = list(arr.shape)
-                    if 0 in arr.shape:
-                        # arr is empty
-                        # gout is all 0s and is the proper shape
-                        warnings.warn(
-                            "This process (rank: {}) is without data after slicing, running the .balance_() function is recommended".format(
-                                self.comm.rank
-                            ),
-                            ResourceWarning,
-                        )
+                # new (not working ...) ===================================================
+                elif isinstance(key[self.split], int):
+                    key = list(key)
+                    key[self.split] = (
+                        key[self.split] + self.gshape[self.split]
+                        if key[self.split] < 0
+                        else key[self.split]
+                    )
+                    if key[self.split] in range(chunk_start, chunk_end):
+                        key[self.split] = key[self.split] - chunk_start
+                        arr = self.__array[tuple(key)]
+                        gout = list(arr.shape)
+                if 0 in arr.shape:
+                    # arr is empty
+                    # gout is all 0s and is the proper shape
+                    warnings.warn(
+                        "This process (rank: {}) is without data after slicing, running the .balance_() function is recommended".format(
+                            self.comm.rank
+                        ),
+                        ResourceWarning,
+                    )
+
+                # old ============================================================================
+                # else:
+                #     # if the given axes are not splits (must be ints OR LISTS for python)
+                #     # this means the whole slice is on one node
+                #     if isinstance(key, list):
+                #         indices = key
+                #     else:
+                #         indices = key[self.split]
+                #     key = list(key)
+                #     if isinstance(indices, list):
+                #         if len(indices) == 0:
+                #             arr = self.__array[key]
+                #             gout = list(arr.shape)
+                #         else:
+                #             indices = [
+                #                 index + self.gshape[self.split] if index < 0 else index
+                #                 for index in indices
+                #             ]
+                #             sorted_key_along_split = sorted(indices)
+                #             if sorted_key_along_split[0] in range(
+                #                     chunk_start, chunk_end
+                #             ) and sorted_key_along_split[-1] in range(chunk_start, chunk_end):
+                #                 indices = [index - chunk_start.item() for index in indices]
+                #                 arr = self.__array[indices]
+                #                 gout = list(arr.shape)
+                #
+                #     elif isinstance(key[self.split], int):
+                #         key[self.split] = (
+                #             key[self.split] + self.gshape[self.split]
+                #             if key[self.split] < 0
+                #             else key[self.split]
+                #         )
+                #         if key[self.split] in range(chunk_start, chunk_end):
+                #             key[self.split] = key[self.split] - chunk_start
+                #             arr = self.__array[tuple(key)]
+                #             gout = list(arr.shape)
+                #     if 0 in arr.shape:
+                #         # arr is empty
+                #         # gout is all 0s and is the proper shape
+                #         warnings.warn(
+                #             "This process (rank: {}) is without data after slicing, running the .balance_() function is recommended".format(
+                #                 self.comm.rank
+                #             ),
+                #             ResourceWarning,
+                #         )
 
             # if the given axes are only a slice
             elif isinstance(key, slice) and self.split == 0:
@@ -1685,6 +1794,7 @@ class DNDarray:
                 arr = self.__array[key]
 
             if gout_full is None:
+                print(gout)
                 for e, _ in enumerate(gout):
                     if e == new_split:
                         gout[e] = self.comm.allreduce(gout[e], MPI.SUM)
@@ -2575,9 +2685,12 @@ class DNDarray:
                 (self.comm.size, len(self.gshape)), dtype=int, device=self.device.torch_device
             )
             _, _, chk = self.comm.chunk(self.shape, self.split)
-            for i in range(len(self.gshape)):
-                target_map[self.comm.rank, i] = chk[i].stop - chk[i].start
-            self.comm.Allreduce(MPI.IN_PLACE, target_map, MPI.SUM)
+            target_map = lshape_map.clone()
+            target_map[..., self.split] = 0
+            for pr in range(self.comm.size):
+                target_map[pr, self.split] = self.comm.chunk(self.shape, self.split, rank=pr)[1][
+                    self.split
+                ]
         else:
             if not isinstance(target_map, torch.Tensor):
                 raise TypeError(
@@ -3172,15 +3285,27 @@ class DNDarray:
         (2/2) >>> tensor([[0., 1., 0., 0., 0.],
                           [0., 1., 0., 0., 0.]])
         """
-        if isinstance(key, DNDarray) and key.gshape[-1] != len(self.gshape):
-            key = tuple(x.item() for x in key)
+        if not isinstance(key, tuple):
+            h = [slice(None, None, None)] * self.ndim
+            # if isinstance(key, int):
+            # if key < 0:
+            #     print('here')
+            #     sl = [self.gshape[0] + key, self.gshape[0], 1]
+            #     h[0] = slice(sl[0], sl[1], sl[2])
+            # else:
+            #     h[0] = key
+            # else:
+            h[0] = key
+            key = tuple(h)
+        # if isinstance(key, DNDarray) and key.gshape[-1] != len(self.gshape):
+        #     key = tuple(x.item() for x in key)
         if not self.is_distributed():
-            if isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
-                # this is for a list of values
-                for i in range(key.gshape[0]):
-                    self.__setter((key[i, 0].item(), key[i, 1].item()), value)
-            else:
-                self.__setter(key, value)
+            # if isinstance(key, DNDarray) and key.gshape[-1] == len(self.gshape):
+            #     # this is for a list of values
+            #     for i in range(key.gshape[0]):
+            #         self.__setter((key[i, 0].item(), key[i, 1].item()), value)
+            # else:
+            self.__setter(key, value)
         else:
             # raise RuntimeError("split axis of array and the target value are not equal") removed
             # this will occur if the local shapes do not match
@@ -3213,69 +3338,83 @@ class DNDarray:
                     self.__setter(key, value)
             elif isinstance(key, (tuple, torch.Tensor)):
                 if isinstance(key[self.split], slice):
-                    # key = list(key)
-                    # key_start = key[self.split].start if key[self.split].start is not None else 0
-                    # key_stop = (
-                    #     key[self.split].stop
-                    #     if key[self.split].stop is not None
-                    #     else self.gshape[self.split]
-                    # )
-                    # if key_stop < 0:
-                    #     key_stop = self.gshape[self.split] + key[self.split].stop
-                    # key_step = key[self.split].step
-                    # og_key_start = key_start
-                    # st_pr = torch.where(key_start < chunk_ends)[0]
-                    # st_pr = st_pr[0] if len(st_pr) > 0 else self.comm.size
-                    # sp_pr = torch.where(key_stop >= chunk_starts)[0]
-                    # sp_pr = sp_pr[-1] if len(sp_pr) > 0 else 0
-                    # actives = list(range(st_pr, sp_pr + 1))
-                    # if rank in actives:
-                    #     key_start = 0 if rank != actives[0] else key_start - chunk_starts[rank]
-                    #     key_stop = (
-                    #         ends[rank] if rank != actives[-1] else key_stop - chunk_starts[rank]
-                    #     )
-                    #     if key_step is not None and rank > actives[0]:
-                    #         offset = (chunk_ends[rank - 1] - og_key_start) % key_step
-                    #         if key_step > 2 and offset > 0:
-                    #             key_start += key_step - offset
-                    #         elif key_step == 2 and offset > 0:
-                    #             key_start += (chunk_ends[rank - 1] - og_key_start) % key_step
-                    #     if isinstance(key_start, torch.Tensor):
-                    #         key_start = key_start.item()
-                    #     if isinstance(key_stop, torch.Tensor):
-                    #         key_stop = key_stop.item()
-                    #     key[self.split] = slice(key_start, key_stop, key_step)
-                    #     print(key)
-                    #     # todo: need to slice the values to be the right size...
-                    #     value_slice = [slice(None, None, None)] * value.ndim
-                    #     step2 = key_step if key_step is not None else 1
-                    #     value_slice[0] = slice(key_start, (key_stop - key_start)//step2)
-                    #     self.__setter(tuple(key), value[value_slice])
                     key = list(key)
-                    overlap = list(
-                        set(
-                            range(
-                                key[self.split].start if key[self.split].start is not None else 0,
-                                key[self.split].stop
-                                if key[self.split].stop is not None
-                                else self.gshape[self.split],
-                                key[self.split].step if key[self.split].step is not None else 1,
-                            )
-                        )
-                        & set(range(chunk_start, chunk_end))
+                    key_start = key[self.split].start if key[self.split].start is not None else 0
+                    key_stop = (
+                        key[self.split].stop
+                        if key[self.split].stop is not None
+                        else self.gshape[self.split]
                     )
-                    if overlap:
-                        overlap.sort()
-                        hold = [x - chunk_start for x in overlap]
-                        key[self.split] = slice(min(hold), max(hold) + 1, key[self.split].step)
-                        try:
-                            self.__setter(tuple(key), value[overlap])
-                        except TypeError as te:
-                            if str(te) != "'int' object is not subscriptable":
-                                raise TypeError(te)
+                    if key_stop < 0:
+                        key_stop = self.gshape[self.split] + key[self.split].stop
+                    key_step = key[self.split].step
+                    og_key_start = key_start
+                    st_pr = torch.where(key_start < chunk_ends)[0]
+                    st_pr = st_pr[0] if len(st_pr) > 0 else self.comm.size
+                    sp_pr = torch.where(key_stop >= chunk_starts)[0]
+                    sp_pr = sp_pr[-1] if len(sp_pr) > 0 else 0
+                    actives = list(range(st_pr, sp_pr + 1))
+                    if rank in actives:
+                        key_start = 0 if rank != actives[0] else key_start - chunk_starts[rank]
+                        key_stop = (
+                            ends[rank] if rank != actives[-1] else key_stop - chunk_starts[rank]
+                        )
+                        if key_step is not None and rank > actives[0]:
+                            offset = (chunk_ends[rank - 1] - og_key_start) % key_step
+                            if key_step > 2 and offset > 0:
+                                key_start += key_step - offset
+                            elif key_step == 2 and offset > 0:
+                                key_start += (chunk_ends[rank - 1] - og_key_start) % key_step
+                        if isinstance(key_start, torch.Tensor):
+                            key_start = key_start.item()
+                        if isinstance(key_stop, torch.Tensor):
+                            key_stop = key_stop.item()
+                        key[self.split] = slice(key_start, key_stop, key_step)
+                        # todo: need to slice the values to be the right size...
+                        if isinstance(value, (torch.Tensor, type(self))):
+                            value_slice = [slice(None, None, None)] * value.ndim
+                            step2 = key_step if key_step is not None else 1
+                            key_start = chunk_starts[rank] - og_key_start
+                            # print(key_start, self.gshape, og_key_start)
+                            key_stop = key_start + key_stop
+                            # todo: slice logic
+                            slice_loc = (
+                                value.ndim - 1 if self.split > value.ndim - 1 else self.split
+                            )
+                            value_slice[slice_loc] = slice(
+                                key_start.item(), math.ceil(torch.true_divide(key_stop, step2)), 1
+                            )
+                            # print(key_start, key_stop, step2, value_slice, value[tuple(value_slice)], chunk_start)
+                            self.__setter(tuple(key), value[tuple(value_slice)])
+                        else:
                             self.__setter(tuple(key), value)
-                        except IndexError:
-                            self.__setter(tuple(key), value)
+
+                    # # old ============================================================================================
+                    # key = list(key)
+                    # overlap = list(
+                    #     set(
+                    #         range(
+                    #             key[self.split].start if key[self.split].start is not None else 0,
+                    #             key[self.split].stop
+                    #             if key[self.split].stop is not None
+                    #             else self.gshape[self.split],
+                    #             key[self.split].step if key[self.split].step is not None else 1,
+                    #         )
+                    #     )
+                    #     & set(range(chunk_start, chunk_end))
+                    # )
+                    # if overlap:
+                    #     overlap.sort()
+                    #     hold = [x - chunk_start for x in overlap]
+                    #     key[self.split] = slice(min(hold), max(hold) + 1, key[self.split].step)
+                    #     try:
+                    #         self.__setter(tuple(key), value[overlap])
+                    #     except TypeError as te:
+                    #         if str(te) != "'int' object is not subscriptable":
+                    #             raise TypeError(te)
+                    #         self.__setter(tuple(key), value)
+                    #     except IndexError:
+                    #         self.__setter(tuple(key), value)
 
                 elif key[self.split] in range(chunk_start, chunk_end):
                     key = list(key)
@@ -3285,7 +3424,7 @@ class DNDarray:
                 elif key[self.split] < 0:
                     key = list(key)
                     if self.gshape[self.split] + key[self.split] in range(chunk_start, chunk_end):
-                        key[self.split] = key[self.split] + chunk_end - chunk_start
+                        key[self.split] = key[self.split] + self.shape[self.split] - chunk_start
                         self.__setter(tuple(key), value)
 
             elif isinstance(key, slice) and self.split == 0:

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -77,7 +77,6 @@ def nonzero(a):
 
     if a.ndim == 1:
         lcl_nonzero = lcl_nonzero.squeeze(dim=1)
-    # lcl_nonzero.squeeze_()
     for g in range(len(gout) - 1, -1, -1):
         if gout[g] == 1:
             del gout[g]

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -77,6 +77,10 @@ def nonzero(a):
 
     if a.ndim == 1:
         lcl_nonzero = lcl_nonzero.squeeze(dim=1)
+    # lcl_nonzero.squeeze_()
+    for g in range(len(gout) - 1, -1, -1):
+        if gout[g] == 1:
+            del gout[g]
 
     return dndarray.DNDarray(
         lcl_nonzero,

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -201,7 +201,7 @@ def concatenate(arrays, axis=0):
             arr0 = arr0.copy()
             arr1 = arr1.copy()
             # maps are created for where the data is and the output shape is calculated
-            lshape_map = factories.zeros((2, arr0.comm.size, len(arr0.gshape)), dtype=int)
+            lshape_map = torch.zeros((2, arr0.comm.size, len(arr0.gshape)), dtype=torch.int)
             lshape_map[0, arr0.comm.rank, :] = torch.Tensor(arr0.lshape)
             lshape_map[1, arr0.comm.rank, :] = torch.Tensor(arr1.lshape)
             lshape_map_comm = arr0.comm.Iallreduce(MPI.IN_PLACE, lshape_map, MPI.SUM)
@@ -211,7 +211,7 @@ def concatenate(arrays, axis=0):
             out_shape = tuple(arr0_shape)
 
             # the chunk map is used for determine how much data should be on each process
-            chunk_map = factories.zeros((arr0.comm.size, len(arr0.gshape)), dtype=int)
+            chunk_map = torch.zeros((arr0.comm.size, len(arr0.gshape)), dtype=torch.int)
             _, _, chk = arr0.comm.chunk(out_shape, s0 if s0 is not None else s1)
             for i in range(len(out_shape)):
                 chunk_map[arr0.comm.rank, i] = chk[i].stop - chk[i].start

--- a/heat/core/operations.py
+++ b/heat/core/operations.py
@@ -383,8 +383,14 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
     if 0 in x.lshape and (axis is None or (x.split in axis)):
         if neutral is None:
             neutral = float("nan")
-        neutral_shape = x.lshape[:split] + (1,) + x.lshape[split + 1 :]
-        partial = torch.full(neutral_shape, fill_value=neutral, dtype=x._DNDarray__array.dtype)
+        neutral_shape = x.gshape[:split] + (1,) + x.gshape[split + 1 :]
+        partial = torch.full(
+            neutral_shape,
+            fill_value=neutral,
+            dtype=x.dtype.torch_type(),
+            device=x.device.torch_device,
+        )
+
     else:
         partial = x._DNDarray__array
 
@@ -406,7 +412,8 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
                 lshape_losedim = (partial.shape[0],) + lshape_losedim
             if 0 not in axis and partial.shape[0] != x.lshape[0]:
                 lshape_losedim = (partial.shape[0],) + lshape_losedim[1:]
-            partial = partial.reshape(lshape_losedim)
+            if len(lshape_losedim) > 0:
+                partial = partial.reshape(lshape_losedim)
 
     # Check shape of output buffer, if any
     if out is not None and out.shape != output_shape:

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -331,9 +331,11 @@ def average(x, axis=None, weights=None, returned=False):
             )
             wgt_slice = [slice(None) if dim == axis else 0 for dim in list(range(x.ndim))]
             wgt_split = None if weights.split is None else axis
-            wgt = factories.empty(wgt_lshape, dtype=weights.dtype, device=x.device)
-            wgt._DNDarray__array[wgt_slice] = weights._DNDarray__array
-            wgt = factories.array(wgt._DNDarray__array, is_split=wgt_split)
+            wgt = torch.empty(
+                wgt_lshape, dtype=weights.dtype.torch_type(), device=x.device.torch_device
+            )
+            wgt[wgt_slice] = weights._DNDarray__array
+            wgt = factories.array(wgt, is_split=wgt_split)
         else:
             if x.comm.is_distributed():
                 if x.split is not None and weights.split != x.split and weights.ndim != 1:
@@ -345,7 +347,6 @@ def average(x, axis=None, weights=None, returned=False):
             wgt._DNDarray__array = weights._DNDarray__array
 
         cumwgt = wgt.sum(axis=axis)
-
         if logical.any(cumwgt == 0.0):
             raise ZeroDivisionError("Weights sum to zero, can't be normalized")
 

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -167,6 +167,7 @@ def sanitize_slice(sl, max_dim) -> slice:
     Parameters
     ----------
     sl : slice
+        slice to adjust
     max_dim : int
         maximum index for the given slice
 
@@ -177,12 +178,15 @@ def sanitize_slice(sl, max_dim) -> slice:
     """
     if not isinstance(sl, slice):
         raise TypeError("This function is only for slices!")
+
     new_sl = [None] * 3
     new_sl[0] = 0 if sl.start is None else sl.start
     if new_sl[0] < 0:
         new_sl[0] += max_dim
+
     new_sl[1] = max_dim if sl.stop is None else sl.stop
     if new_sl[1] < 0:
         new_sl[1] += max_dim
+
     new_sl[2] = 1 if sl.step is None else sl.step
     return slice(new_sl[0], new_sl[1], new_sl[2])

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -158,3 +158,30 @@ def sanitize_shape(shape):
             raise ValueError("negative dimensions are not allowed")
 
     return shape
+
+
+def sanitize_slice(sl, max_dim):
+    """
+    Remove Nonetypes from a slice
+
+    Parameters
+    ----------
+    sl : slice
+    max_dim : int
+        maximum index for the given slice
+
+    Returns
+    -------
+
+    """
+    if not isinstance(sl, slice):
+        raise TypeError("This function is only for slices!")
+    new_sl = [None] * 3
+    new_sl[0] = 0 if sl.start is None else sl.start
+    if new_sl[0] < 0:
+        new_sl[0] += max_dim
+    new_sl[1] = max_dim if sl.stop is None else sl.stop
+    if new_sl[1] < 0:
+        new_sl[1] += max_dim
+    new_sl[2] = 1 if sl.step is None else sl.step
+    return slice(new_sl[0], new_sl[1], new_sl[2])

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -160,9 +160,9 @@ def sanitize_shape(shape):
     return shape
 
 
-def sanitize_slice(sl, max_dim):
+def sanitize_slice(sl, max_dim) -> slice:
     """
-    Remove Nonetypes from a slice
+    Remove None-types from a slice
 
     Parameters
     ----------
@@ -170,9 +170,10 @@ def sanitize_slice(sl, max_dim):
     max_dim : int
         maximum index for the given slice
 
-    Returns
-    -------
-
+    Raises
+    ------
+    TypeError
+        if sl is not a slice
     """
     if not isinstance(sl, slice):
         raise TypeError("This function is only for slices!")

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -289,8 +289,9 @@ class TestArithmetics(unittest.TestCase):
                     # loop to 3 for the number of times to do the diff
                     for nl in range(1, 4):
                         # only generating the number once and then
-                        lp_array = ht.manipulations.resplit(ht_array[arb_slice], sp)
-                        np_array = ht_array[arb_slice].numpy()
+                        tup_arb = tuple(arb_slice)
+                        lp_array = ht.manipulations.resplit(ht_array[tup_arb], sp)
+                        np_array = ht_array[tup_arb].numpy()
 
                         ht_diff = ht.diff(lp_array, n=nl, axis=ax)
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax), device=ht_device)

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -778,6 +778,7 @@ class TestDNDarray(unittest.TestCase):
 
         a = ht.zeros((13, 5), split=0, device=ht_device)
         a[-1] = 1
+        # print('here', a)
         b = a[-1]
         self.assertTrue((b == 1).all())
         self.assertEqual(b.dtype, ht.float32)
@@ -961,8 +962,12 @@ class TestDNDarray(unittest.TestCase):
         # setting with heat tensor
         a = ht.zeros((4, 5), split=1, device=ht_device)
         a[1, 0:4] = ht.arange(4, device=ht_device)
+        # print(a)
+        # print(a[1, 2])
         for c, i in enumerate(range(4)):
-            self.assertEqual(a[1, c], i)
+            b = a[1, c]
+            if b._DNDarray__array.numel() > 0:
+                self.assertEqual(b.item(), i)
 
         # setting with torch tensor
         a = ht.zeros((4, 5), split=1, device=ht_device)

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -778,7 +778,6 @@ class TestDNDarray(unittest.TestCase):
 
         a = ht.zeros((13, 5), split=0, device=ht_device)
         a[-1] = 1
-        # print('here', a)
         b = a[-1]
         self.assertTrue((b == 1).all())
         self.assertEqual(b.dtype, ht.float32)
@@ -962,8 +961,6 @@ class TestDNDarray(unittest.TestCase):
         # setting with heat tensor
         a = ht.zeros((4, 5), split=1, device=ht_device)
         a[1, 0:4] = ht.arange(4, device=ht_device)
-        # print(a)
-        # print(a[1, 2])
         for c, i in enumerate(range(4)):
             b = a[1, c]
             if b._DNDarray__array.numel() > 0:

--- a/heat/core/tests/test_indexing.py
+++ b/heat/core/tests/test_indexing.py
@@ -78,7 +78,7 @@ class TestIndexing(unittest.TestCase):
             [[0.0, 1.0, 2.0], [0.0, 2.0, -1.0], [0.0, 3.0, -1.0]], split=0, device=ht_device
         )
         wh = ht.where(a < 4.0, a, -1)
-        self.assertTrue(ht.all(wh[ht.nonzero(a >= 4)], -1))
+        self.assertTrue(ht.all(wh[ht.nonzero(a >= 4)] == -1))
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))
         self.assertEqual(wh.dtype, ht.float)

--- a/heat/core/tests/test_stride_tricks.py
+++ b/heat/core/tests/test_stride_tricks.py
@@ -78,3 +78,18 @@ class TestStrideTricks(unittest.TestCase):
             ht.core.stride_tricks.sanitize_shape(1.0)
         with self.assertRaises(TypeError):
             ht.core.stride_tricks.sanitize_shape((1, 1.0))
+
+    def test_sanitize_slice(self):
+        test_slice = slice(None, None, None)
+        ret_slice = ht.core.stride_tricks.sanitize_slice(test_slice, 100)
+        self.assertEqual(ret_slice.start, 0)
+        self.assertEqual(ret_slice.stop, 100)
+        self.assertEqual(ret_slice.step, 1)
+        test_slice = slice(-50, -5, 2)
+        ret_slice = ht.core.stride_tricks.sanitize_slice(test_slice, 100)
+        self.assertEqual(ret_slice.start, 50)
+        self.assertEqual(ret_slice.stop, 95)
+        self.assertEqual(ret_slice.step, 2)
+
+        with self.assertRaises(TypeError):
+            ht.core.stride_tricks.sanitize_slice("test_slice", 100)

--- a/heat/naive_bayes/gaussianNB.py
+++ b/heat/naive_bayes/gaussianNB.py
@@ -354,16 +354,10 @@ class GaussianNB(ht.ClassificationMixin, ht.BaseEstimator):
                 )
                 i = torch.argsort(classes_ext)[-1].item()
             where_y_i = ht.where(y == y_i)
-            # print(y_i, 'e', where_y_i.shape)
-            # print("\nSTART")
             X_i = X[where_y_i, :]
-            # print(X_i)
-            # print(X_i.shape)
 
             if sample_weight is not None:
-                # print('sample', sample_weight)
                 sw_i = sample_weight[where_y_i]
-                # print('after sample')
                 if 0 not in sw_i.shape:
                     N_i = sw_i.sum()
                 else:
@@ -372,18 +366,14 @@ class GaussianNB(ht.ClassificationMixin, ht.BaseEstimator):
             else:
                 sw_i = None
                 N_i = X_i.shape[0]
-
             new_theta, new_sigma = self.__update_mean_variance(
                 self.class_count_[i], self.theta_[i, :], self.sigma_[i, :], X_i, sw_i
             )
-
             self.theta_[i, :] = new_theta
             self.sigma_[i, :] = new_sigma
             self.class_count_[i] += N_i
 
         self.sigma_[:, :] += self.epsilon_
-
-        # print(self.theta_)
 
         # Update if only no priors is provided
         if self.priors is None:

--- a/heat/naive_bayes/gaussianNB.py
+++ b/heat/naive_bayes/gaussianNB.py
@@ -353,11 +353,17 @@ class GaussianNB(ht.ClassificationMixin, ht.BaseEstimator):
                     (classes._DNDarray__array, y_i._DNDarray__array.unsqueeze(0))
                 )
                 i = torch.argsort(classes_ext)[-1].item()
-            where_y_i = ht.where(y == y_i)._DNDarray__array.tolist()
+            where_y_i = ht.where(y == y_i)
+            # print(y_i, 'e', where_y_i.shape)
+            # print("\nSTART")
             X_i = X[where_y_i, :]
+            # print(X_i)
+            # print(X_i.shape)
 
             if sample_weight is not None:
+                # print('sample', sample_weight)
                 sw_i = sample_weight[where_y_i]
+                # print('after sample')
                 if 0 not in sw_i.shape:
                     N_i = sw_i.sum()
                 else:
@@ -376,6 +382,8 @@ class GaussianNB(ht.ClassificationMixin, ht.BaseEstimator):
             self.class_count_[i] += N_i
 
         self.sigma_[:, :] += self.epsilon_
+
+        # print(self.theta_)
 
         # Update if only no priors is provided
         if self.priors is None:
@@ -400,7 +408,6 @@ class GaussianNB(ht.ClassificationMixin, ht.BaseEstimator):
             n_ij = -0.5 * ht.sum(ht.log(2.0 * ht.pi * self.sigma_[i, :]))
             n_ij -= 0.5 * ht.sum(((X - self.theta_[i, :]) ** 2) / (self.sigma_[i, :]), 1)
             joint_log_likelihood[:, i] = jointi + n_ij
-
         return joint_log_likelihood
 
     def logsumexp(self, a, axis=None, b=None, keepdim=False, return_sign=False):


### PR DESCRIPTION
## Description

`getitem`/`setitem` now use tuples for most key types. 
Advanced indexing is also implemented via this approach. keys for advanced indexing can be `lists`, `torch.Tensors`, or `ht.DNDarrays`. This means that the results of `where` and `nonzero` can be fed directly into another DNDarray as a key. However, it also means that `list`s are treated differently than `tuple`s when given as a key

Issue/s resolved: #591 #505 

## Changes proposed:
- most keys in `getitem`/`setitem` create a tuple for a given key
- removal of other types of key options in `getitem`/`setitem`
- `reduce_op` neutral value array created using the gshape instead of the lshape
- addition of advanced indexing

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?

yes, any function which uses `where` or `nonzero` can now use the DNDarray instead of a list.
