### PR TITLE
added resplit to None for slicing with DNDarrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [#620](https://github.com/helmholtz-analytics/heat/pull/620) New feature: KNN
 - [#624](https://github.com/helmholtz-analytics/heat/pull/624) Bugfix: distributed median() indexing and casting
 - [#629](https://github.com/helmholtz-analytics/heat/pull/629) New features: `asin`, `acos`, `atan`, `atan2`
+- [#635](https://github.com/helmholtz-analytics/heat/pull/635) `DNDarray.__getitem__` balances and resplits the given key to None if the key is a DNDarray
 
 # v0.4.0
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1408,6 +1408,8 @@ class DNDarray:
             """ if the key is a DNDarray and it has as many dimensions as self, then each of the entries in the 0th
                 dim refer to a single element. To handle this, the key is split into the torch tensors for each dimension.
                 This signals that advanced indexing is to be used. """
+            key.balance_()
+            key = manipulations.resplit(key.copy(), None)
             lkey = [slice(None, None, None)] * self.ndim
             kgshape_flag = True
             kgshape = [0] * len(self.gshape)
@@ -1425,6 +1427,7 @@ class DNDarray:
                 lists mean advanced indexing will be used"""
             h = [slice(None, None, None)] * self.ndim
             if isinstance(key, DNDarray):
+                key = manipulations.resplit(key)
                 h[0] = key._DNDarray__array.tolist()
             elif isinstance(key, torch.Tensor):
                 h[0] = key.tolist()

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1409,7 +1409,7 @@ class DNDarray:
                 dim refer to a single element. To handle this, the key is split into the torch tensors for each dimension.
                 This signals that advanced indexing is to be used. """
             key.balance_()
-            key = manipulations.resplit(key.copy(), None)
+            key = manipulations.resplit(key.copy())
             lkey = [slice(None, None, None)] * self.ndim
             kgshape_flag = True
             kgshape = [0] * len(self.gshape)
@@ -1427,7 +1427,8 @@ class DNDarray:
                 lists mean advanced indexing will be used"""
             h = [slice(None, None, None)] * self.ndim
             if isinstance(key, DNDarray):
-                key = manipulations.resplit(key)
+                key.balance_()
+                key = manipulations.resplit(key.copy())
                 h[0] = key._DNDarray__array.tolist()
             elif isinstance(key, torch.Tensor):
                 h[0] = key.tolist()


### PR DESCRIPTION
## Description

Update to slicing with DNDarrays

Issue/s resolved: n/a

## Changes proposed:
- resplit to split None if the key given to the DNDarray getitem is itself a DNDarray

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
yes, possibly. If a function was working with unbalanced DNDarrays then this slicing scheme would cause issues
