### PR TITLE
Features/31 outer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
 - [#578](https://github.com/helmholtz-analytics/heat/pull/578) Bugfix: Bad variable in reshape
 - [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
-- [#596](https://github.com/helmholtz-analytics/heat/pull/596) New feature: outer()
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) New feature: Advanced indexing
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) Bugfix: getitem and setitem memory consumption heavily reduced
+- [#596](https://github.com/helmholtz-analytics/heat/pull/596) New feature: outer()
 
 # v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
 - [#578](https://github.com/helmholtz-analytics/heat/pull/578) Bugfix: Bad variable in reshape
 - [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
-- [#581](https://github.com/helmholtz-analytics/heat/pull/581) New Feature: DNDarray.tolist()
-- [#593](https://github.com/helmholtz-analytics/heat/pull/593) New feature arctan2()
+- [#581](https://github.com/helmholtz-analytics/heat/pull/581) New feature: DNDarray.tolist()
+- [#593](https://github.com/helmholtz-analytics/heat/pull/593) New feature: arctan2()
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) New feature: Advanced indexing
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) Bugfix: getitem and setitem memory consumption heavily reduced
 - [#596](https://github.com/helmholtz-analytics/heat/pull/596) New feature: outer()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
 - [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
-
+- [#595](https://github.com/helmholtz-analytics/heat/pull/595) New feature: outer()
 
 # v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
 - [#578](https://github.com/helmholtz-analytics/heat/pull/578) Bugfix: Bad variable in reshape
 - [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
-- [#595](https://github.com/helmholtz-analytics/heat/pull/595) New feature: outer()
+- [#596](https://github.com/helmholtz-analytics/heat/pull/596) New feature: outer()
 
 # v0.4.0
 

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -842,10 +842,10 @@ def outer(a, b, out=None, split=None):
     ----------
 
     a(M,): DNDarray
-            First input DNDarray. Must be 1-dimensional.
+            First input DNDarray. Must be 1-dimensional. Will be flattened by default if more than 1D
 
     b(N,): DNDarray
-            Second input DNDarray. Must be 1-dimensional.
+            Second input DNDarray. Must be 1-dimensional. Will be flattened by default if more than 1D
 
     out(M, N): DNDarray, optional
             A location where the result is stored

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -831,14 +831,17 @@ def outer(a, b, out=None, split=None):
     """
     Compute the outer product of two 1-D DNDarrays.
 
-    Given two vectors, ``a`` = [a_0, a_1, ..., a_n] and ``b`` = [b_0, b_1, ..., b_m], the outer product is:
+    Given two vectors, :math:`a = (a_0, a_1, ..., a_N)` and :math:`b = (b_0, b_1, ..., b_M)`, the outer product is:
 
     .. math::
+        :nowrap:
 
-           a_0 \times b_0  & a_0 \times b_1 & . & . &  a_0 \times b_m \\
-           a_1 \times b_0 & a_1 \times b_1 & . & . & a_1 \times b_m \\
+        \\begin{pmatrix}
+           a_0 \\cdot b_0  & a_0 \\cdot b_1 & . & . &  a_0 \\cdot b_M \\
+           a_1 \\cdot b_0 & a_1 \\cdot b_1 & . & . & a_1 \\cdot b_M \\
            . & . & . & . & .   \\
-           a_n \times b_0 & a_n \times b_1 & . & . & a_n \times b_m
+           a_N \\cdot b_0 & a_N \\cdot b_1 & . & . & a_N \\cdot b_M
+        \\end{pmatrix}
 
     Parameters
     ----------

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -853,7 +853,7 @@ def outer(a, b, out=None, split=None):
     split: int, optional #TODO check out docstring format
             Split dimension of the resulting DNDarray. Can be 0, 1, or None.
             This is only relevant if the calculations are memory-distributed,
-            default is split=0 (see Note).
+            in which case default is split=0 (see Note).
 
     Note: parallel implementation of outer product, arrays are dense. #TODO sparse
         In the classical (dense) case, one DNDarray stays put, the other one is passed around the ranks in
@@ -862,8 +862,8 @@ def outer(a, b, out=None, split=None):
               if 'a' is sent around, the resulting outer product is split along the columns (split = 1).
         So if 'split' is not None, 'split' defines which DNDarray stays put and which one is passed around. No
         communication is needed beyond ring communication of one of the DNDarrays.
-        If 'split' is None or unspecified, the result will be distributed along axis 0, i.e. by default b is
-        passed around, a stays put.
+        If 'split' is None or unspecified, the result will be distributed along axis 0, i.e. by default 'b' is
+        passed around, 'a' stays put.
 
     Returns
     -------

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -831,36 +831,36 @@ def outer(a, b, out=None, split=None):
     """
     Compute the outer product of two 1-D DNDarrays.
 
-    Given two vectors, a = [a0, a1, ..., aM] and b = [b0, b1, ..., bN], the outer product is:
+    Given two vectors, ``a`` = [a_0, a_1, ..., a_n] and ``b`` = [b_0, b_1, ..., b_m], the outer product is:
 
-    [[a0*b0  a0*b1 ... a0*bN ]
-    [a1*b0    .
-    [ ...          .
-    [aM*b0            aM*bN ]]
+    [[a_0*b_0  a_0*b_1 ... a_0*b_m]
+     [a_1*b_0     .
+     [ ...        .
+     [a_n*b_0     .        a_n*b_m]]
 
     Parameters
     ----------
 
-    a(M,): DNDarray
-            First input DNDarray. Must be 1-dimensional. Will be flattened by default if more than 1D
+    a(n,): DNDarray
+            First input DNDarray. Must be 1-dimensional. Will be flattened by default if more than 1-D
 
-    b(N,): DNDarray
-            Second input DNDarray. Must be 1-dimensional. Will be flattened by default if more than 1D
+    b(m,): DNDarray
+            Second input DNDarray. Must be 1-dimensional. Will be flattened by default if more than 1-D
 
-    out(M, N): DNDarray, optional
+    out(n, m): DNDarray, optional
             A location where the result is stored
 
     split: int, optional #TODO check out docstring format
             Split dimension of the resulting DNDarray. Can be 0, 1, or None.
             This is only relevant if the calculations are memory-distributed,
-            in which case default is split=0 (see Note).
+            in which case default is ``split=0`` (see Note).
 
-    Note: parallel implementation of outer product, arrays are dense. #TODO sparse
+    Note: parallel implementation of outer product, arrays are dense. #TODO sparse #384
         In the classical (dense) case, one DNDarray stays put, the other one is passed around the ranks in
         ring communication. The slice-by-slice outer product is calculated locally (here via torch.einsum()).
-        N.B.: if 'b' is sent around, the resulting outer product is split along the rows dimension (split = 0).
-              if 'a' is sent around, the resulting outer product is split along the columns (split = 1).
-        So if 'split' is not None, 'split' defines which DNDarray stays put and which one is passed around. No
+        N.B.: if ``b`` is sent around, the resulting outer product is split along the rows dimension (``split = 0``).
+              if ``a`` is sent around, the resulting outer product is split along the columns (``split = 1``).
+        So if ``split`` is not None, ``split`` defines which DNDarray stays put and which one is passed around. No
         communication is needed beyond ring communication of one of the DNDarrays.
         If 'split' is None or unspecified, the result will be distributed along axis 0, i.e. by default 'b' is
         passed around, 'a' stays put.
@@ -868,7 +868,7 @@ def outer(a, b, out=None, split=None):
     Returns
     -------
 
-    out(M, N): DNDarray
+    out(n, m): DNDarray
 
         out[i, j] = a[i] * b[j]
 
@@ -969,7 +969,7 @@ def outer(a, b, out=None, split=None):
                 "Split dimension mismatch for out: expected {}, got {}".format(split, out.split)
             )
 
-    # distributed outer product (dense, TODO: implement sparse version, #??)
+    # distributed outer product (dense, TODO: implement sparse version, #384)
     if a.comm.is_distributed() and split is not None or a.split is not None or b.split is not None:
         # MPI coordinates
         rank = a.comm.rank

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -833,29 +833,34 @@ def outer(a, b, out=None, split=None):
 
     Given two vectors, ``a`` = [a_0, a_1, ..., a_n] and ``b`` = [b_0, b_1, ..., b_m], the outer product is:
 
-    [[a_0*b_0  a_0*b_1 ... a_0*b_m]
-     [a_1*b_0     .
-     [ ...        .
-     [a_n*b_0     .        a_n*b_m]]
+    .. math::
+
+           a_0 \times b_0  & a_0 \times b_1 & . & . &  a_0 \times b_m \\
+           a_1 \times b_0 & a_1 \times b_1 & . & . & a_1 \times b_m \\
+           . & . & . & . & .   \\
+           a_n \times b_0 & a_n \times b_1 & . & . & a_n \times b_m
 
     Parameters
     ----------
 
-    a(n,): DNDarray
-            First input DNDarray. Must be 1-dimensional. Will be flattened by default if more than 1-D
+    a : DNDarray
+        1-dimensional: :math: `N`
+        Will be flattened by default if more than 1-D.
 
-    b(m,): DNDarray
-            Second input DNDarray. Must be 1-dimensional. Will be flattened by default if more than 1-D
+    b : DNDarray
+        1-dimensional: :math: `M`
+        Will be flattened by default if more than 1-D.
 
-    out(n, m): DNDarray, optional
-            A location where the result is stored
+    out : DNDarray, optional
+          2-dimensional: :math: `N \\times M`
+          A location where the result is stored
 
-    split: int, optional #TODO check out docstring format
+    split : int, optional
             Split dimension of the resulting DNDarray. Can be 0, 1, or None.
             This is only relevant if the calculations are memory-distributed,
             in which case default is ``split=0`` (see Note).
 
-    Note: parallel implementation of outer product, arrays are dense. #TODO sparse #384
+    Note: parallel implementation of outer product, arrays are dense.
         In the classical (dense) case, one DNDarray stays put, the other one is passed around the ranks in
         ring communication. The slice-by-slice outer product is calculated locally (here via torch.einsum()).
         N.B.: if ``b`` is sent around, the resulting outer product is split along the rows dimension (``split = 0``).
@@ -969,7 +974,7 @@ def outer(a, b, out=None, split=None):
                 "Split dimension mismatch for out: expected {}, got {}".format(split, out.split)
             )
 
-    # distributed outer product (dense, TODO: implement sparse version, #384)
+    # distributed outer product, dense arrays (TODO: sparse, #384)
     if a.comm.is_distributed() and split is not None or a.split is not None or b.split is not None:
         # MPI coordinates
         rank = a.comm.rank

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -852,8 +852,8 @@ def outer(a, b, out=None, split=None):
 
     split: int, optional #TODO check out docstring format
             Split dimension of the resulting DNDarray. Can be 0, 1, or None.
-            This is only relevant if the calculations are memory-distributed (see Note)
-            Default is split=None, i.e. result will reside on each rank.
+            This is only relevant if the calculations are memory-distributed,
+            default is split=0 (see Note).
 
     Note: parallel implementation of outer product, arrays are dense. #TODO sparse
         In the classical (dense) case, one DNDarray stays put, the other one is passed around the ranks in
@@ -931,12 +931,19 @@ def outer(a, b, out=None, split=None):
                     [ 9.],
                     [12.]], dtype=torch.float64)
     """
+    # sanitize input
     if not isinstance(a, dndarray.DNDarray) or not isinstance(b, dndarray.DNDarray):
         raise TypeError(
             "a, b must be of type ht.DNDarray, but were {}, {}".format(type(a), type(b))
         )
 
-    if a.ndim != 1 or b.ndim != 1:
+    # sanitize dimensions
+    # TODO move to sanitation module #468
+    if a.ndim > 1:
+        a = manipulations.flatten(a)
+    if b.ndim > 1:
+        b = manipulations.flatten(b)
+    if a.ndim == 0 or b.ndim == 0:
         raise RuntimeError(
             "a, b must be 1-D DNDarrays, but were {}-D and {}-D".format(a.ndim, b.ndim)
         )

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -862,8 +862,8 @@ def outer(a, b, out=None, split=None):
               if ``a`` is sent around, the resulting outer product is split along the columns (``split = 1``).
         So if ``split`` is not None, ``split`` defines which DNDarray stays put and which one is passed around. No
         communication is needed beyond ring communication of one of the DNDarrays.
-        If 'split' is None or unspecified, the result will be distributed along axis 0, i.e. by default 'b' is
-        passed around, 'a' stays put.
+        If ``split`` is None or unspecified, the result will be distributed along axis 0, i.e. by default ``b`` is
+        passed around, ``a`` stays put.
 
     Returns
     -------

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -827,9 +827,9 @@ def norm(a):
     return exponential.sqrt(d).item()
 
 
-def outer(a, b, out=None):
+def outer(a, b, out=None, split=0):
     """
-    Compute the outer product of two vectors.
+    Compute the outer product of two 1-D DNDarrays.
 
     Given two vectors, a = [a0, a1, ..., aM] and b = [b0, b1, ..., bN], the outer product is:
 
@@ -841,39 +841,74 @@ def outer(a, b, out=None):
     Parameters
     ----------
 
-    a(M,): ht.DNDarray
-            First input tensor. Input is flattened if not already 1-dimensional.
+    a(M,): DNDarray
+            First input DNDarray. Input is flattened if not already 1-dimensional.
 
-    b(N,): ht.DNDarray
-            Second input tensor. Input is flattened if not already 1-dimensional.
+    b(N,): DNDarray
+            Second input DNDarray. Input is flattened if not already 1-dimensional.
 
-    out(M, N): ht.DNDarray, optional
+    out(M, N): DNDarray, optional
             A location where the result is stored
+
+    split: int, optional #TODO check out docstring format
+            Split dimension of the resulting DNDarray. Can be 0, 1, or None.
+            Default is split=0.
 
     Returns
     -------
 
-    out(M, N): ht.DNDarray
+    out(M, N): DNDarray
 
         out[i, j] = a[i] * b[j]
+
+    Examples #TODO
+    --------
 
     """
     # TODO sanitize input
     # TODO sanitize shape (1d or flatten)
 
-    out_dtype = types.promote_types(a.dtype, b.dtype)
-    out_shape = (a.gshape[0], b.gshape[0])
-    out_split = 0
+    out_gshape = (a.gshape[0], b.gshape[0])
 
     t_a = a._DNDarray__array
     t_b = b._DNDarray__array
+    t_out_dtype = torch.promote_types(t_a.dtype, t_b.dtype)
 
-    # outer product, local
-    if not a.comm.is_distributed():
+    # TODO: determine sparseness of data, if necessary skip steps below
+    if a.comm.is_distributed() and a.split is not None and b.split is not None:
+        # MPI coordinates
+        rank = a.comm.rank
+        size = a.comm.size
+
+        # Decide which DNDarray gets sent around ring communication
+        # case 1: out.split = 0 --> a stays put, b gets sent around
+        # case 2: out.split = 1 --> a gets sent around, b stays put
+        # case 3: out.split = None --> bigger (element size) DNDarray stays put, smaller one gets sent around
+        if split == 0:
+            lshape_map = b.create_lshape_map()
+            t_out_shape = (a.lshape[0], b.gshape[0])
+            t_out = torch.zeros(t_out_shape, dtype=t_out_dtype, device=t_a.device)
+            _, _, t_out_slice = b.comm.chunk(b.gshape, b.split)
+            t_out[:, t_out_slice[0]] = torch.einsum("i,j->ij", t_a, t_b)
+            for i in range(size):
+                # prepare for shipping
+                dest_rank = rank + 1 if rank != size - 1 else 0
+                # prepare for receiving
+                origin_rank = rank - 1 if rank != 0 else size - 1
+                # blocking send and recv
+                b.comm.Send(t_b, dest_rank)
+                t_inbox = torch.empty(lshape_map[origin_rank], dtype=t_b.dtype, device=t_b.device)
+                b.comm.Recv(t_inbox, origin_rank)
+                _, _, t_out_slice = b.comm.chunk(b.gshape, b.split, rank=origin_rank)
+                t_out[:, t_out_slice[0]] = torch.einsum("i,j->ij", t_a, t_inbox)
+                # TODO: check that original a and b haven't been modified
+    else:
+        # outer product, local
         t_out = torch.einsum("i,j->ij", t_a, t_b)
 
+    out_dtype = types.canonical_heat_type(t_out_dtype)
     out = dndarray.DNDarray(
-        t_out, gshape=out_shape, dtype=out_dtype, split=out_split, device=a.device, comm=a.comm
+        t_out, gshape=out_gshape, dtype=out_dtype, split=split, device=a.device, comm=a.comm
     )
 
     return out

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -542,6 +542,20 @@ class TestLinalgBasics(unittest.TestCase):
         a_2d = ht.random.randn(2, 2)
         with self.assertRaises(RuntimeError):
             ht.outer(a_2d, b)
+        t_out = torch.empty((a.gshape[0], b.gshape[0]), dtype=torch.float32)
+        with self.assertRaises(TypeError):
+            ht.outer(a, b, out=t_out)
+        ht_out_wrong_dtype = ht.empty((a.gshape[0], b.gshape[0]), dtype=ht.float64)
+        with self.assertRaises(TypeError):
+            ht.outer(a, b, out=ht_out_wrong_dtype)
+        ht_out_wrong_shape = ht.empty((7, b.gshape[0]), dtype=ht.float32)
+        with self.assertRaises(ValueError):
+            ht.outer(a, b, out=ht_out_wrong_shape)
+        ht_out_wrong_split = ht.empty(
+            (a_split.gshape[0], b_split.gshape[0]), dtype=ht.float32, split=1
+        )
+        with self.assertRaises(ValueError):
+            ht.outer(a_split, b_split, out=ht_out_wrong_split, split=0)
 
     def test_projection(self):
         a = ht.arange(1, 4, dtype=ht.float32, split=None)

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -509,10 +509,10 @@ class TestLinalgBasics(unittest.TestCase):
         self.assertTrue((ht_outer_split.numpy() == np_outer).all())
         self.assertTrue(ht_outer_split.split == 1)
 
-        # a and b distributed, outer local
+        # a and b distributed, outer split unspecified
         ht_outer_split = ht.outer(a_split, b_split, split=None)
         self.assertTrue((ht_outer_split.numpy() == np_outer).all())
-        self.assertTrue(ht_outer_split.split is None)
+        self.assertTrue(ht_outer_split.split == 0)
 
         # a not distributed, outer.split = 1
         ht_outer_split = ht.outer(a, b_split, split=1)

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -524,6 +524,13 @@ class TestLinalgBasics(unittest.TestCase):
         self.assertTrue((ht_outer_split.numpy() == np_outer).all())
         self.assertTrue(ht_outer_split.split == 0)
 
+        # a_split.ndim > 1 and a.split != 0
+        a_split_3d = ht.random.randn(3, 3, 3, dtype=ht.float64, split=2)
+        ht_outer_split = ht.outer(a_split_3d, b_split)
+        np_outer_3d = np.outer(a_split_3d.numpy(), b_split.numpy())
+        self.assertTrue((ht_outer_split.numpy() == np_outer_3d).all())
+        self.assertTrue(ht_outer_split.split == 0)
+
         # write to out buffer
         ht_out = ht.empty((a.gshape[0], b.gshape[0]), dtype=ht.float32)
         ht.outer(a, b, out=ht_out)
@@ -539,9 +546,9 @@ class TestLinalgBasics(unittest.TestCase):
         np_b = np.arange(8)
         with self.assertRaises(TypeError):
             ht.outer(a, np_b)
-        a_2d = ht.random.randn(2, 2)
+        a_0d = ht.array(2.3)
         with self.assertRaises(RuntimeError):
-            ht.outer(a_2d, b)
+            ht.outer(a_0d, b)
         t_out = torch.empty((a.gshape[0], b.gshape[0]), dtype=torch.float32)
         with self.assertRaises(TypeError):
             ht.outer(a, b, out=t_out)

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -516,8 +516,6 @@ class TestLinalgBasics(unittest.TestCase):
 
         # a not distributed, outer.split = 1
         ht_outer_split = ht.outer(a, b_split, split=1)
-        print("DEBUGGING: ht_outer_split = ", ht_outer_split)
-        print("DEBUGGING: np_outer = ", np_outer)
         self.assertTrue((ht_outer_split.numpy() == np_outer).all())
         self.assertTrue(ht_outer_split.split == 1)
 


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Introducing the outer product of two DNDarrays as per [numpy.outer()](https://numpy.org/doc/1.18/reference/generated/numpy.outer.html), i.e.:

`ht.outer(a, b)`

`a` and `b` must be 1-dimensional, or will be flattened by default. 
In linear algebra, if `a` is a vector of _n_ elements, and `b` is a vector of _m_ elements, the outer product `outer(a,b)` is a matrix of size (_n_, _m_) and elements:

![$\begin{pmatrix}  a_0\cdot b_0  & a_0\cdot b_1 & . & . &  a_0\cdot b_m \\  a_1\cdot b_0 & a_1\cdot b_1 & . & . & a_1\cdot b_m \\  . & . & . & . & .   \\   a_n\cdot b_0 & a_n\cdot b_1 & . & . & a_n\cdot b_m \end{pmatrix} $](https://render.githubusercontent.com/render/math?math=%24%5Cbegin%7Bpmatrix%7D%20%20a_0%5Ccdot%20b_0%20%20%26%20a_0%5Ccdot%20b_1%20%26%20.%20%26%20.%20%26%20%20a_0%5Ccdot%20b_m%20%5C%5C%20%20a_1%5Ccdot%20b_0%20%26%20a_1%5Ccdot%20b_1%20%26%20.%20%26%20.%20%26%20a_1%5Ccdot%20b_m%20%5C%5C%20%20.%20%26%20.%20%26%20.%20%26%20.%20%26%20.%20%20%20%5C%5C%20%20%20a_n%5Ccdot%20b_0%20%26%20a_n%5Ccdot%20b_1%20%26%20.%20%26%20.%20%26%20a_n%5Ccdot%20b_m%20%5Cend%7Bpmatrix%7D%20%24)

### Implementation
- Locally, the outer product is calculated via PyTorch's Einstein summation, as in:
`torch.einsum("i,j->ij", a, b)`

- The memory-distributed implementation works under the assumption that the vectors / DNDarrays are dense (implementation for sparse case will be addressed at a later point (#384). Procedure:
    - `a` and `b` are distributed 
    - one of the DNDarrays always stays local, the other is passed around the ranks in ring communication until all `a_i * b_j` multiplications have taken place.
    - outer product (`torch.einsum`) is calculated locally, written into the appropriate slice of `out = ht.outer(a,b)`, and never needs to be communicated among ranks
    - `out` is by definition split along 0 if `b` is sent around and `a` stays put. Conversely, it is split along 1 if `a` is sent around and `b` stays put. As  a consequence...
    - ... split semantics: I have introduced a kwarg `split` to allow users to choose the split direction of the output matrix. `split` decides which DNDarray stays and which one goes round the ranks. If split is None in the distributed case, `ht.outer(a,b).split` will be the same as `a.split` and `b.split`, i.e. 0. 

Note that the distributed case requires that at least one among `a.split`, `b.split` and `out.split` be `not None`. Otherwise we fall back to local.

Issue/s resolved: #31 

## Changes proposed:
- with respect to np.outer, ht.outer has an extra kwarg `split` to define the split dimension of the output matrix, e.g.: `out = ht.outer(a, b, split=1)`

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- New feature (non-breaking change which adds functionality)
## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
