### PR TITLE
Changed to intuitive casting, removed dtype tests from basic test class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#593](https://github.com/helmholtz-analytics/heat/pull/593) New feature arctan2()
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) New feature: Advanced indexing
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) Bugfix: getitem and setitem memory consumption heavily reduced
+- [#598](https://github.com/helmholtz-analytics/heat/pull/598) Type casting changed to PyTorch style casting (i.e. intuitive casting) instead of safe casting
 
 # v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 - [#593](https://github.com/helmholtz-analytics/heat/pull/593) New feature: arctan2()
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) New feature: Advanced indexing
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) Bugfix: getitem and setitem memory consumption heavily reduced
-- [#598](https://github.com/helmholtz-analytics/heat/pull/598) Type casting changed to PyTorch style casting (i.e. intuitive casting) instead of safe casting
 - [#596](https://github.com/helmholtz-analytics/heat/pull/596) New feature: outer()
+- [#598](https://github.com/helmholtz-analytics/heat/pull/598) Type casting changed to PyTorch style casting (i.e. intuitive casting) instead of safe casting
 - [#600](https://github.com/helmholtz-analytics/heat/pull/600) New feature: shape()
 
 # v0.4.0

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -31,8 +31,8 @@ class TestExponential(TestCase):
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_exp = ht.exp(int32_tensor)
         self.assertIsInstance(int32_exp, ht.DNDarray)
-        self.assertEqual(int32_exp.dtype, ht.float64)
-        self.assertTrue(ht.allclose(int32_exp, comparison))
+        self.assertEqual(int32_exp.dtype, ht.float32)
+        self.assertTrue(ht.allclose(int32_exp, ht.float32(comparison)))
 
         # exponential of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
@@ -80,8 +80,8 @@ class TestExponential(TestCase):
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_expm1 = ht.expm1(int32_tensor)
         self.assertIsInstance(int32_expm1, ht.DNDarray)
-        self.assertEqual(int32_expm1.dtype, ht.float64)
-        self.assertTrue(ht.allclose(int32_expm1, comparison))
+        self.assertEqual(int32_expm1.dtype, ht.float32)
+        self.assertTrue(ht.allclose(int32_expm1, ht.float32(comparison)))
 
         # expm1onential of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
@@ -106,7 +106,6 @@ class TestExponential(TestCase):
         float32_exp2 = ht.exp2(float32_tensor)
         self.assertIsInstance(float32_exp2, ht.DNDarray)
         self.assertEqual(float32_exp2.dtype, ht.float32)
-        self.assertEqual(float32_exp2.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_exp2, comparison.astype(ht.float32)))
 
         # exponential of float64
@@ -114,22 +113,19 @@ class TestExponential(TestCase):
         float64_exp2 = ht.exp2(float64_tensor)
         self.assertIsInstance(float64_exp2, ht.DNDarray)
         self.assertEqual(float64_exp2.dtype, ht.float64)
-        self.assertEqual(float64_exp2.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_exp2, comparison))
 
         # exponential of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_exp2 = ht.exp2(int32_tensor)
         self.assertIsInstance(int32_exp2, ht.DNDarray)
-        self.assertEqual(int32_exp2.dtype, ht.float64)
-        self.assertEqual(int32_exp2.dtype, ht.float64)
-        self.assertTrue(ht.allclose(int32_exp2, comparison))
+        self.assertEqual(int32_exp2.dtype, ht.float32)
+        self.assertTrue(ht.allclose(int32_exp2, ht.float32(comparison)))
 
         # exponential of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_exp2 = int64_tensor.exp2()
         self.assertIsInstance(int64_exp2, ht.DNDarray)
-        self.assertEqual(int64_exp2.dtype, ht.float64)
         self.assertEqual(int64_exp2.dtype, ht.float64)
         self.assertTrue(ht.allclose(int64_exp2, comparison))
 
@@ -149,7 +145,6 @@ class TestExponential(TestCase):
         float32_log = ht.log(float32_tensor)
         self.assertIsInstance(float32_log, ht.DNDarray)
         self.assertEqual(float32_log.dtype, ht.float32)
-        self.assertEqual(float32_log.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_log, comparison.astype(ht.float32)))
 
         # logarithm of float64
@@ -157,22 +152,19 @@ class TestExponential(TestCase):
         float64_log = ht.log(float64_tensor)
         self.assertIsInstance(float64_log, ht.DNDarray)
         self.assertEqual(float64_log.dtype, ht.float64)
-        self.assertEqual(float64_log.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_log, comparison))
 
         # logarithm of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(1, elements, dtype=ht.int32)
         int32_log = ht.log(int32_tensor)
         self.assertIsInstance(int32_log, ht.DNDarray)
