### PR TITLE
added aliases for arc___ functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#615](https://github.com/helmholtz-analytics/heat/pull/615) New feature: `kurtosis()`
 - [#618](https://github.com/helmholtz-analytics/heat/pull/618) Printing of unbalanced DNDarrays added
 - [#624](https://github.com/helmholtz-analytics/heat/pull/624) Bugfix: distributed median() indexing and casting
+- [#629](https://github.com/helmholtz-analytics/heat/pull/629) New features: `asin`, `acos`, `atan`, `atan2`
 
 # v0.4.0
 

--- a/heat/core/tests/test_trigonometrics.py
+++ b/heat/core/tests/test_trigonometrics.py
@@ -6,6 +6,74 @@ from .test_suites.basic_test import TestCase
 
 
 class TestTrigonometrics(TestCase):
+    def test_arccos(self):
+        # base elements
+        elements = [-1.0, -0.83, -0.12, 0.0, 0.24, 0.67, 1.0]
+        comparison = torch.tensor(
+            elements, dtype=torch.float64, device=self.device.torch_device
+        ).acos()
+
+        # arccos of float32
+        float32_tensor = ht.array(elements, dtype=ht.float32)
+        float32_arccos = ht.acos(float32_tensor)
+        self.assertIsInstance(float32_arccos, ht.DNDarray)
+        self.assertEqual(float32_arccos.dtype, ht.float32)
+        self.assertTrue(torch.allclose(float32_arccos._DNDarray__array.double(), comparison))
+
+        # arccos of float64
+        float64_tensor = ht.array(elements, dtype=ht.float64)
+        float64_arccos = ht.arccos(float64_tensor)
+        self.assertIsInstance(float64_arccos, ht.DNDarray)
+        self.assertEqual(float64_arccos.dtype, ht.float64)
+        self.assertTrue(torch.allclose(float64_arccos._DNDarray__array.double(), comparison))
+
+        # arccos of value out of domain
+        nan_tensor = ht.array([1.2])
+        nan_arccos = ht.arccos(nan_tensor)
+        self.assertIsInstance(float64_arccos, ht.DNDarray)
+        self.assertEqual(nan_arccos.dtype, ht.float32)
+        self.assertTrue(math.isnan(nan_arccos._DNDarray__array.item()))
+
+        # check exceptions
+        with self.assertRaises(TypeError):
+            ht.arccos([1, 2, 3])
+        with self.assertRaises(TypeError):
+            ht.arccos("hello world")
+
+    def test_arcsin(self):
+        # base elements
+        elements = [-1.0, -0.83, -0.12, 0.0, 0.24, 0.67, 1.0]
+        comparison = torch.tensor(
+            elements, dtype=torch.float64, device=self.device.torch_device
+        ).asin()
+
+        # arcsin of float32
+        float32_tensor = ht.array(elements, dtype=ht.float32)
+        float32_arcsin = ht.asin(float32_tensor)
+        self.assertIsInstance(float32_arcsin, ht.DNDarray)
+        self.assertEqual(float32_arcsin.dtype, ht.float32)
+        self.assertTrue(torch.allclose(float32_arcsin._DNDarray__array.double(), comparison))
+
+        # arcsin of float64
+        float64_tensor = ht.array(elements, dtype=ht.float64)
+        float64_arcsin = ht.arcsin(float64_tensor)
+        self.assertIsInstance(float64_arcsin, ht.DNDarray)
+        self.assertEqual(float64_arcsin.dtype, ht.float64)
+        self.assertTrue(torch.allclose(float64_arcsin._DNDarray__array.double(), comparison))
+
+        # arcsin of value out of domain
+        nan_tensor = ht.array([1.2])
+        nan_arcsin = ht.arcsin(nan_tensor)
+        self.assertIsInstance(float64_arcsin, ht.DNDarray)
+        self.assertEqual(nan_arcsin.dtype, ht.float32)
+        self.assertTrue(math.isnan(nan_arcsin._DNDarray__array.item()))
+
+        # check exceptions
+        with self.assertRaises(TypeError):
+            ht.arcsin([1, 2, 3])
+        with self.assertRaises(TypeError):
+            ht.arcsin("hello world")
+
     def test_arctan(self):
         # base elements
         elements = 30
@@ -36,7 +104,7 @@ class TestTrigonometrics(TestCase):
 
         # arctan of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
-        int64_arctan = ht.arctan(int64_tensor)
+        int64_arctan = ht.atan(int64_tensor)
         self.assertIsInstance(int64_arctan, ht.DNDarray)
         self.assertEqual(int64_arctan.dtype, ht.float64)
         self.assertTrue(torch.allclose(int64_arctan._DNDarray__array.double(), comparison))
@@ -62,7 +130,7 @@ class TestTrigonometrics(TestCase):
         float64_x = torch.randn(30, dtype=torch.float64, device=self.device.torch_device)
 
         float64_comparison = torch.atan2(float64_y, float64_x)
-        float64_arctan2 = ht.arctan2(ht.array(float64_y), ht.array(float64_x))
+        float64_arctan2 = ht.atan2(ht.array(float64_y), ht.array(float64_x))
 
         self.assertIsInstance(float64_arctan2, ht.DNDarray)
         self.assertEqual(float64_arctan2.dtype, ht.float64)
@@ -88,74 +156,6 @@ class TestTrigonometrics(TestCase):
         self.assertIsInstance(int16_arctan2, ht.DNDarray)
         self.assertEqual(int16_arctan2.dtype, ht.float32)
         self.assertTrue(ht.allclose(int16_arctan2, int16_comparison))
-
-    def test_arcsin(self):
-        # base elements
-        elements = [-1.0, -0.83, -0.12, 0.0, 0.24, 0.67, 1.0]
-        comparison = torch.tensor(
-            elements, dtype=torch.float64, device=self.device.torch_device
-        ).asin()
-
-        # arcsin of float32
-        float32_tensor = ht.array(elements, dtype=ht.float32)
-        float32_arcsin = ht.arcsin(float32_tensor)
-        self.assertIsInstance(float32_arcsin, ht.DNDarray)
-        self.assertEqual(float32_arcsin.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arcsin._DNDarray__array.double(), comparison))
-
-        # arcsin of float64
-        float64_tensor = ht.array(elements, dtype=ht.float64)
-        float64_arcsin = ht.arcsin(float64_tensor)
-        self.assertIsInstance(float64_arcsin, ht.DNDarray)
-        self.assertEqual(float64_arcsin.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_arcsin._DNDarray__array.double(), comparison))
-
-        # arcsin of value out of domain
-        nan_tensor = ht.array([1.2])
-        nan_arcsin = ht.arcsin(nan_tensor)
-        self.assertIsInstance(float64_arcsin, ht.DNDarray)
-        self.assertEqual(nan_arcsin.dtype, ht.float32)
-        self.assertTrue(math.isnan(nan_arcsin._DNDarray__array.item()))
-
-        # check exceptions
-        with self.assertRaises(TypeError):
-            ht.arcsin([1, 2, 3])
-        with self.assertRaises(TypeError):
-            ht.arcsin("hello world")
-
-    def test_arccos(self):
-        # base elements
-        elements = [-1.0, -0.83, -0.12, 0.0, 0.24, 0.67, 1.0]
-        comparison = torch.tensor(
-            elements, dtype=torch.float64, device=self.device.torch_device
-        ).acos()
-
-        # arccos of float32
-        float32_tensor = ht.array(elements, dtype=ht.float32)
-        float32_arccos = ht.arccos(float32_tensor)
-        self.assertIsInstance(float32_arccos, ht.DNDarray)
-        self.assertEqual(float32_arccos.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arccos._DNDarray__array.double(), comparison))
-
-        # arccos of float64
-        float64_tensor = ht.array(elements, dtype=ht.float64)
-        float64_arccos = ht.arccos(float64_tensor)
-        self.assertIsInstance(float64_arccos, ht.DNDarray)
-        self.assertEqual(float64_arccos.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_arccos._DNDarray__array.double(), comparison))
-
-        # arccos of value out of domain
-        nan_tensor = ht.array([1.2])
-        nan_arccos = ht.arccos(nan_tensor)
-        self.assertIsInstance(float64_arccos, ht.DNDarray)
-        self.assertEqual(nan_arccos.dtype, ht.float32)
-        self.assertTrue(math.isnan(nan_arccos._DNDarray__array.item()))
-
-        # check exceptions
-        with self.assertRaises(TypeError):
-            ht.arccos([1, 2, 3])
-        with self.assertRaises(TypeError):
-            ht.arccos("hello world")
 
     def test_degrees(self):
         # base elements

