### PR TITLE
Bug/median

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 - [#614](https://github.com/helmholtz-analytics/heat/pull/614) New feature: printing of DNDarrays and ``__repr__`` and ``__str__`` functions
 - [#615](https://github.com/helmholtz-analytics/heat/pull/615) New feature: `skew()`
 - [#615](https://github.com/helmholtz-analytics/heat/pull/615) New feature: `kurtosis()`
-- [#618](https://github.com/helmholtz-analytics/heat/pull/618) Printing of unbalnced DNDarrays added
+- [#618](https://github.com/helmholtz-analytics/heat/pull/618) Printing of unbalanced DNDarrays added
+- [#624](https://github.com/helmholtz-analytics/heat/pull/624) Bugfix: distributed median() indexing and casting
 
 # v0.4.0
 

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -1380,13 +1380,13 @@ def percentile(x, q, axis=None, out=None, interpolation="linear", keepdim=False)
         # leave fractional indices, interpolate linearly
         pass
     elif interpolation == "lower":
-        t_indices = t_indices.floor().type(t_perc_dtype)
+        t_indices = t_indices.floor().type(torch.int)
     elif interpolation == "higher":
-        t_indices = t_indices.ceil().type(t_perc_dtype)
+        t_indices = t_indices.ceil().type(torch.int)
     elif interpolation == "midpoint":
         t_indices = 0.5 * (t_indices.floor() + t_indices.ceil())
     elif interpolation == "nearest":
-        t_indices = t_indices.round().type(t_perc_dtype)
+        t_indices = t_indices.round().type(torch.int)
     else:
         raise ValueError(
             "Invalid interpolation method. Interpolation can be 'lower', 'higher', 'midpoint', 'nearest', or 'linear'."

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -1407,14 +1407,14 @@ def percentile(x, q, axis=None, out=None, interpolation="linear", keepdim=False)
 
         if split == axis:
             # map percentile location: which q on what rank
-            t_indices_map = torch.ones((size, nperc), dtype=t_perc_dtype, device=t_q.device) * -1
-            t_local_indices = torch.ones((1, nperc), dtype=t_perc_dtype, device=t_q.device) * -1
+            t_indices_map = torch.ones((size, nperc), dtype=t_indices.dtype, device=t_q.device) * -1
+            t_local_indices = torch.ones((1, nperc), dtype=t_indices.dtype, device=t_q.device) * -1
             offset, _, chunk = x.comm.chunk(gshape, split)
             chunk_start = chunk[split].start
             chunk_stop = chunk[split].stop
             t_ind_on_rank = t_indices[(t_indices < chunk_stop) & (t_indices >= chunk_start)]
             for el_id, el in enumerate(t_ind_on_rank):
-                t_which_q = torch.where(t_indices == el)[0]
+                t_which_q = torch.where(t_indices == el)
                 t_local_indices[:, t_which_q] = el - offset
             x.comm.Allgather(t_local_indices, t_indices_map)
 

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -971,7 +971,13 @@ class TestStatistics(TestCase):
         q = 100
         p_np = np.percentile(x_np, q, axis=0)
         p_ht = ht.percentile(x_ht, q, axis=0)
-        self.assertAlmostEqual(p_ht.numpy().all(), p_np.all())
+        self.assertTrue((p_ht.numpy() == p_np).all())
+
+        # test median (q = 50)
+        q = 50
+        p_np = np.percentile(x_np, q, axis=0)
+        p_ht = ht.median(x_ht_split0, axis=0)
+        self.assertTrue((p_ht.numpy() == p_np).all())
 
         # test list q and writing to output buffer
         q = [0.1, 2.3, 15.9, 50.0, 84.1, 97.7, 99.9]


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
`ht.median(a, axis)` (aka `ht.percentile(a, q=50, axis)`) was returning erroneous results, or sometimes an empty DNDarray, when `a.split == axis` and the number of mpi processes was larger than 2.

Problems:
 - line 1437, `perc_chunk` was being calculated based on the wrong rank value, which led to `perc_slice` being off and percentile() returning wrong (or "empty") values. Fixed.
- indices on ranks > 0  not being corrected for the presence of halo data. This affects the result when the relevant data aren't on rank 0, which is always the case for median() on more than 2 processes. Fixed at lines 1441 and ff.

Not occurring in #623 but also a problem: 
 - dtype of output was `promote_type(data.dtype, q.dtype)`, but we might have integer data and integer q (e.g. q=50) and still need a float result. Fixed at lines 1326-1336.



Issue/s resolved: #623 

## Changes proposed:
- see above, plus:
- implemented explicit test for median in test_percentile()

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue)
## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
