### PR TITLE
Add prepend-append functionality to diff()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@
 - [#664](https://github.com/helmholtz-analytics/heat/pull/664) New feature / enhancement: `random.random_sample`, `random.random`, `random.sample`, `random.ranf`, `random.random_integer`
 - [#666](https://github.com/helmholtz-analytics/heat/pull/666) New feature: distributed prepend/append for diff().
 - [#667](https://github.com/helmholtz-analytics/heat/pull/667) Enhancement `reshape`: rename axis parameter
-- [#666](https://github.com/helmholtz-analytics/heat/pull/666) New feature: distributed prepend/append for diff().
 
 # v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Bugfixes: Update unittests argmax & argmin + force index order in mpi_argmax & mpi_argmin. Add device parameter for tensor creation in dndarray.get_halo().
 - [#664](https://github.com/helmholtz-analytics/heat/pull/664) New feature / enhancement: `random.random_sample`, `random.random`, `random.sample`, `random.ranf`, `random.random_integer`
 - [#667](https://github.com/helmholtz-analytics/heat/pull/667) Enhancement `reshape`: rename axis parameter
+- [#666](https://github.com/helmholtz-analytics/heat/pull/666) New feature: distributed prepend/append for diff().
 
 # v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [#652](https://github.com/helmholtz-analytics/heat/pull/652) Feature: benchmark scripts and jobscript generation
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Printing above threshold gathers the data without a buffer now
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Bugfixes: Update unittests argmax & argmin + force index order in mpi_argmax & mpi_argmin. Add device parameter for tensor creation in dndarray.get_halo().
+- [#664](https://github.com/helmholtz-analytics/heat/pull/664) New feature / enhancement: `random.random_sample`, `random.random`, `random.sample`, `random.ranf`, `random.random_integer`
 - [#667](https://github.com/helmholtz-analytics/heat/pull/667) Enhancement `reshape`: rename axis parameter
 
 # v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [#652](https://github.com/helmholtz-analytics/heat/pull/652) Feature: benchmark scripts and jobscript generation
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Printing above threshold gathers the data without a buffer now
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Bugfixes: Update unittests argmax & argmin + force index order in mpi_argmax & mpi_argmin. Add device parameter for tensor creation in dndarray.get_halo().
+- [#667](https://github.com/helmholtz-analytics/heat/pull/667) Enhancement `reshape`: rename axis parameter
 
 # v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Printing above threshold gathers the data without a buffer now
 - [#653](https://github.com/helmholtz-analytics/heat/pull/653) Bugfixes: Update unittests argmax & argmin + force index order in mpi_argmax & mpi_argmin. Add device parameter for tensor creation in dndarray.get_halo().
 - [#664](https://github.com/helmholtz-analytics/heat/pull/664) New feature / enhancement: `random.random_sample`, `random.random`, `random.sample`, `random.ranf`, `random.random_integer`
+- [#666](https://github.com/helmholtz-analytics/heat/pull/666) New feature: distributed prepend/append for diff().
 - [#667](https://github.com/helmholtz-analytics/heat/pull/667) Enhancement `reshape`: rename axis parameter
 - [#666](https://github.com/helmholtz-analytics/heat/pull/666) New feature: distributed prepend/append for diff().
 

--- a/heat/core/arithmetics.py
+++ b/heat/core/arithmetics.py
@@ -3,6 +3,7 @@ import torch
 from .communication import MPI
 from . import dndarray
 from . import factories
+from . import manipulations
 from . import _operations
 from . import stride_tricks
 from . import types
@@ -282,7 +283,7 @@ def cumsum(a, axis, dtype=None, out=None):
     return _operations.__cum_op(a, torch.cumsum, MPI.SUM, torch.add, 0, axis, dtype, out)
 
 
-def diff(a, n=1, axis=-1):
+def diff(a, n=1, axis=-1, prepend=None, append=None):
     """
     Calculate the n-th discrete difference along the given axis.
     The first difference is given by out[i] = a[i+1] - a[i] along the given axis, higher differences are calculated by using diff recursively.
@@ -295,13 +296,18 @@ def diff(a, n=1, axis=-1):
         n=2 is equivalent to ht.diff(ht.diff(a))
     axis : int, optional
         The axis along which the difference is taken, default is the last axis.
+    prepend, append : Optional[int, float, DNDarray]
+        Values to prepend or append along axis prior to performing the difference.
+        Scalar values are expanded to arrays with length 1 in the direction of axis and
+        the shape of the input array in along all other axes. Otherwise the dimension and
+        shape must match a except along axis.
 
     Returns
     -------
     diff : DNDarray
         The n-th differences. The shape of the output is the same as a except along axis where the dimension is smaller by n.
         The type of the output is the same as the type of the difference between any two elements of a.
-        The split does not change. The outpot array is balanced.
+        The split does not change. The output array is balanced.
     """
     if n == 0:
         return a
@@ -311,6 +317,41 @@ def diff(a, n=1, axis=-1):
         raise TypeError("'a' must be a DNDarray")
 
     axis = stride_tricks.sanitize_axis(a.gshape, axis)
+
+    if prepend is not None or append is not None:
+        pend_shape = a.gshape[:axis] + (1,) + a.gshape[axis + 1 :]
+        pend = [prepend, append]
+
+        for p, p_el in enumerate(pend):
+            if p_el is not None:
+                if isinstance(p_el, (int, float)):
+                    # TODO: implement broadcast_to
+                    p_el = factories.full(
+                        pend_shape,
+                        p_el,
+                        dtype=types.canonical_heat_type(torch.tensor(p_el).dtype),
+                        split=a.split,
+                        device=a.device,
+                        comm=a.comm,
+                    )
+                elif isinstance(p_el, dndarray.DNDarray) and p_el.gshape == pend_shape:
+                    pass
+                elif not isinstance(p_el, dndarray.DNDarray):
+                    raise TypeError(
+                        "prepend/append should be a scalar or a DNDarray, was {}".format(type(p_el))
+                    )
+                elif p_el.gshape != pend_shape:
+                    raise ValueError(
+                        "shape mismatch: expected prepend/append to be {}, got {}".format(
+                            pend_shape, p_el.gshape
+                        )
+                    )
+                if p == 0:
+                    # prepend
+                    a = manipulations.concatenate((p_el, a), axis=axis)
+                else:
+                    # append
+                    a = manipulations.concatenate((a, p_el), axis=axis)
 
     if not a.is_distributed():
         ret = a.copy()

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -911,7 +911,7 @@ def hstack(tup):
     return concatenate(tup, axis=axis)
 
 
-def reshape(a, shape, axis=None):
+def reshape(a, shape, new_split=None):
     """
     Returns a tensor with the same data and number of elements as a, but with the specified shape.
 
@@ -921,8 +921,8 @@ def reshape(a, shape, axis=None):
         The input tensor
     shape : tuple, list
         Shape of the new tensor
-    axis : int, optional
-        The new split axis. None denotes same axis
+    new_split : int, optional
+        The new split axis if `a` is a split DNDarray. None denotes same axis.
         Default : None
 
     Returns
@@ -953,10 +953,10 @@ def reshape(a, shape, axis=None):
         raise TypeError("'a' must be a DNDarray, currently {}".format(type(a)))
     if not isinstance(shape, (list, tuple)):
         raise TypeError("shape must be list, tuple, currently {}".format(type(shape)))
-        # check axis parameter
-    if axis is None:
-        axis = a.split
-    stride_tricks.sanitize_axis(shape, axis)
+        # check new_split parameter
+    if new_split is None:
+        new_split = a.split
+    stride_tricks.sanitize_axis(shape, new_split)
     tdtype, tdevice = a.dtype.torch_type(), a.device.torch_device
     # Check the type of shape and number elements
     shape = stride_tricks.sanitize_shape(shape)
@@ -1005,21 +1005,21 @@ def reshape(a, shape, axis=None):
         )
 
     # Create new flat result tensor
-    _, local_shape, _ = a.comm.chunk(shape, axis)
+    _, local_shape, _ = a.comm.chunk(shape, new_split)
     data = torch.empty(local_shape, dtype=tdtype, device=tdevice).flatten()
 
     # Calculate the counts and displacements
     _, old_displs, _ = a.comm.counts_displs_shape(a.shape, a.split)
-    _, new_displs, _ = a.comm.counts_displs_shape(shape, axis)
+    _, new_displs, _ = a.comm.counts_displs_shape(shape, new_split)
 
     old_displs += (a.shape[a.split],)
-    new_displs += (shape[axis],)
+    new_displs += (shape[new_split],)
 
     sendsort, sendcounts, senddispls = reshape_argsort_counts_displs(
-        a.shape, a.lshape, old_displs, a.split, shape, new_displs, axis, a.comm
+        a.shape, a.lshape, old_displs, a.split, shape, new_displs, new_split, a.comm
     )
     recvsort, recvcounts, recvdispls = reshape_argsort_counts_displs(
-        shape, local_shape, new_displs, axis, a.shape, old_displs, a.split, a.comm
+        shape, local_shape, new_displs, new_split, a.shape, old_displs, a.split, a.comm
     )
 
     # rearange order
@@ -1033,7 +1033,7 @@ def reshape(a, shape, axis=None):
     # Reshape local tensor
     data = data.reshape(local_shape)
 
-    return factories.array(data, dtype=a.dtype, is_split=axis, device=a.device, comm=a.comm)
+    return factories.array(data, dtype=a.dtype, is_split=new_split, device=a.device, comm=a.comm)
 
 
 def rot90(m, k=1, axes=(0, 1)):

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -7,6 +7,7 @@ from . import devices
 from . import dndarray
 from . import stride_tricks
 from . import types
+from typing import Type, List, Optional, Tuple
 
 
 # introduce the global random state variables, will be correctly initialized at the end of file
@@ -374,6 +375,10 @@ def randint(low, high=None, size=None, dtype=None, split=None, device=None, comm
     return dndarray.DNDarray(values, shape, dtype, split, device, comm)
 
 
+# alias
+random_integer = randint
+
+
 def randn(*args, dtype=types.float32, split=None, device=None, comm=None):
     """
     Returns a tensor filled with random numbers from a standard normal distribution with zero mean and variance of one.
@@ -420,6 +425,44 @@ def randn(*args, dtype=types.float32, split=None, device=None, comm=None):
     normal_tensor._DNDarray__array = __kundu_transform(normal_tensor._DNDarray__array)
 
     return normal_tensor
+
+
+def random_sample(
+    shape: Optional[Tuple[int]] = None,
+    dtype=types.float32,
+    split: Optional[int] = None,
+    device: Optional[str] = None,
+    comm=None,
+):
+    """
+    Random values in a given shape.
+    Create a :class:`~heat.core.dndarray.DNDarray`  of the given shape and populate it with random samples from a
+    uniform distribution over [0, 1).
+
+    Parameters
+    ----------
+    shape : Tuple[int]
+        The shape of the returned array, should all be positive. If no argument is given a single random sample is
+        generated.
+    dtype: Type[datatype], optional
+        The datatype of the returned values. Has to be one of
+        [:class:`~heat.core.types.float32, :class:`~heat.core.types.float64`].
+    split: int, optional
+        The axis along which the array is split and distributed, defaults to no distribution.
+    device : str, optional
+        Specifies the :class:`~heat.core.devices.Device`  the array shall be allocated on, defaults to globally
+        set default device.
+    comm: Communication, optional
+        Handle to the nodes holding distributed parts or copies of this array.
+    """
+    if not shape:
+        shape = (1,)
+    shape = stride_tricks.sanitize_shape(shape)
+    return rand(*shape, dtype=dtype, split=split, device=device, comm=comm)
+
+
+# aliases
+random = ranf = sample = random_sample
 
 
 def seed(seed=None):

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -300,6 +300,12 @@ class TestArithmetics(TestCase):
             ht.diff(ht_array, axis="string")
         with self.assertRaises(TypeError):
             ht.diff("string", axis=2)
+        t_prepend = torch.zeros(ht_array.gshape)
+        with self.assertRaises(TypeError):
+            ht.diff(ht_array, prepend=t_prepend)
+        append_wrong_shape = ht.ones(ht_array.gshape)
+        with self.assertRaises(ValueError):
+            ht.diff(ht_array, axis=0, append=append_wrong_shape)
 
     def test_div(self):
         result = ht.array([[0.5, 1.0], [1.5, 2.0]])

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -265,9 +265,13 @@ class TestArithmetics(TestCase):
                         self.assertEqual(ht_diff.dtype, lp_array.dtype)
 
                         # test prepend/append. Note heat's intuitive casting vs. numpy's safe casting
-                        ht_diff_pend = ht.diff(lp_array, n=nl, axis=ax, prepend=0, append=1.0)
+                        append_shape = lp_array.gshape[:ax] + (1,) + lp_array.gshape[ax + 1 :]
+                        ht_append = ht.ones(
+                            append_shape, dtype=lp_array.dtype, split=lp_array.split
+                        )
+                        ht_diff_pend = ht.diff(lp_array, n=nl, axis=ax, prepend=0, append=ht_append)
                         np_diff_pend = ht.array(
-                            np.diff(np_array, n=nl, axis=ax, prepend=0, append=1.0),
+                            np.diff(np_array, n=nl, axis=ax, prepend=0, append=ht_append.numpy()),
                             dtype=ht_diff_pend.dtype,
                         )
                         self.assertTrue(ht.equal(ht_diff_pend, np_diff_pend))

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -264,6 +264,16 @@ class TestArithmetics(TestCase):
                         self.assertEqual(ht_diff.split, sp)
                         self.assertEqual(ht_diff.dtype, lp_array.dtype)
 
+                        # test prepend/append. Note heat's intuitive casting vs. numpy's safe casting
+                        ht_diff_pend = ht.diff(lp_array, n=nl, axis=ax, prepend=0, append=1.0)
+                        np_diff_pend = ht.array(
+                            np.diff(np_array, n=nl, axis=ax, prepend=0, append=1.0),
+                            dtype=ht_diff_pend.dtype,
+                        )
+                        self.assertTrue(ht.equal(ht_diff_pend, np_diff_pend))
+                        self.assertEqual(ht_diff_pend.split, sp)
+                        self.assertEqual(ht_diff_pend.dtype, ht.float64)
+
         np_array = ht_array.numpy()
         ht_diff = ht.diff(ht_array, n=2)
         np_diff = ht.array(np.diff(np_array, n=2))

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1082,7 +1082,7 @@ class TestManipulations(TestCase):
 
         a = ht.array(torch.arange(3 * 4 * 5).reshape([3, 4, 5]), split=2)
         result = ht.array(torch.arange(4 * 5 * 3).reshape([4, 5, 3]), split=1)
-        reshaped = ht.reshape(a, [4, 5, 3], axis=1)
+        reshaped = ht.reshape(a, [4, 5, 3], new_split=1)
         self.assertEqual(reshaped.size, result.size)
         self.assertEqual(reshaped.shape, result.shape)
         self.assertEqual(reshaped.split, 1)
@@ -1090,7 +1090,7 @@ class TestManipulations(TestCase):
 
         a = ht.array(torch.arange(3 * 4 * 5).reshape([3, 4, 5]), split=1)
         result = ht.array(torch.arange(4 * 5 * 3).reshape([4 * 5, 3]), split=0)
-        reshaped = ht.reshape(a, [4 * 5, 3], axis=0)
+        reshaped = ht.reshape(a, [4 * 5, 3], new_split=0)
         self.assertEqual(reshaped.size, result.size)
         self.assertEqual(reshaped.shape, result.shape)
         self.assertEqual(reshaped.split, 0)
@@ -1098,7 +1098,7 @@ class TestManipulations(TestCase):
 
         a = ht.array(torch.arange(3 * 4 * 5).reshape([3, 4, 5]), split=0)
         result = ht.array(torch.arange(4 * 5 * 3).reshape([4, 5 * 3]), split=1)
-        reshaped = ht.reshape(a, [4, 5 * 3], axis=1)
+        reshaped = ht.reshape(a, [4, 5 * 3], new_split=1)
         self.assertEqual(reshaped.size, result.size)
         self.assertEqual(reshaped.shape, result.shape)
         self.assertEqual(reshaped.split, 1)

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -245,6 +245,13 @@ class TestRandom(TestCase):
         self.assertTrue(4900 < median < 5100)
         self.assertTrue(std < 2900)
 
+        # test aliases
+        ht.random.seed(234)
+        a = ht.random.randint(10, 50)
+        ht.random.seed(234)
+        b = ht.random.random_integer(10, 50)
+        self.assertTrue(ht.equal(a, b))
+
     def test_randn(self):
         # Test that the random values have the correct distribution
         ht.random.seed(54321)
@@ -309,6 +316,29 @@ class TestRandom(TestCase):
         c = ht.random.randn(30, 30, 30, dtype=ht.float32, split=2).numpy()
         self.assertFalse(np.allclose(a, c))
         self.assertFalse(np.allclose(b, c))
+
+    def test_random_sample(self):
+        # short test
+        # compare random and aliases with rand
+        ht.random.seed(534)
+        a = ht.random.rand(6, 2, 3)
+        ht.random.seed(534)
+        b = ht.random.random((6, 2, 3))
+        ht.random.seed(534)
+        c = ht.random.random_sample((6, 2, 3))
+        ht.random.seed(534)
+        d = ht.random.ranf((6, 2, 3))
+        ht.random.seed(534)
+        e = ht.random.sample((6, 2, 3))
+
+        self.assertTrue(ht.equal(a, b))
+        self.assertTrue(ht.equal(a, c))
+        self.assertTrue(ht.equal(a, d))
+        self.assertTrue(ht.equal(a, e))
+
+        # empty input
+        a = ht.random.random_sample()
+        self.assertEqual(a.shape, (1,))
 
     def test_set_state(self):
         ht.random.set_state(("Threefry", 12345, 0xFFF))


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
This one is self-explanatory, see https://numpy.org/doc/stable/reference/generated/numpy.diff.html
Issue/s resolved: none, needed in ASSET

## Changes proposed:
- kwargs prepend, append for ht.diff(), can be scalars or DNDarrays 

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