--- a/heat/core/trigonometrics.py
+++ b/heat/core/trigonometrics.py
@@ -6,6 +6,10 @@ from . import types
 
 
 __all__ = [
+    "acos",
+    "asin",
+    "atan",
+    "atan2",
     "arccos",
     "arcsin",
     "arctan",
@@ -49,6 +53,10 @@ def arccos(x, out=None):
     return local_op(torch.acos, x, out)
 
 
+acos = arccos
+acos.__doc__ = arccos.__doc__
+
+
 def arcsin(x, out=None):
     """
     Return the trigonometric arcsin, element-wise.
@@ -73,6 +81,10 @@ def arcsin(x, out=None):
     tensor([-1.5708,  0.0000,  0.9791])
     """
     return local_op(torch.asin, x, out)
+
+
+asin = arcsin
+asin.__doc__ = arcsin.__doc__
 
 
 def arctan(x, out=None):
@@ -100,6 +112,10 @@ def arctan(x, out=None):
        dtype=torch.float64)
     """
     return local_op(torch.atan, x, out)
+
+
+atan = arctan
+atan.__doc__ = arctan.__doc__
 
 
 def arctan2(x1, x2):
@@ -130,6 +146,10 @@ def arctan2(x1, x2):
     x2 = x2.astype(types.promote_types(x2.dtype, types.float))
 
     return binary_op(torch.atan2, x1, x2)
+
+
+atan2 = arctan2
+atan2.__doc__ = arctan2.__doc__
 
 
 def cos(x, out=None):


### PR DESCRIPTION
## Description

aliases added, tests rearranged into alphabetic order in test_trigonmetrics

Issue/s resolved: #628 

## Changes proposed:
- added aliases for arctan -> atan, arctan2 -> atan2, arccos -> acos, arcsin -> asin
- ordered tests in test_trig...

## Type of change

- New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
