### PR TITLE
Fixed torch 1.6.0 printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@
 - [#633](https://github.com/helmholtz-analytics/heat/pull/633) Documentation: updated contributing.md
 - [#635](https://github.com/helmholtz-analytics/heat/pull/635) `DNDarray.__getitem__` balances and resplits the given key to None if the key is a DNDarray
 - [#638](https://github.com/helmholtz-analytics/heat/pull/638) Fix: arange returns float32 with single input of type float & update skipped device tests
-- [#639](https://github.com/helmholtz-analytics/heat/pull/639) Bufix: balanced array in demo_knn, changed behaviour of knn
+- [#639](https://github.com/helmholtz-analytics/heat/pull/639) Bugfix: balanced array in demo_knn, changed behaviour of knn
+- [#648](https://github.com/helmholtz-analytics/heat/pull/648) Bugfix: tensor printing with PyTorch 1.6.0
 
 # v0.4.0
 

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -446,8 +446,8 @@ def matmul(a, b, allow_resplit=False):
         # need to send b here and not a
         #   the rows on 'a' are complete, and the columns of 'b' are split
         # locations of the remainders in b
-        b_rem_locs0 = (rem_map[:, 1, 0] == 1).nonzero()
-        a_rem_locs0 = (rem_map[:, 0, 0] == 1).nonzero()
+        b_rem_locs0 = torch.nonzero(rem_map[:, 1, 0] == 1, as_tuple=False)
+        a_rem_locs0 = torch.nonzero(rem_map[:, 0, 0] == 1, as_tuple=False)
         # remainders for a in the
         a_node_rem_s0 = a._DNDarray__array[:mB, kB : (kB + 1) * b_rem_locs0.numel() : kB + 1]
         b_rem = torch.empty(
@@ -570,8 +570,8 @@ def matmul(a, b, allow_resplit=False):
         # for this case, a is sent to b
         #   this is because 'b' has complete columns and the rows of 'a' are split
         # locations of the remainders in b
-        b_rem_locs1 = (rem_map[:, 1, 1] == 1).nonzero()
-        a_rem_locs1 = (rem_map[:, 0, 1] == 1).nonzero()
+        b_rem_locs1 = torch.nonzero(rem_map[:, 1, 1] == 1, as_tuple=False)
+        a_rem_locs1 = torch.nonzero(rem_map[:, 0, 1] == 1, as_tuple=False)
         b_node_rem_s1 = b._DNDarray__array[
             kB : (kB + 1) * a_rem_locs1.numel() : kB + 1, :nB
         ]  # remainders for a in the
@@ -736,9 +736,9 @@ def matmul(a, b, allow_resplit=False):
     elif split_10_flag:
         # todo: this may create the full matrix on evey process, issue #360
         # for this case, only a sum is needed at the end
-        a_rem_locs1 = (rem_map[:, 0, 1] == 1).nonzero()
+        a_rem_locs1 = torch.nonzero(rem_map[:, 0, 1] == 1, as_tuple=False)
         # locations of the remainders in b
-        b_rem_locs0 = (rem_map[:, 1, 0] == 1).nonzero()
+        b_rem_locs0 = torch.nonzero(rem_map[:, 1, 0] == 1, as_tuple=False)
         res = torch.zeros(
             (a.gshape[-2], b.gshape[1]), dtype=c_type.torch_type(), device=c.device.torch_device
         )

--- a/heat/core/printing.py
+++ b/heat/core/printing.py
@@ -168,4 +168,11 @@ def _tensor_str(dndarray, indent):
     torch_data = _torch_data(dndarray, summarize)
     formatter = torch._tensor_str._Formatter(torch_data)
 
-    return torch._tensor_str._tensor_str_with_formatter(torch_data, indent, formatter, summarize)
+    if int(torch.__version__[2]) <= 5:
+        return torch._tensor_str._tensor_str_with_formatter(
+            torch_data, indent, formatter, summarize
+        )
+    else:
+        return torch._tensor_str._tensor_str_with_formatter(
+            torch_data, indent, summarize, formatter
+        )

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -99,25 +99,6 @@ def argmax(x, axis=None, out=None, **kwargs):
     if axis is not None and not isinstance(axis, int):
         raise TypeError("axis must be None or int, but was {}".format(type(axis)))
 
-    if not x.is_distributed():
-        keep_dim = kwargs.get("keepdim")
-        if keep_dim is None:
-            keep_dim = False
-        axis = stride_tricks.sanitize_axis(x.shape, axis)
-        ret = factories.array(torch.argmax(x._DNDarray__array, axis, keepdim=keep_dim))
-        if ret.gnumel == 1:
-            ret = manipulations.expand_dims(ret, 0)
-        if out is not None:
-            if out.shape != ret.shape:
-                raise ValueError(
-                    "Expecting output buffer of shape {}, got {}".format(ret.shape, out.shape)
-                )
-            out._DNDarray__array.storage().copy_(ret._DNDarray__array.storage())
-            out._DNDarray__array = out._DNDarray__array.type(torch.int64)
-            out._DNDarray__dtype = types.int64
-            return out
-        return ret
-
     # perform the global reduction
     smallest_value = -constants.sanitize_infinity(x._DNDarray__array.dtype)
     reduced_result = _operations.__reduce_op(
@@ -218,25 +199,6 @@ def argmin(x, axis=None, out=None, **kwargs):
     # axis sanitation
     if axis is not None and not isinstance(axis, int):
         raise TypeError("axis must be None or int, but was {}".format(type(axis)))
-
-    if not x.is_distributed():
-        keep_dim = kwargs.get("keepdim")
-        if keep_dim is None:
-            keep_dim = False
-        axis = stride_tricks.sanitize_axis(x.shape, axis)
-        ret = factories.array(torch.argmin(x._DNDarray__array, axis, keepdim=keep_dim))
-        if ret.gnumel == 1:
-            ret = manipulations.expand_dims(ret, 0)
-        if out is not None:
-            if out.shape != ret.shape:
-                raise ValueError(
-                    "Expecting output buffer of shape {}, got {}".format(ret.shape, out.shape)
-                )
-            out._DNDarray__array.storage().copy_(ret._DNDarray__array.storage())
-            out._DNDarray__array = out._DNDarray__array.type(torch.int64)
-            out._DNDarray__dtype = types.int64
-            return out
-        return ret
 
     # perform the global reduction
     largest_value = constants.sanitize_infinity(x._DNDarray__array.dtype)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -57,7 +57,7 @@ class TestStatistics(TestCase):
         self.assertEqual(result._DNDarray__array.dtype, torch.int64)
         self.assertEqual(result.shape, (ht.MPI_WORLD.size * 4,))
         self.assertEqual(result.lshape, (4,))
-        self.assertEqual(result.split, 0)
+        self.assertEqual(result.split, 0 if ht.MPI_WORLD.size > 1 else None)
         self.assertTrue((result._DNDarray__array == expected).all())
 
         # 2D split tensor, across the axis
@@ -147,7 +147,7 @@ class TestStatistics(TestCase):
         self.assertEqual(result._DNDarray__array.dtype, torch.int64)
         self.assertEqual(result.shape, (ht.MPI_WORLD.size * 4,))
         self.assertEqual(result.lshape, (4,))
-        self.assertEqual(result.split, 0)
+        self.assertEqual(result.split, 0 if ht.MPI_WORLD.size > 1 else None)
         self.assertTrue((result._DNDarray__array == expected).all())
 
         # 2D split tensor, across the axis


### PR DESCRIPTION
## Description

Fixed tensor printing issues with torch 1.6.0

Issue/s resolved: #647

## Changes proposed:
- Torch 1.6.0 switches the order of two parameters, respective version check implemented and call-through with corresponding parameter order

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no