### PR TITLE
added balance to printing._torch_data for printing of unbalanced arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,19 @@
 - [#573](https://github.com/helmholtz-analytics/heat/pull/573) Bugfix: matmul fixes: early out for 2 vectors, remainders not added if inner block is 1 for split 10 case
 - [#575](https://github.com/helmholtz-analytics/heat/pull/558) Bugfix: Binary operations use proper type casting
 - [#575](https://github.com/helmholtz-analytics/heat/pull/558) Bugfix: `where` and `cov` convert ints to floats when given as parameters
-- [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add ndim property in dndarray
+- [#577](https://github.com/helmholtz-analytics/heat/pull/577) Add `ndim` property in dndarray
 - [#578](https://github.com/helmholtz-analytics/heat/pull/578) Bugfix: Bad variable in reshape
-- [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: fliplr()
-- [#581](https://github.com/helmholtz-analytics/heat/pull/581) New Feature: DNDarray.tolist()
-- [#583](https://github.com/helmholtz-analytics/heat/pull/583) New feature: rot90()
-- [#593](https://github.com/helmholtz-analytics/heat/pull/593) New feature arctan2()
+- [#580](https://github.com/helmholtz-analytics/heat/pull/580) New feature: `fliplr()`
+- [#581](https://github.com/helmholtz-analytics/heat/pull/581) New Feature: `DNDarray.tolist()`
+- [#583](https://github.com/helmholtz-analytics/heat/pull/583) New feature: `rot90()`
+- [#593](https://github.com/helmholtz-analytics/heat/pull/593) New feature `arctan2()`
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) New feature: Advanced indexing
 - [#594](https://github.com/helmholtz-analytics/heat/pull/594) Bugfix: getitem and setitem memory consumption heavily reduced
-- [#596](https://github.com/helmholtz-analytics/heat/pull/596) New feature: outer()
+- [#596](https://github.com/helmholtz-analytics/heat/pull/596) New feature: `outer()`
 - [#598](https://github.com/helmholtz-analytics/heat/pull/598) Type casting changed to PyTorch style casting (i.e. intuitive casting) instead of safe casting
-- [#600](https://github.com/helmholtz-analytics/heat/pull/600) New feature: shape()
+- [#600](https://github.com/helmholtz-analytics/heat/pull/600) New feature: `shape()`
 - [#614](https://github.com/helmholtz-analytics/heat/pull/614) New feature: printing of DNDarrays and ``__repr__`` and ``__str__`` functions
+- [#618](https://github.com/helmholtz-analytics/heat/pull/618) Printing of unbalnced DNDarrays added
 
 # v0.4.0
 

--- a/heat/core/printing.py
+++ b/heat/core/printing.py
@@ -68,8 +68,9 @@ def __str__(dndarray):
     if dndarray.comm.rank != 0:
         return ""
 
-    return "{}({}, dtype=ht.{}, device={}, split={})".format(
-        __PREFIX, tensor_string, dndarray.dtype.__name__, dndarray.device, dndarray.split
+    return (
+        f"{__PREFIX}({tensor_string}, dtype=ht.{dndarray.dtype.__name__}, "
+        f"device={dndarray.device}, split={dndarray.split})"
     )
 
 
@@ -84,6 +85,8 @@ def _torch_data(dndarray, summarize):
     summarize: bool
         Flag indicating whether to print the full data or summarized, i.e. ellipsed, version of the data.
     """
+    if not dndarray.is_balanced():
+        dndarray.balance_()
     # data is not split, we can use it as is
     if dndarray.split is None or dndarray.comm.size == 1:
         data = dndarray._DNDarray__array

--- a/heat/core/tests/test_printing.py
+++ b/heat/core/tests/test_printing.py
@@ -97,6 +97,18 @@ class TestPrinting(TestCase):
         if tensor.comm.rank == 0:
             self.assertEqual(comparison, __str)
 
+    def test_unbalanced(self):
+        dndarray = ht.arange(2 * 3 * 4, split=0).reshape((2, 3, 4))
+        if dndarray.comm.size == 2:
+            comparison = (
+                "DNDarray([[ 0,  1,  2,  3],\n"
+                "          [ 4,  5,  6,  7],\n"
+                "          [ 8,  9, 10, 11]], dtype=ht.int32, device=cpu:0, split=0)"
+            )
+            __str = str(dndarray[0])
+            if dndarray.comm.rank == 0:
+                self.assertEqual(comparison, __str)
+
     def test_unsplit_below_threshold(self):
         dndarray = ht.arange(2 * 3 * 4).reshape((2, 3, 4))
         comparison = (


### PR DESCRIPTION
## Description
added balance to printing to allow for unbalanced arrays to be printed. 

Issue/s resolved: #617 

## Changes proposed:
- balance added to print

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Due Diligence

- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