-        self.assertEqual(int32_log.dtype, ht.float64)
-        self.assertEqual(int32_log.dtype, ht.float64)
-        self.assertTrue(ht.allclose(int32_log, comparison))
+        self.assertEqual(int32_log.dtype, ht.float32)
+        self.assertTrue(ht.allclose(int32_log, ht.float32(comparison)))
 
         # logarithm of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(1, elements, dtype=ht.int64)
         int64_log = int64_tensor.log()
         self.assertIsInstance(int64_log, ht.DNDarray)
-        self.assertEqual(int64_log.dtype, ht.float64)
         self.assertEqual(int64_log.dtype, ht.float64)
         self.assertTrue(ht.allclose(int64_log, comparison))
 
@@ -192,7 +184,6 @@ class TestExponential(TestCase):
         float32_log2 = ht.log2(float32_tensor)
         self.assertIsInstance(float32_log2, ht.DNDarray)
         self.assertEqual(float32_log2.dtype, ht.float32)
-        self.assertEqual(float32_log2.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_log2, comparison.astype(ht.float32)))
 
         # logarithm of float64
@@ -200,22 +191,19 @@ class TestExponential(TestCase):
         float64_log2 = ht.log2(float64_tensor)
         self.assertIsInstance(float64_log2, ht.DNDarray)
         self.assertEqual(float64_log2.dtype, ht.float64)
-        self.assertEqual(float64_log2.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_log2, comparison))
 
         # logarithm of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(1, elements, dtype=ht.int32)
         int32_log2 = ht.log2(int32_tensor)
         self.assertIsInstance(int32_log2, ht.DNDarray)
-        self.assertEqual(int32_log2.dtype, ht.float64)
-        self.assertEqual(int32_log2.dtype, ht.float64)
-        self.assertTrue(ht.allclose(int32_log2, comparison))
+        self.assertEqual(int32_log2.dtype, ht.float32)
+        self.assertTrue(ht.allclose(int32_log2, ht.float32(comparison)))
 
         # logarithm of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(1, elements, dtype=ht.int64)
         int64_log2 = int64_tensor.log2()
         self.assertIsInstance(int64_log2, ht.DNDarray)
-        self.assertEqual(int64_log2.dtype, ht.float64)
         self.assertEqual(int64_log2.dtype, ht.float64)
         self.assertTrue(ht.allclose(int64_log2, comparison))
 
@@ -237,7 +225,6 @@ class TestExponential(TestCase):
         float32_log10 = ht.log10(float32_tensor)
         self.assertIsInstance(float32_log10, ht.DNDarray)
         self.assertEqual(float32_log10.dtype, ht.float32)
-        self.assertEqual(float32_log10.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_log10, comparison.astype(ht.float32)))
 
         # logarithm of float64
@@ -245,22 +232,19 @@ class TestExponential(TestCase):
         float64_log10 = ht.log10(float64_tensor)
         self.assertIsInstance(float64_log10, ht.DNDarray)
         self.assertEqual(float64_log10.dtype, ht.float64)
-        self.assertEqual(float64_log10.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_log10, comparison))
 
         # logarithm of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(1, elements, dtype=ht.int32)
         int32_log10 = ht.log10(int32_tensor)
         self.assertIsInstance(int32_log10, ht.DNDarray)
-        self.assertEqual(int32_log10.dtype, ht.float64)
-        self.assertEqual(int32_log10.dtype, ht.float64)
-        self.assertTrue(ht.allclose(int32_log10, comparison))
+        self.assertEqual(int32_log10.dtype, ht.float32)
+        self.assertTrue(ht.allclose(int32_log10, ht.float32(comparison)))
 
         # logarithm of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(1, elements, dtype=ht.int64)
         int64_log10 = int64_tensor.log10()
         self.assertIsInstance(int64_log10, ht.DNDarray)
-        self.assertEqual(int64_log10.dtype, ht.float64)
         self.assertEqual(int64_log10.dtype, ht.float64)
         self.assertTrue(ht.allclose(int64_log10, comparison))
 
