### PR TITLE
Features/554 permutation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,3 +30,6 @@ i.e.
 
 #### Does this change modify the behaviour of other functions? If so, which?
 yes / no
+
+<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
+skip ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@
 - [#652](https://github.com/helmholtz-analytics/heat/pull/652) Feature: benchmark scripts and jobscript generation
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Printing above threshold gathers the data without a buffer now
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Bugfixes: Update unittests argmax & argmin + force index order in mpi_argmax & mpi_argmin. Add device parameter for tensor creation in dndarray.get_halo().
+- [#659](https://github.com/helmholtz-analytics/heat/pull/659) New feature: `random.permutation` + `random.randperm`
+- [#639](https://github.com/helmholtz-analytics/heat/pull/639) Bufix: balanced array in demo_knn, changed behaviour of knn
+- [#652](https://github.com/helmholtz-analytics/heat/pull/652) Feature: benchmark scripts and jobscript generation
 
 # v0.4.0
 

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -276,7 +276,7 @@ def permutation(x):
         return randperm(x)
 
     if not isinstance(x, dndarray.DNDarray):
-        raise TypeError("x must be integer or DNDarray")
+        raise TypeError("x must be int or DNDarray")
 
     # random permutation
     recv = torch.randperm(x.shape[0], device=x.device.torch_device)
@@ -313,7 +313,7 @@ def permutation(x):
     else:
         data = torch.empty_like(x._DNDarray__array)
 
-    return factories.array(data, dtype=x.dtype, is_split=x.split, comm=x.comm)
+    return factories.array(data, dtype=x.dtype, is_split=x.split, device=x.device, comm=x.comm)
 
 
 def rand(*args, dtype=types.float32, split=None, device=None, comm=None):

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -543,7 +543,7 @@ def randperm(
 
     return factories.array(perm, dtype=dtype, device=device, split=split, comm=comm)
 
-    
+
 def random_sample(
     shape: Optional[Tuple[int]] = None,
     dtype=types.float32,
@@ -568,7 +568,7 @@ def random_sample(
         The axis along which the array is split and distributed, defaults to no distribution.
     device : str, optional
         Specifies the :class:`~heat.core.devices.Device`  the array shall be allocated on, defaults to globally
-        set default device. 
+        set default device.
     comm: Communication, optional
         Handle to the nodes holding distributed parts or copies of this array.
     """

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -5,8 +5,10 @@ import torch
 from . import communication
 from . import devices
 from . import dndarray
+from . import factories
 from . import stride_tricks
 from . import types
+from typing import Type, List, Optional, Tuple
 
 
 # introduce the global random state variables, will be correctly initialized at the end of file
@@ -237,6 +239,83 @@ def __kundu_transform(values):
     return (torch.log(-torch.log(1 - values ** 0.0775)) - 1.0821) * __KUNDU_INVERSE
 
 
+def permutation(x):
+    """
+    Randomly permute a sequence, or return a permuted range.
+
+    If x is a multi-dimensional array, it is only shuffled along its first index.
+
+    Parameters
+    -----------
+    x : int or DNDarray
+        If x is an integer, call :function:`~heat.core.random.randperm`. If x is an array, make a copy and shuffle the elements randomly.
+
+    Returns
+    -----------
+    DNDarray
+
+    See Also
+    -----------
+    :function:`~heat.core.random.randperm` Random permuted range
+
+    Examples
+    ----------
+    >>> ht.random.permutation(10)
+    DNDarray([9, 1, 5, 4, 8, 2, 7, 6, 3, 0], dtype=ht.int64, device=cpu:0, split=None)
+
+    >>> ht.random.permutation(ht.array([1, 4, 9, 12, 15]))
+    DNDarray([ 9,  1, 12,  4, 15], dtype=ht.int64, device=cpu:0, split=None)
+
+    >>> arr = ht.arange(9).reshape((3, 3))
+    >>> ht.random.permutation(arr)
+    DNDarray([[3, 4, 5],
+              [6, 7, 8],
+              [0, 1, 2]], dtype=ht.int32, device=cpu:0, split=None)
+    """
+    if isinstance(x, int):
+        return randperm(x)
+
+    if not isinstance(x, dndarray.DNDarray):
+        raise TypeError("x must be integer or DNDarray")
+
+    # random permutation
+    recv = torch.randperm(x.shape[0], device=x.device.torch_device)
+
+    # rearange locally
+    if (x.split is None) or (x.split != 0):
+        return x[recv]
+
+    # split == 0 -> Need for communication
+    if x.lshape[0] > 0:
+        cumsum = [x.comm.chunk(x.gshape, 0, i)[0] for i in range(0, x.comm.size)]
+        cumsum.append(x.shape[0])
+
+        send = torch.argsort(recv)
+        size = cumsum[x.comm.rank + 1] - cumsum[x.comm.rank]
+        torch_cumsum = torch.tensor(cumsum, device=x.device.torch_device)
+
+        buf = []
+        requests = []
+
+        for i in range(size):
+            proc_recv = torch.where(recv[torch_cumsum[x.comm.rank] + i] < torch_cumsum)[0][0] - 1
+            buf.append(torch.empty_like(x.lloc[i]))
+            requests.append(x.comm.Irecv(buf[-1], proc_recv, tag=i))
+
+            proc_send = torch.where(send[torch_cumsum[x.comm.rank] + i] < torch_cumsum)[0][0] - 1
+            tag = send[torch_cumsum[x.comm.rank] + i] - torch_cumsum[proc_send]
+            requests.append(x.comm.Isend(x.lloc[i].clone(), proc_send, tag=tag))
+
+        for req in requests:
+            req.Wait()
+
+        data = torch.stack(buf)
+    else:
+        data = torch.empty_like(x._DNDarray__array)
+
+    return factories.array(data, dtype=x.dtype, is_split=x.split, comm=x.comm)
+
+
 def rand(*args, dtype=types.float32, split=None, device=None, comm=None):
     """
     Random values in a given shape.
@@ -420,6 +499,45 @@ def randn(*args, dtype=types.float32, split=None, device=None, comm=None):
     normal_tensor._DNDarray__array = __kundu_transform(normal_tensor._DNDarray__array)
 
     return normal_tensor
+
+
+def randperm(
+    n: int, dtype=types.int64, split: Optional[int] = None, device: Optional[str] = None, comm=None
+):
+    """
+    Returns a random permutation of integers from 0 to n - 1
+
+    Parameters
+    ----------
+    n : int
+        Number of integers
+    dtype : datatype, optional
+        The datatype of the returned values.
+    split : int, optional
+        The axis along which the array is split and distributed, defaults to no distribution.
+    device : str, optional
+        Specifies the :class:`~heat.core.devices.Device`  the array shall be allocated on, defaults to globally
+        set default device.
+    comm : Communication, optional
+        Handle to the nodes holding distributed parts or copies of this array.
+
+    Returns
+    -------
+    DNDarray
+
+    Example
+    --------
+    >>> ht.random.randperm(4)
+    DNDarray([2, 3, 1, 0], dtype=ht.int64, device=cpu:0, split=None)
+    """
+    if not isinstance(n, int):
+        raise TypeError("n must be an integer.")
+
+    device = devices.sanitize_device(device)
+    comm = communication.sanitize_comm(comm)
+    perm = torch.randperm(n, dtype=dtype.torch_type(), device=device.torch_device)
+
+    return factories.array(perm, dtype=dtype, device=device, split=split, comm=comm)
 
 
 def seed(seed=None):

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -383,7 +383,7 @@ class TestRandom(TestCase):
 
         with self.assertRaises(TypeError):
             ht.random.randperm("abc")
-            
+
     def test_random_sample(self):
         # short test
         # compare random and aliases with rand

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -354,15 +354,25 @@ class TestRandom(TestCase):
         # results
         a = ht.random.randperm(10, dtype=ht.int32)
         b = ht.random.randperm(4, dtype=ht.float32, split=0)
+        c = ht.random.randperm(5, split=0)
+        d = ht.random.randperm(5, dtype=ht.float64)
 
         torch.random.set_rng_state(state)
 
         # torch results to compare to
         a_cmp = torch.randperm(10, dtype=torch.int32, device=self.device.torch_device)
         b_cmp = torch.randperm(4, dtype=torch.float32, device=self.device.torch_device)
+        c_cmp = torch.randperm(5, dtype=torch.int64, device=self.device.torch_device)
+        d_cmp = torch.randperm(5, dtype=torch.float64, device=self.device.torch_device)
 
+        self.assertEqual(a.dtype, ht.int32)
         self.assertTrue((a._DNDarray__array == a_cmp).all())
+        self.assertEqual(b.dtype, ht.float32)
         self.assertTrue((ht.resplit(b)._DNDarray__array == b_cmp).all())
+        self.assertEqual(c.dtype, ht.int64)
+        self.assertTrue((ht.resplit(c)._DNDarray__array == c_cmp).all())
+        self.assertEqual(d.dtype, ht.float64)
+        self.assertTrue((d._DNDarray__array == d_cmp).all())
 
         with self.assertRaises(TypeError):
             ht.random.randperm("abc")

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -6,6 +6,44 @@ from .test_suites.basic_test import TestCase
 
 
 class TestRandom(TestCase):
+    def test_permutation(self):
+        # Reset RNG
+        ht.random.seed()
+        state = torch.random.get_rng_state()
+
+        # results
+        a = ht.random.permutation(10)
+
+        b_arr = ht.arange(10, dtype=ht.float32)
+        b = ht.random.permutation(ht.resplit(b_arr, 0))
+
+        c_arr = ht.arange(16).reshape((4, 4))
+        c = ht.random.permutation(c_arr)
+
+        c0 = ht.random.permutation(ht.resplit(c_arr, 0))
+        c1 = ht.random.permutation(ht.resplit(c_arr, 1))
+
+        torch.set_rng_state(state)
+
+        # torch results to compare to
+        a_cmp = torch.randperm(a.shape[0], device=self.device.torch_device)
+        b_cmp = b_arr._DNDarray__array[torch.randperm(b.shape[0], device=self.device.torch_device)]
+        c_cmp = c_arr._DNDarray__array[torch.randperm(c.shape[0], device=self.device.torch_device)]
+        c0_cmp = c_arr._DNDarray__array[torch.randperm(c.shape[0], device=self.device.torch_device)]
+        c1_cmp = c_arr._DNDarray__array[torch.randperm(c.shape[0], device=self.device.torch_device)]
+
+        # compare
+        self.assertEqual(a.dtype, ht.int64)
+        self.assertTrue((a._DNDarray__array == a_cmp).all())
+        self.assertEqual(b.dtype, ht.float32)
+        self.assertTrue((ht.resplit(b)._DNDarray__array == b_cmp).all())
+        self.assertTrue((c._DNDarray__array == c_cmp).all())
+        self.assertTrue((ht.resplit(c0)._DNDarray__array == c0_cmp).all())
+        self.assertTrue((ht.resplit(c1)._DNDarray__array == c1_cmp).all())
+
+        with self.assertRaises(TypeError):
+            ht.random.permutation("abc")
+
     def test_rand(self):
         # int64 tests
 
@@ -309,6 +347,25 @@ class TestRandom(TestCase):
         c = ht.random.randn(30, 30, 30, dtype=ht.float32, split=2).numpy()
         self.assertFalse(np.allclose(a, c))
         self.assertFalse(np.allclose(b, c))
+
+    def test_randperm(self):
+        state = torch.random.get_rng_state()
+
+        # results
+        a = ht.random.randperm(10, dtype=ht.int32)
+        b = ht.random.randperm(4, dtype=ht.float32, split=0)
+
+        torch.random.set_rng_state(state)
+
+        # torch results to compare to
+        a_cmp = torch.randperm(10, dtype=torch.int32, device=self.device.torch_device)
+        b_cmp = torch.randperm(4, dtype=torch.float32, device=self.device.torch_device)
+
+        self.assertTrue((a._DNDarray__array == a_cmp).all())
+        self.assertTrue((ht.resplit(b)._DNDarray__array == b_cmp).all())
+
+        with self.assertRaises(TypeError):
+            ht.random.randperm("abc")
 
     def test_set_state(self):
         ht.random.set_state(("Threefry", 12345, 0xFFF))


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
This Pull Request introduces the functions random.permutation and random.randperm imitating the behaviour of the respective NumPy or PyTorch function.

Issue/s resolved: #554 

## Changes proposed:
- add `random.permutation` [NumPy documentation](https://numpy.org/devdocs/reference/random/generated/numpy.random.permutation.html)
- add `random.randperm` [PyTorch documentation](https://pytorch.org/docs/stable/generated/torch.randperm.html)

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
New feature

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
