### PR TITLE
mm checks and correct int dtypes if A is on the gpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [#652](https://github.com/helmholtz-analytics/heat/pull/652) Feature: benchmark scripts and jobscript generation
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Printing above threshold gathers the data without a buffer now
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Bugfixes: Update unittests argmax & argmin + force index order in mpi_argmax & mpi_argmin. Add device parameter for tensor creation in dndarray.get_halo().
+- [#658](https://github.com/helmholtz-analytics/heat/pull/658) Bugfix: `matmul` on GPU will cast away from `int`s to `float`s for the operation and cast back upon its completion. This may result in numerical inaccuracies for very large `int64` DNDarrays
 - [#659](https://github.com/helmholtz-analytics/heat/pull/659) New feature: `random.permutation` + `random.randperm`
 - [#662](https://github.com/helmholtz-analytics/heat/pull/662) Bugfixes: minimum() and maximum() split semantics, scalar input, different input dtype
 - [#664](https://github.com/helmholtz-analytics/heat/pull/664) New feature / enhancement: `random.random_sample`, `random.random`, `random.sample`, `random.ranf`, `random.random_integer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
 - [#652](https://github.com/helmholtz-analytics/heat/pull/652) Feature: benchmark scripts and jobscript generation
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Printing above threshold gathers the data without a buffer now
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Bugfixes: Update unittests argmax & argmin + force index order in mpi_argmax & mpi_argmin. Add device parameter for tensor creation in dndarray.get_halo().
+- [#659](https://github.com/helmholtz-analytics/heat/pull/659) New feature: distributed `random.permutation` + `random.randperm`
+- [#662](https://github.com/helmholtz-analytics/heat/pull/662) Bugfixes: `minimum()` and `maximum()` split semantics, scalar input, different input dtype
+- [#664](https://github.com/helmholtz-analytics/heat/pull/664) New feature / enhancement: distributed `random.random_sample`, `random.random`, `random.sample`, `random.ranf`, `random.random_integer`
+- [#666](https://github.com/helmholtz-analytics/heat/pull/666) New feature: distributed prepend/append for `diff()`.
 - [#667](https://github.com/helmholtz-analytics/heat/pull/667) Enhancement `reshape`: rename axis parameter
 - [#674](https://github.com/helmholtz-analytics/heat/pull/674) New feature: `repeat`
 - [#670](https://github.com/helmholtz-analytics/heat/pull/670) New Feature: distributed `bincount()`

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -147,6 +147,12 @@ def matmul(a, b, allow_resplit=False):
 
     # determine if a larger type is needed for c
     c_type = types.promote_types(a.dtype, b.dtype)
+    if str(a.device)[:3] == "gpu":
+        if c_type in [types.uint8, types.int8, types.int16, types.int32]:
+            c_type = types.float32
+        elif c_type == types.int64:
+            c_type = types.float64
+
     if a.dtype != c_type:
         a = c_type(a, device=a.device)
     if b.dtype != c_type:

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -564,7 +564,7 @@ def matmul(a, b, allow_resplit=False):
             c_loc = c.larray.squeeze()
             if c_loc.nelement() == 1:
                 c_loc = torch.tensor(c_loc, device=tdev)
-                
+
             c = factories.array(c_loc, is_split=0, device=a.device)
         if gpu_int_flag:
             c = og_type(c, device=a.device)
@@ -576,7 +576,7 @@ def matmul(a, b, allow_resplit=False):
         # locations of the remainders in b
         b_rem_locs1 = torch.nonzero(rem_map[:, 1, 1] == 1, as_tuple=False)
         a_rem_locs1 = torch.nonzero(rem_map[:, 0, 1] == 1, as_tuple=False)
-        b_node_rem_s1 = b.larray[kB : (kB + 1) * a_rem_locs1.numel() : kB + 1, :nB]  
+        b_node_rem_s1 = b.larray[kB : (kB + 1) * a_rem_locs1.numel() : kB + 1, :nB]
         # b_node_rem_s1 -> remainders for a in the
 
         a_rem = torch.empty(

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -381,6 +381,19 @@ class TestLinalgBasics(TestCase):
             self.assertEqual(ret00.dtype, ht.float)
             self.assertEqual(ret00.split, None)
 
+            a = ht.ones((n, m), split=None, dtype=ht.int64)
+            b = ht.ones((j), split=None, dtype=ht.int64)
+            a[0] = ht.arange(1, m + 1, dtype=ht.int64)
+            a[:, -1] = ht.arange(1, n + 1, dtype=ht.int64)
+            ret00 = ht.matmul(a, b)
+
+            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            self.assertTrue(ht.equal(ret00, ret_comp))
+            self.assertIsInstance(ret00, ht.DNDarray)
+            self.assertEqual(ret00.shape, (n,))
+            self.assertEqual(ret00.dtype, ht.int64)
+            self.assertEqual(ret00.split, None)
+
             # splits 0 None
             a = ht.ones((n, m), split=0)
             b = ht.ones((j), split=None)
@@ -393,6 +406,19 @@ class TestLinalgBasics(TestCase):
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n,))
             self.assertEqual(ret00.dtype, ht.float)
+            self.assertEqual(ret00.split, 0)
+
+            a = ht.ones((n, m), split=0, dtype=ht.int64)
+            b = ht.ones((j), split=None, dtype=ht.int64)
+            a[0] = ht.arange(1, m + 1, dtype=ht.int64)
+            a[:, -1] = ht.arange(1, n + 1, dtype=ht.int64)
+            ret00 = ht.matmul(a, b)
+
+            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            self.assertTrue(ht.equal(ret00, ret_comp))
+            self.assertIsInstance(ret00, ht.DNDarray)
+            self.assertEqual(ret00.shape, (n,))
+            self.assertEqual(ret00.dtype, ht.int64)
             self.assertEqual(ret00.split, 0)
 
             # splits 1 None
@@ -409,6 +435,19 @@ class TestLinalgBasics(TestCase):
             self.assertEqual(ret00.dtype, ht.float)
             self.assertEqual(ret00.split, 0)
 
+            a = ht.ones((n, m), split=1, dtype=ht.int64)
+            b = ht.ones((j), split=None, dtype=ht.int64)
+            a[0] = ht.arange(1, m + 1, dtype=ht.int64)
+            a[:, -1] = ht.arange(1, n + 1, dtype=ht.int64)
+            ret00 = ht.matmul(a, b)
+
+            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            self.assertTrue(ht.equal(ret00, ret_comp))
+            self.assertIsInstance(ret00, ht.DNDarray)
+            self.assertEqual(ret00.shape, (n,))
+            self.assertEqual(ret00.dtype, ht.int64)
+            self.assertEqual(ret00.split, 0)
+
             # splits None 0
             a = ht.ones((n, m), split=None)
             b = ht.ones((j), split=0)
@@ -421,6 +460,19 @@ class TestLinalgBasics(TestCase):
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n,))
             self.assertEqual(ret00.dtype, ht.float)
+            self.assertEqual(ret00.split, 0)
+
+            a = ht.ones((n, m), split=None, dtype=ht.int64)
+            b = ht.ones((j), split=0, dtype=ht.int64)
+            a[0] = ht.arange(1, m + 1, dtype=ht.int64)
+            a[:, -1] = ht.arange(1, n + 1, dtype=ht.int64)
+            ret00 = ht.matmul(a, b)
+
+            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            self.assertTrue(ht.equal(ret00, ret_comp))
+            self.assertIsInstance(ret00, ht.DNDarray)
+            self.assertEqual(ret00.shape, (n,))
+            self.assertEqual(ret00.dtype, ht.int64)
             self.assertEqual(ret00.split, 0)
 
             # splits 0 0
@@ -437,6 +489,19 @@ class TestLinalgBasics(TestCase):
             self.assertEqual(ret00.dtype, ht.float)
             self.assertEqual(ret00.split, 0)
 
+            a = ht.ones((n, m), split=0, dtype=ht.int64)
+            b = ht.ones((j), split=0, dtype=ht.int64)
+            a[0] = ht.arange(1, m + 1, dtype=ht.int64)
+            a[:, -1] = ht.arange(1, n + 1, dtype=ht.int64)
+            ret00 = ht.matmul(a, b)
+
+            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            self.assertTrue(ht.equal(ret00, ret_comp))
+            self.assertIsInstance(ret00, ht.DNDarray)
+            self.assertEqual(ret00.shape, (n,))
+            self.assertEqual(ret00.dtype, ht.int64)
+            self.assertEqual(ret00.split, 0)
+
             # splits 1 0
             a = ht.ones((n, m), split=1)
             b = ht.ones((j), split=0)
@@ -449,6 +514,19 @@ class TestLinalgBasics(TestCase):
             self.assertIsInstance(ret00, ht.DNDarray)
             self.assertEqual(ret00.shape, (n,))
             self.assertEqual(ret00.dtype, ht.float)
+            self.assertEqual(ret00.split, 0)
+
+            a = ht.ones((n, m), split=1, dtype=ht.int64)
+            b = ht.ones((j), split=0, dtype=ht.int64)
+            a[0] = ht.arange(1, m + 1, dtype=ht.int64)
+            a[:, -1] = ht.arange(1, n + 1, dtype=ht.int64)
+            ret00 = ht.matmul(a, b)
+
+            ret_comp = ht.array((a_torch @ b_torch), split=None)
+            self.assertTrue(ht.equal(ret00, ret_comp))
+            self.assertIsInstance(ret00, ht.DNDarray)
+            self.assertEqual(ret00.shape, (n,))
+            self.assertEqual(ret00.dtype, ht.int64)
             self.assertEqual(ret00.split, 0)
 
             with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
## Description

fixes bug by casting tensors to floats before mm operation

Issue/s resolved: #657 

## Changes proposed:
- for `matmul`: cast tensors to floats if the devices are GPUs and the dtypes are ints

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