@@ -282,7 +266,6 @@ class TestExponential(TestCase):
         float32_log1p = ht.log1p(float32_tensor)
         self.assertIsInstance(float32_log1p, ht.DNDarray)
         self.assertEqual(float32_log1p.dtype, ht.float32)
-        self.assertEqual(float32_log1p.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_log1p, comparison.astype(ht.float32)))
 
         # logarithm of float64
@@ -290,22 +273,19 @@ class TestExponential(TestCase):
         float64_log1p = ht.log1p(float64_tensor)
         self.assertIsInstance(float64_log1p, ht.DNDarray)
         self.assertEqual(float64_log1p.dtype, ht.float64)
-        self.assertEqual(float64_log1p.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_log1p, comparison))
 
         # logarithm of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(1, elements, dtype=ht.int32)
         int32_log1p = ht.log1p(int32_tensor)
         self.assertIsInstance(int32_log1p, ht.DNDarray)
-        self.assertEqual(int32_log1p.dtype, ht.float64)
-        self.assertEqual(int32_log1p.dtype, ht.float64)
-        self.assertTrue(ht.allclose(int32_log1p, comparison))
+        self.assertEqual(int32_log1p.dtype, ht.float32)
+        self.assertTrue(ht.allclose(int32_log1p, ht.float32(comparison)))
 
         # logarithm of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(1, elements, dtype=ht.int64)
         int64_log1p = int64_tensor.log1p()
         self.assertIsInstance(int64_log1p, ht.DNDarray)
-        self.assertEqual(int64_log1p.dtype, ht.float64)
         self.assertEqual(int64_log1p.dtype, ht.float64)
         self.assertTrue(ht.allclose(int64_log1p, comparison))
 
@@ -325,7 +305,6 @@ class TestExponential(TestCase):
         float32_sqrt = ht.sqrt(float32_tensor)
         self.assertIsInstance(float32_sqrt, ht.DNDarray)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
-        self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_sqrt, comparison.astype(ht.float32), 1e-06))
 
         # square roots of float64
@@ -333,22 +312,19 @@ class TestExponential(TestCase):
         float64_sqrt = ht.sqrt(float64_tensor)
         self.assertIsInstance(float64_sqrt, ht.DNDarray)
         self.assertEqual(float64_sqrt.dtype, ht.float64)
-        self.assertEqual(float64_sqrt.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_sqrt, comparison, 1e-06))
 
         # square roots of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_sqrt = ht.sqrt(int32_tensor)
         self.assertIsInstance(int32_sqrt, ht.DNDarray)
-        self.assertEqual(int32_sqrt.dtype, ht.float64)
-        self.assertEqual(int32_sqrt.dtype, ht.float64)
-        self.assertTrue(ht.allclose(int32_sqrt, comparison, 1e-06))
+        self.assertEqual(int32_sqrt.dtype, ht.float32)
+        self.assertTrue(ht.allclose(int32_sqrt, ht.float32(comparison), 1e-06))
 
         # square roots of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_sqrt = int64_tensor.sqrt()
         self.assertIsInstance(int64_sqrt, ht.DNDarray)
-        self.assertEqual(int64_sqrt.dtype, ht.float64)
         self.assertEqual(int64_sqrt.dtype, ht.float64)
         self.assertTrue(ht.allclose(int64_sqrt, comparison, 1e-06))
 
@@ -367,27 +343,23 @@ class TestExponential(TestCase):
         float32_sqrt = ht.arange(elements, dtype=ht.float32).sqrt()
         self.assertIsInstance(float32_sqrt, ht.DNDarray)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
-        self.assertEqual(float32_sqrt.dtype, ht.float32)
         self.assertTrue(ht.allclose(float32_sqrt, comparison.astype(ht.float32), 1e-05))
 
         # square roots of float64
         float64_sqrt = ht.arange(elements, dtype=ht.float64).sqrt()
         self.assertIsInstance(float64_sqrt, ht.DNDarray)
         self.assertEqual(float64_sqrt.dtype, ht.float64)
-        self.assertEqual(float64_sqrt.dtype, ht.float64)
         self.assertTrue(ht.allclose(float64_sqrt, comparison, 1e-05))
 
         # square roots of ints, automatic conversion to intermediate floats
         int32_sqrt = ht.arange(elements, dtype=ht.int32).sqrt()
         self.assertIsInstance(int32_sqrt, ht.DNDarray)
