### PR TITLE
remove MPIRequest.wait()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [#664](https://github.com/helmholtz-analytics/heat/pull/664) New feature / enhancement: `random.random_sample`, `random.random`, `random.sample`, `random.ranf`, `random.random_integer`
 - [#666](https://github.com/helmholtz-analytics/heat/pull/666) New feature: distributed prepend/append for diff().
 - [#667](https://github.com/helmholtz-analytics/heat/pull/667) Enhancement `reshape`: rename axis parameter
+- [#672](https://github.com/helmholtz-analytics/heat/pull/672) Bug / Enhancement: Remove `MPIRequest.wait()`, rewrite calls with capital letters
 
 # v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - [#666](https://github.com/helmholtz-analytics/heat/pull/666) New feature: distributed prepend/append for diff().
 - [#667](https://github.com/helmholtz-analytics/heat/pull/667) Enhancement `reshape`: rename axis parameter
 - [#670](https://github.com/helmholtz-analytics/heat/pull/670) New Feature: `bincount()`
-- [#672](https://github.com/helmholtz-analytics/heat/pull/672) Bug / Enhancement: Remove `MPIRequest.wait()`, rewrite calls with capital letters
+- [#672](https://github.com/helmholtz-analytics/heat/pull/672) Bug / Enhancement: Remove `MPIRequest.wait()`, rewrite calls with capital letters. lower case `wait()` now falls back to the `mpi4py` function
 
 # v0.4.0
 

--- a/heat/core/arithmetics.py
+++ b/heat/core/arithmetics.py
@@ -387,7 +387,7 @@ def diff(a, n=1, axis=-1, prepend=None, append=None):
         ret.lloc[diff_slice] = dif
 
         if rank > 0:
-            snd.wait()  # wait for the send to finish
+            snd.Wait()  # wait for the send to finish
         if rank < size - 1:
             cr_slice = [slice(None)] * len(a.shape)
             # slice of 1 element in the selected axis for the shape creation
@@ -399,7 +399,7 @@ def diff(a, n=1, axis=-1, prepend=None, append=None):
             axis_slice_end = [slice(None)] * len(a.shape)
             # select the last elements in the selected axis
             axis_slice_end[axis] = slice(-1, None)
-            rec.wait()
+            rec.Wait()
             # diff logic
             ret.lloc[axis_slice_end] = (
                 recv_data.reshape(ret.lloc[axis_slice_end].shape) - ret.lloc[axis_slice_end]

--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -1103,18 +1103,6 @@ class MPIRequest:
                 self.recvbuf = self.recvbuf.permute(self.permutation)
             self.tensor.copy_(self.recvbuf)
 
-    def wait(self, status=None):
-        self.handle.wait(status)
-        if (
-            self.tensor is not None
-            and isinstance(self.tensor, torch.Tensor)
-            and self.tensor.is_cuda
-            and not CUDA_AWARE_MPI
-        ):
-            if self.permutation is not None:
-                self.recvbuf = self.recvbuf.permute(self.permutation)
-            self.tensor.copy_(self.recvbuf)
-
     def __getattr__(self, name):
         """
         Default pass-through for the communicator methods.

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -353,7 +353,7 @@ class DNDarray:
                 req_list.append(self.comm.Irecv(res_next, source=self.comm.rank - 1))
 
             for req in req_list:
-                req.wait()
+                req.Wait()
 
             self.__halo_next = res_prev
             self.__halo_prev = res_next
@@ -2775,7 +2775,7 @@ class DNDarray:
             lp_arr = None
             for k in lp_keys:
                 if rcv[k][0] is not None:
-                    rcv[k][0].wait()
+                    rcv[k][0].Wait()
                 if lp_arr is None:
                     lp_arr = rcv[k][1]
                 else:

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -364,7 +364,7 @@ def matmul(a, b, allow_resplit=False):
     if any(lshape_map[:, 0, :][:, 1] == 1):
         a_d1_1s_flag = True
 
-    index_map_comm.wait()
+    index_map_comm.Wait()
     for pr in range(a.comm.size):
         start0 = index_map[pr, 0, 0, 0].item()
         stop0 = index_map[pr, 0, 0, 1].item()
@@ -382,7 +382,7 @@ def matmul(a, b, allow_resplit=False):
                 a_block_map[pr, dim0, dim1] = torch.tensor(
                     (dim0 * mB, dim1 * kB), dtype=torch.int, device=a._DNDarray__array.device
                 )
-    rem_map_comm.wait()
+    rem_map_comm.Wait()
     if b.split == 0:
         # the blocks are shifted in the 2nd dimension of A for as many remainders
         # there are between the blocks in the first dim of B
@@ -440,7 +440,7 @@ def matmul(a, b, allow_resplit=False):
                 b_block_map[:, cnt:, :, 0] += 1
 
     # work loop: loop over all processes (also will incorporate the remainder calculations)
-    c_wait.wait()
+    c_wait.Wait()
 
     if split_0_flag:
         # need to send b here and not a
@@ -484,7 +484,7 @@ def matmul(a, b, allow_resplit=False):
 
             # receive the data from the last loop and do the calculation with that
             if pr != 0:
-                req[pr - 1].wait()
+                req[pr - 1].Wait()
                 # after receiving the last loop's bcast
                 __mm_c_block_setter(
                     b_proc=pr - 1,
@@ -518,7 +518,7 @@ def matmul(a, b, allow_resplit=False):
 
             # need to wait if its the last loop, also need to collect the remainders
             if pr == b.comm.size - 1:
-                req[pr].wait()
+                req[pr].Wait()
                 __mm_c_block_setter(
                     b_proc=pr,
                     a_proc=a.comm.rank,
@@ -610,7 +610,7 @@ def matmul(a, b, allow_resplit=False):
             # receive the data from the last loop and do the calculation with that
             if pr != 0:
                 # after receiving the last loop's bcast
-                req[pr - 1].wait()
+                req[pr - 1].Wait()
                 __mm_c_block_setter(
                     a_proc=pr - 1,
                     b_proc=b.comm.rank,
@@ -645,7 +645,7 @@ def matmul(a, b, allow_resplit=False):
 
             # need to wait if its the last loop, also need to collect the remainders
             if pr == b.comm.size - 1:
-                req[pr].wait()
+                req[pr].Wait()
                 __mm_c_block_setter(
                     a_proc=pr,
                     b_proc=a.comm.rank,
@@ -706,7 +706,7 @@ def matmul(a, b, allow_resplit=False):
 
             # receive the data from the last loop and do the calculation with that
             if pr != 0:
-                req[pr - 1].wait()
+                req[pr - 1].Wait()
                 # after receiving the last loop's bcast
                 st0 = index_map[pr - 1, 0, 0, 0].item()
                 sp0 = index_map[pr - 1, 0, 0, 1].item() + 1
@@ -717,7 +717,7 @@ def matmul(a, b, allow_resplit=False):
                 del b_lp_data[pr - 1]
 
             if pr == b.comm.size - 1:
-                req[pr].wait()
+                req[pr].Wait()
                 st0 = index_map[pr, 0, 0, 0].item()
                 sp0 = index_map[pr, 0, 0, 1].item() + 1
                 st1 = index_map[pr, 1, 1, 0].item()

--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -671,7 +671,7 @@ def __split0_q_loop(col, r_tiles, proc_tile_start, active_procs, q0_tiles, q_dic
     if col in q_dict_waits.keys():
         for key in q_dict_waits[col].keys():
             new_key = q_dict_waits[col][key][3] + key + "e"
-            q_dict_waits[col][key][0][1].wait()
+            q_dict_waits[col][key][0][1].Wait()
             q_dict[col][new_key] = [
                 q_dict_waits[col][key][0][0],
                 q_dict_waits[col][key][1].wait(),
@@ -728,7 +728,7 @@ def __split0_q_loop(col, r_tiles, proc_tile_start, active_procs, q0_tiles, q_dic
     for pr in range(diag_process, active_procs[-1] + 1):
         if local_merge_q[pr][1] is not None:
             # receive q from the other processes
-            local_merge_q[pr][1].wait()
+            local_merge_q[pr][1].Wait()
         if rank in active_procs:
             sum_row = sum(q0_tiles.tile_rows_per_process[:pr])
             end_row = q0_tiles.tile_rows_per_process[pr] + sum_row
@@ -790,7 +790,7 @@ def __split0_q_loop(col, r_tiles, proc_tile_start, active_procs, q0_tiles, q_dic
             )
             for ind in qi_mult[qi_col]:
                 if global_merge_dict[ind][1] is not None:
-                    global_merge_dict[ind][1].wait()
+                    global_merge_dict[ind][1].Wait()
                 lp_q = global_merge_dict[ind][0]
                 if mult_qi_col.shape[1] < lp_q.shape[1]:
                     new_mult = torch.zeros(
@@ -810,7 +810,7 @@ def __split0_q_loop(col, r_tiles, proc_tile_start, active_procs, q0_tiles, q_dic
             q0_tiles.arr.lloc[:, write_inds[2] : write_inds[2] + hold.shape[1]] = hold
     else:
         for ind in merge_dict_keys:
-            global_merge_dict[ind][1].wait()
+            global_merge_dict[ind][1].Wait()
     if col in q_dict.keys():
         del q_dict[col]
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -317,8 +317,8 @@ def concatenate(arrays, axis=0):
                 chunk_map[arr0.comm.rank, i] = chk[i].stop - chk[i].start
             chunk_map_comm = arr0.comm.Iallreduce(MPI.IN_PLACE, chunk_map, MPI.SUM)
 
-            lshape_map_comm.wait()
-            chunk_map_comm.wait()
+            lshape_map_comm.Wait()
+            chunk_map_comm.Wait()
 
             if s0 is not None:
                 send_slice = [slice(None)] * arr0.ndim
@@ -341,7 +341,7 @@ def concatenate(arrays, axis=0):
                                     tag=pr + arr0.comm.size + spr,
                                 )
                                 arr0._DNDarray__array = arr0.lloc[keep_slice].clone()
-                                send.wait()
+                                send.Wait()
                     for pr in range(spr):
                         snt = abs((chunk_map[pr, s0] - lshape_map[0, pr, s0]).item())
                         snt = (
@@ -388,7 +388,7 @@ def concatenate(arrays, axis=0):
                                     tag=pr + arr1.comm.size + spr,
                                 )
                                 arr1._DNDarray__array = arr1.lloc[keep_slice].clone()
-                                send.wait()
+                                send.Wait()
                     for pr in range(arr1.comm.size - 1, spr, -1):
                         snt = abs((chunk_map[pr, axis] - lshape_map[1, pr, axis]).item())
                         snt = (
@@ -2010,9 +2010,9 @@ def resplit(arr, axis=None):
                 buf = torch.zeros_like(new_tiles[key])
                 rcv_waits[key] = [arr.comm.Irecv(buf=buf, source=spr, tag=spr), buf]
     for w in waits:
-        w.wait()
+        w.Wait()
     for k in rcv_waits.keys():
-        rcv_waits[k][0].wait()
+        rcv_waits[k][0].Wait()
         new_tiles[k] = rcv_waits[k][1]
 
     return new_arr

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -995,7 +995,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Iallgather(data, output)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1015,7 +1015,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Iallgather(data, output, recv_axis=1)
-            req.wait()
+            req.Wait()
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
@@ -1034,7 +1034,7 @@ class TestCommunication(TestCase):
             self.assertFalse(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Iallgather(data, output)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -1054,7 +1054,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(output._DNDarray__array.is_contiguous())
             req = data.comm.Iallgather(data, output, recv_axis=1)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1085,7 +1085,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(1, ht.MPI_WORLD.size + 1))
             displs = tuple(np.cumsum(range(ht.MPI_WORLD.size)))
             req = data.comm.Iallgatherv(data, (output, counts, displs))
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1110,7 +1110,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Iallgatherv(data, (output, counts, displs))
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -1135,7 +1135,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Iallgatherv(data, (output, counts, displs))
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1160,7 +1160,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Iallgatherv(data, (output, counts, displs))
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -1186,7 +1186,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(out._DNDarray__array.is_contiguous())
             req = data.comm.Iallreduce(data, out, op=ht.MPI.SUM)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1201,7 +1201,7 @@ class TestCommunication(TestCase):
             self.assertFalse(data._DNDarray__array.is_contiguous())
             self.assertTrue(out._DNDarray__array.is_contiguous())
             req = data.comm.Iallreduce(data, out, op=ht.MPI.SUM)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             # the data tensor will be contiguous after the reduction
@@ -1220,7 +1220,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(out._DNDarray__array.is_contiguous())
             req = data.comm.Iallreduce(data, out, op=ht.MPI.SUM)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             # the data tensor will be contiguous after the reduction
@@ -1245,7 +1245,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Ialltoall(data, output)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1265,7 +1265,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Ialltoall(data, output, send_axis=1)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1285,7 +1285,7 @@ class TestCommunication(TestCase):
             self.assertFalse(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Ialltoall(data, output)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -1303,7 +1303,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(output._DNDarray__array.is_contiguous())
             req = data.comm.Ialltoall(data, output, send_axis=1)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1338,7 +1338,7 @@ class TestCommunication(TestCase):
             req = data.comm.Ialltoallv(
                 (data, send_counts, send_displs), (output, recv_counts, recv_displs)
             )
-            req.wait()
+            req.Wait()
 
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
@@ -1370,7 +1370,7 @@ class TestCommunication(TestCase):
             req = data.comm.Ialltoallv(
                 (data, send_counts, send_displs), (output, recv_counts, recv_displs)
             )
-            req.wait()
+            req.Wait()
 
             self.assertFalse(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
@@ -1403,7 +1403,7 @@ class TestCommunication(TestCase):
             req = data.comm.Ialltoallv(
                 (data, send_counts, send_displs), (output, recv_counts, recv_displs)
             )
-            req.wait()
+            req.Wait()
 
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(output._DNDarray__array.is_contiguous())
@@ -1436,7 +1436,7 @@ class TestCommunication(TestCase):
             req = data.comm.Ialltoallv(
                 (data, send_counts, send_displs), (output, recv_counts, recv_displs)
             )
-            req.wait()
+            req.Wait()
 
             self.assertFalse(data._DNDarray__array.is_contiguous())
             self.assertFalse(output._DNDarray__array.is_contiguous())
@@ -1463,7 +1463,7 @@ class TestCommunication(TestCase):
             # broadcast data to all nodes
             self.assertTrue(data._DNDarray__array.is_contiguous())
             req = data.comm.Ibcast(data, root=0)
-            req.wait()
+            req.Wait()
 
             # assert output is equal
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1479,7 +1479,7 @@ class TestCommunication(TestCase):
             # broadcast data to all nodes
             self.assertFalse(data._DNDarray__array.is_contiguous())
             req = data.comm.Ibcast(data, root=0)
-            req.wait()
+            req.Wait()
 
             # assert output is equal
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -1504,7 +1504,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(out._DNDarray__array.is_contiguous())
             req = data.comm.Iexscan(data, out)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1519,7 +1519,7 @@ class TestCommunication(TestCase):
             self.assertFalse(data._DNDarray__array.is_contiguous())
             self.assertTrue(out._DNDarray__array.is_contiguous())
             req = data.comm.Iexscan(data, out)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             # the data tensor will be contiguous after the reduction
@@ -1538,7 +1538,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(out._DNDarray__array.is_contiguous())
             req = data.comm.Iexscan(data, out)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             # the data tensor will be contiguous after the reduction
@@ -1563,7 +1563,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Igather(data, output, root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1588,7 +1588,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Igather(data, output, root=0, axis=1)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1613,7 +1613,7 @@ class TestCommunication(TestCase):
             self.assertFalse(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Igather(data, output, root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -1638,7 +1638,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(output._DNDarray__array.is_contiguous())
             req = data.comm.Igather(data, output, root=0, axis=1)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1674,7 +1674,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(1, ht.MPI_WORLD.size + 1))
             displs = tuple(np.cumsum(range(ht.MPI_WORLD.size)))
             req = data.comm.Igatherv(data, (output, counts, displs), root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1700,7 +1700,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Igatherv(data, (output, counts, displs), root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -1726,7 +1726,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Igatherv(data, (output, counts, displs), root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1752,7 +1752,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Igatherv(data, (output, counts, displs), root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -1779,7 +1779,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(out._DNDarray__array.is_contiguous())
             req = data.comm.Ireduce(data, out, op=ht.MPI.SUM, root=0)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1795,7 +1795,7 @@ class TestCommunication(TestCase):
             self.assertFalse(data._DNDarray__array.is_contiguous())
             self.assertTrue(out._DNDarray__array.is_contiguous())
             req = data.comm.Ireduce(data, out, op=ht.MPI.SUM, root=0)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             # the data tensor will be contiguous after the reduction
@@ -1815,7 +1815,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(out._DNDarray__array.is_contiguous())
             req = data.comm.Ireduce(data, out, op=ht.MPI.SUM, root=0)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             # the data tensor will be contiguous after the reduction
@@ -1841,7 +1841,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(out._DNDarray__array.is_contiguous())
             req = data.comm.Iscan(data, out)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1856,7 +1856,7 @@ class TestCommunication(TestCase):
             self.assertFalse(data._DNDarray__array.is_contiguous())
             self.assertTrue(out._DNDarray__array.is_contiguous())
             req = data.comm.Iscan(data, out)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             # the data tensor will be contiguous after the reduction
@@ -1875,7 +1875,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(out._DNDarray__array.is_contiguous())
             req = data.comm.Iscan(data, out)
-            req.wait()
+            req.Wait()
 
             # check the reduction result
             # the data tensor will be contiguous after the reduction
@@ -1903,7 +1903,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Iscatter(data, output, root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1923,7 +1923,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Iscatter(data, output, root=0, axis=1)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1944,7 +1944,7 @@ class TestCommunication(TestCase):
             # ensure prior invariants
             self.assertTrue(output._DNDarray__array.is_contiguous())
             req = data.comm.Iscatter(data, output, root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             if ht.MPI_WORLD.rank == 0:
@@ -1967,7 +1967,7 @@ class TestCommunication(TestCase):
             self.assertTrue(data._DNDarray__array.is_contiguous())
             self.assertFalse(output._DNDarray__array.is_contiguous())
             req = data.comm.Iscatter(data, output, root=0, axis=1)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -1996,7 +1996,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Iscatterv((data, counts, displs), output, root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -2022,7 +2022,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Iscatterv((data, counts, displs), output, root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertFalse(data._DNDarray__array.is_contiguous())
@@ -2048,7 +2048,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Iscatterv((data, counts, displs), output, root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertTrue(data._DNDarray__array.is_contiguous())
@@ -2074,7 +2074,7 @@ class TestCommunication(TestCase):
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
             displs = tuple(np.cumsum(range(0, 2 * ht.MPI_WORLD.size, 2)))
             req = data.comm.Iscatterv((data, counts, displs), output, root=0)
-            req.wait()
+            req.Wait()
 
             # check scatter result
             self.assertFalse(data._DNDarray__array.is_contiguous())


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Removes the `wait` method of `MPIRequest` such that it does not interfere with the lowercase non-blocking MPI functions of mpi4py.

Issue/s resolved: #671 

## Changes proposed:
- delete MPIRequest.wait()
- fix calls using wait() to Wait()

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- Bug fix
- Breaking change

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