-        self.assertEqual(int32_sqrt.dtype, ht.float64)
-        self.assertEqual(int32_sqrt.dtype, ht.float64)
-        self.assertTrue(ht.allclose(int32_sqrt, comparison, 1e-05))
+        self.assertEqual(int32_sqrt.dtype, ht.float32)
+        self.assertTrue(ht.allclose(int32_sqrt, ht.float32(comparison), 1e-05))
 
         # square roots of longs, automatic conversion to intermediate floats
         int64_sqrt = ht.arange(elements, dtype=ht.int64).sqrt()
         self.assertIsInstance(int64_sqrt, ht.DNDarray)
-        self.assertEqual(int64_sqrt.dtype, ht.float64)
         self.assertEqual(int64_sqrt.dtype, ht.float64)
         self.assertTrue(ht.allclose(int64_sqrt, comparison, 1e-05))
 

--- a/heat/core/tests/test_rounding.py
+++ b/heat/core/tests/test_rounding.py
@@ -61,7 +61,7 @@ class TestRounding(TestCase):
         # for fabs
         self.assertEqual(int8_absolute_values_fabs.dtype, ht.float32)
         self.assertEqual(int16_absolute_values_fabs.dtype, ht.float32)
-        self.assertEqual(int32_absolute_values_fabs.dtype, ht.float64)
+        self.assertEqual(int32_absolute_values_fabs.dtype, ht.float32)
         self.assertEqual(int64_absolute_values_fabs.dtype, ht.float64)
         self.assertEqual(float32_absolute_values_fabs.dtype, ht.float32)
         self.assertEqual(float64_absolute_values_fabs.dtype, ht.float64)

--- a/heat/core/tests/test_suites/basic_test.py
+++ b/heat/core/tests/test_suites/basic_test.py
@@ -136,7 +136,7 @@ class TestCase(unittest.TestCase):
             "Local shapes do not match. "
             "Got {} expected {}".format(heat_array.lshape, expected_array[slices].shape),
         )
-        local_heat_numpy = ht.resplit(heat_array, None).numpy()
+        local_heat_numpy = heat_array.numpy()
         self.assertTrue(np.allclose(local_heat_numpy, expected_array))
 
     def assert_func_equal(

--- a/heat/core/tests/test_suites/basic_test.py
+++ b/heat/core/tests/test_suites/basic_test.py
@@ -104,11 +104,6 @@ class TestCase(unittest.TestCase):
             # self.assertEqual(expected_array.device, torch.device(heat_array.device.torch_device))
             expected_array = expected_array.cpu().numpy()
 
-        # Determine with what kind of numbers we are working
-        compare_func = (
-            np.array_equal if np.issubdtype(expected_array.dtype, np.integer) else np.allclose
-        )
-
         self.assertIsInstance(
             heat_array,
             dndarray.DNDarray,
@@ -130,8 +125,7 @@ class TestCase(unittest.TestCase):
         )
 
         if not heat_array.is_balanced():
-            # Array is distributed correctly
-            # print("Heat array is unbalanced, balancing now")
+            # Array is not distributed correctly
             heat_array.balance_()
 
         split = heat_array.split
@@ -142,29 +136,8 @@ class TestCase(unittest.TestCase):
             "Local shapes do not match. "
             "Got {} expected {}".format(heat_array.lshape, expected_array[slices].shape),
         )
-        local_numpy = heat_array._DNDarray__array.cpu().numpy()
-
-        equal_res = np.array(compare_func(local_numpy, expected_array[slices]))
-
-        self.comm.Allreduce(MPI.IN_PLACE, equal_res, MPI.LAND)
-        self.assertTrue(
-            equal_res,
-            "Local tensors do not match the corresponding numpy slices. "
-            "dtype was {}, split was {}".format(heat_array.dtype, heat_array.split),
-        )
-
-        self.assertEqual(
-            local_numpy.dtype,
-            expected_array.dtype,
-            "Resulting types do not match heat: {} numpy: {}.".format(
-                heat_array.dtype, expected_array.dtype
-            ),
-        )
-
-        # Combined array is correct
-        self.assertTrue(
-            compare_func(heat_array.numpy(), expected_array), "Combined tensors do not match."
-        )
+        local_heat_numpy = ht.resplit(heat_array, None).numpy()
+        self.assertTrue(np.allclose(local_heat_numpy, expected_array))
 
     def assert_func_equal(
         self,
@@ -313,11 +286,11 @@ class TestCase(unittest.TestCase):
                 + "numpy.ndarray, torch.tensor] but is {}".format(type(tensor))
             )
 
+        dtype = types.canonical_heat_type(torch_tensor.dtype)
         np_res = numpy_func(np_array, **numpy_args)
         if not isinstance(np_res, np.ndarray):
             np_res = np.array([np_res])
 
-        dtype = types.canonical_heat_type(torch_tensor.dtype)
         for i in range(len(tensor.shape)):
             ht_array = factories.array(
                 torch_tensor, split=i, dtype=dtype, device=self.device, comm=self.comm
@@ -349,7 +322,7 @@ class TestCase(unittest.TestCase):
         else:
             raise ValueError("expected order to be 'C' or 'F', but was {}".format(order))
 
-    def __create_random_np_array(self, shape, dtype=np.float64, low=-10000, high=10000):
+    def __create_random_np_array(self, shape, dtype=np.float32, low=-10000, high=10000):
         """
         Creates a random array based on the input parameters.
         The used seed will be printed to stdout for debugging purposes.

--- a/heat/core/tests/test_suites/test_basic_test.py
+++ b/heat/core/tests/test_suites/test_basic_test.py
@@ -37,9 +37,9 @@ class TestBasicTest(TestCase):
         # Testing with random values
         shape = (5, 3, 2, 9)
 
-        self.assert_func_equal(shape, heat_func=ht.exp, numpy_func=np.exp, low=-100, high=100)
+        self.assert_func_equal(shape, heat_func=ht.exp, numpy_func=np.exp, low=-10, high=10)
 
-        self.assert_func_equal(shape, heat_func=ht.exp2, numpy_func=np.exp2, low=-100, high=100)
+        self.assert_func_equal(shape, heat_func=ht.exp2, numpy_func=np.exp2, low=-10, high=10)
 
         # np.random.randn eventually creates values < 0 which will result in math.nan.
         # Because math.nan != math.nan this would always produce an exception.
@@ -48,7 +48,7 @@ class TestBasicTest(TestCase):
         )
 
         with self.assertRaises(AssertionError):
-            self.assert_func_equal(shape, heat_func=ht.exp, numpy_func=np.exp2, low=-100, high=100)
+            self.assert_func_equal(shape, heat_func=ht.exp, numpy_func=np.exp2, low=-10, high=10)
 
         with self.assertRaises(ValueError):
             self.assert_func_equal(np.ones(shape), heat_func=np.exp, numpy_func=np.exp)

--- a/heat/core/tests/test_trigonometrics.py
+++ b/heat/core/tests/test_trigonometrics.py
@@ -33,7 +33,7 @@ class TestTrigonometrics(TestCase):
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_arctan = ht.arctan(int32_tensor)
         self.assertIsInstance(int32_arctan, ht.DNDarray)
-        self.assertEqual(int32_arctan.dtype, ht.float64)
+        self.assertEqual(int32_arctan.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_arctan._DNDarray__array.double(), comparison))
 
         # arctan of longs, automatic conversion to intermediate floats
@@ -242,7 +242,7 @@ class TestTrigonometrics(TestCase):
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_cos = ht.cos(int32_tensor)
         self.assertIsInstance(int32_cos, ht.DNDarray)
-        self.assertEqual(int32_cos.dtype, ht.float64)
+        self.assertEqual(int32_cos.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_cos._DNDarray__array.double(), comparison))
 
         # cosine of longs, automatic conversion to intermediate floats
@@ -283,7 +283,7 @@ class TestTrigonometrics(TestCase):
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_cosh = ht.cosh(int32_tensor)
         self.assertIsInstance(int32_cosh, ht.DNDarray)
-        self.assertEqual(int32_cosh.dtype, ht.float64)
+        self.assertEqual(int32_cosh.dtype, ht.float32)
         self.assertTrue(torch.allclose(float32_cosh._DNDarray__array.double(), comparison))
 
         # hyperbolic cosine of longs, automatic conversion to intermediate floats
@@ -382,7 +382,7 @@ class TestTrigonometrics(TestCase):
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_sin = ht.sin(int32_tensor)
         self.assertIsInstance(int32_sin, ht.DNDarray)
-        self.assertEqual(int32_sin.dtype, ht.float64)
+        self.assertEqual(int32_sin.dtype, ht.float32)
         self.assertTrue(torch.allclose(int32_sin._DNDarray__array.double(), comparison))
 
         # sine of longs, automatic conversion to intermediate floats
@@ -423,7 +423,7 @@ class TestTrigonometrics(TestCase):
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_sinh = ht.sinh(int32_tensor)
         self.assertIsInstance(int32_sinh, ht.DNDarray)
-        self.assertEqual(int32_sinh.dtype, ht.float64)
+        self.assertEqual(int32_sinh.dtype, ht.float32)
         self.assertTrue(torch.allclose(int32_sinh._DNDarray__array.double(), comparison))
 
         # hyperbolic sine of longs, automatic conversion to intermediate floats
@@ -464,7 +464,7 @@ class TestTrigonometrics(TestCase):
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_tan = ht.tan(int32_tensor)
         self.assertIsInstance(int32_tan, ht.DNDarray)
-        self.assertEqual(int32_tan.dtype, ht.float64)
+        self.assertEqual(int32_tan.dtype, ht.float32)
         self.assertTrue(torch.allclose(int32_tan._DNDarray__array.double(), comparison))
 
         # tangent of longs, automatic conversion to intermediate floats
@@ -505,7 +505,7 @@ class TestTrigonometrics(TestCase):
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_tanh = ht.tanh(int32_tensor)
         self.assertIsInstance(int32_tanh, ht.DNDarray)
-        self.assertEqual(int32_tanh.dtype, ht.float64)
+        self.assertEqual(int32_tanh.dtype, ht.float32)
         self.assertTrue(torch.allclose(int32_tanh._DNDarray__array.double(), comparison))
 
         # hyperbolic tangent of longs, automatic conversion to intermediate floats

--- a/heat/core/tests/test_types.py
+++ b/heat/core/tests/test_types.py
@@ -187,7 +187,7 @@ class TestTypeConversion(TestCase):
     def test_type_promotions(self):
         self.assertEqual(ht.promote_types(ht.uint8, ht.uint8), ht.uint8)
         self.assertEqual(ht.promote_types(ht.int8, ht.uint8), ht.int16)
-        self.assertEqual(ht.promote_types(ht.int32, ht.float32), ht.float64)
+        self.assertEqual(ht.promote_types(ht.int32, ht.float32), ht.float32)
         self.assertEqual(ht.promote_types("f4", ht.float), ht.float32)
         self.assertEqual(ht.promote_types(ht.bool_, "?"), ht.bool)
 

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -452,13 +452,13 @@ def can_cast(from_, to, casting="intuitive"):
         Scalar, data type or type specifier to cast from.
     to : type, str, ht.dtype
         Target type to cast to.
-    casting: str {'no', 'safe', 'same_kind', 'unsafe', "intuitive"}, optional
+    casting: str {"no", "safe", "same_kind", "unsafe", "intuitive"}, optional
         Controls the way the cast is evaluated
-            * 'no' the types may not be cast, i.e. they need to be identical
-            * 'safe' allows only casts that can preserve values with complete precision
-            * 'same_kind' safe casts are possible and down_casts within the same type family, e.g. int32 -> int8
-            * 'unsafe' means any conversion can be performed, i.e. this casting is always possible
-            * 'intuitive' allows all of the casts of safe plus casting from int32 to float32
+            * "no" the types may not be cast, i.e. they need to be identical
+            * "safe" allows only casts that can preserve values with complete precision
+            * "same_kind" safe casts are possible and down_casts within the same type family, e.g. int32 -> int8
+            * "unsafe" means any conversion can be performed, i.e. this casting is always possible
+            * "intuitive" allows all of the casts of safe plus casting from int32 to float32
 
     Returns
     -------
@@ -486,17 +486,17 @@ def can_cast(from_, to, casting="intuitive"):
     The usage of scalars is also possible
     >>> ht.can_cast(1, ht.float64)
     True
-    >>> ht.can_cast(2.0e200, 'u1')
+    >>> ht.can_cast(2.0e200, "u1")
     False
 
     can_cast supports different casting rules
-    >>> ht.can_cast('i8', 'i4', 'no')
+    >>> ht.can_cast("i8", "i4", "no")
     False
-    >>> ht.can_cast('i8', 'i4', 'safe')
+    >>> ht.can_cast("i8", "i4", "safe")
     False
-    >>> ht.can_cast('i8', 'i4', 'same_kind')
+    >>> ht.can_cast("i8", "i4", "same_kind")
     True
-    >>> ht.can_cast('i8', 'i4', 'unsafe')
+    >>> ht.can_cast("i8", "i4", "unsafe")
     True
     """
     if not isinstance(casting, str):
@@ -562,7 +562,7 @@ def promote_types(type1, type2):
     ht.uint8
     >>> ht.promote_types(ht.int8, ht.uint8)
     ht.int16
-    >>> ht.promote_types('i8', 'f4')
+    >>> ht.promote_types("i8", "f4")
     ht.float64
     """
     typecode_type1 = __type_codes[canonical_heat_type(type1)]

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -441,7 +441,7 @@ __same_kind = [
 __cast_kinds = ["no", "safe", "same_kind", "unsafe", "intuitive"]
 
 
-def can_cast(from_, to, casting="safe"):
+def can_cast(from_, to, casting="intuitive"):
     """
     Returns True if cast between data types can occur according to the casting rule. If from is a scalar or array
     scalar, also returns True if the scalar value can be cast without overflow or truncation to an integer.
@@ -452,12 +452,13 @@ def can_cast(from_, to, casting="safe"):
         Scalar, data type or type specifier to cast from.
     to : type, str, ht.dtype
         Target type to cast to.
-    casting: str {'no', 'safe', 'same_kind', 'unsafe'}, optional
+    casting: str {'no', 'safe', 'same_kind', 'unsafe', "intuitive"}, optional
         Controls the way the cast is evaluated
             * 'no' the types may not be cast, i.e. they need to be identical
             * 'safe' allows only casts that can preserve values with complete precision
             * 'same_kind' safe casts are possible and down_casts within the same type family, e.g. int32 -> int8
             * 'unsafe' means any conversion can be performed, i.e. this casting is always possible
+            * 'intuitive' allows all of the casts of safe plus casting from int32 to float32
 
     Returns
     -------

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -541,8 +541,9 @@ for i, operand_a in enumerate(__type_codes.keys()):
 
 def promote_types(type1, type2):
     """
-    Returns the data type with the smallest size and smallest scalar kind to which both type1 and type2 may be safely
-    cast. This function is symmetric.
+    Returns the data type with the smallest size and smallest scalar kind to which both type1 and type2 may be
+    intuitively cast to, where intuitive casting refers to maintaining the same bit length if possible. This
+    function is symmetric.
 
     Parameters
     ----------
@@ -560,6 +561,8 @@ def promote_types(type1, type2):
     --------
     >>> ht.promote_types(ht.uint8, ht.uint8)
     ht.uint8
+    >>> ht.promote_types(ht.int32, ht.float32)
+    ht.float32
     >>> ht.promote_types(ht.int8, ht.uint8)
     ht.int16
     >>> ht.promote_types("i8", "f4")

--- a/heat/spatial/tests/test_distances.py
+++ b/heat/spatial/tests/test_distances.py
@@ -168,7 +168,7 @@ class TestDistances(TestCase):
         B = A.astype(ht.int32)
 
         d = ht.spatial.cdist(A, B, quadratic_expansion=False)
-        result = ht.array(res, dtype=ht.float64, split=0)
+        result = ht.array(res, dtype=ht.float32, split=0)
         self.assertTrue(ht.allclose(d, result, atol=1e-5))
 
         n = ht.communication.MPI_WORLD.size
@@ -185,7 +185,7 @@ class TestDistances(TestCase):
         B = A.astype(ht.int32)
 
         d = ht.spatial.cdist(A, B, quadratic_expansion=False)
-        result = ht.array(res, dtype=ht.float64, split=0)
+        result = ht.array(res, dtype=ht.float32, split=0)
         self.assertTrue(ht.allclose(d, result, atol=1e-8))
 
         B = A.astype(ht.float64)
@@ -204,7 +204,7 @@ class TestDistances(TestCase):
 
         B = A.astype(ht.int32)
         d = ht.spatial.cdist(B, quadratic_expansion=False)
-        result = ht.array(res, dtype=ht.float64, split=0)
+        result = ht.array(res, dtype=ht.float32, split=0)
         self.assertTrue(ht.allclose(d, result, atol=1e-8))
 
         B = A.astype(ht.float64)


### PR DESCRIPTION
## Description

The dtype comparison was removed as the basic tests works with numpy, which does safe casting instead of intuitive casting. other changes were adjustments for types

Issue/s resolved: 

## Changes proposed:
- change from safe casting to intuitive casting (this come with the possibility of loss during the conversion)
-
-
-

## Type of change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
