### PR TITLE
Features/510 split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Pending additions
+- [#677](https://github.com/helmholtz-analytics/heat/pull/677) New feature: split, vsplit, dsplit, hsplit
 ## New features
 ### Manipulations
 ### Statistical Functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Pending additions
-- [#677](https://github.com/helmholtz-analytics/heat/pull/677) New feature: split, vsplit, dsplit, hsplit
+
 ## New features
 - [#680](https://github.com/helmholtz-analytics/heat/pull/680) New property: larray
 - [#683](https://github.com/helmholtz-analytics/heat/pull/683) New properties: nbytes, gnbytes, lnbytes
 ### Manipulations
+- [#677](https://github.com/helmholtz-analytics/heat/pull/677) split, vsplit, dsplit, hsplit
 ### Statistical Functions
 ### Linear Algebra
 ### ...

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -939,8 +939,70 @@ def flipud(a):
     return flip(a, 0)
 
 
-def hsplit(ary, indices_or_sections):  # TODO
-    pass
+def hsplit(ary, indices_or_sections):
+    """
+    Split array into multiple sub-arrays along the 2nd axis (horizontally/column-wise).
+
+    Please refer to the split documentation. hsplit is nearly equivalent to split with axis=1,
+    the array is always split along the second axis though, in contrary to split, regardless of the array dimension.
+
+    Parameters
+    ----------
+    ary : DNDarray
+        DNDArray to be divided into sub-DNDarrays.
+    indices_or_sections : int or 1-dimensional array_like (i.e. undistributed DNDarray, list or tuple)
+        If indices_or_sections is an integer, N, the DNDarray will be divided into N equal DNDarrays along the 2nd axis.
+        If such a split is not possible, an error is raised.
+        If indices_or_sections is a 1-D DNDarray of sorted integers, the entries indicate where along the 2nd axis
+        the array is split.
+        If an index exceeds the dimension of the array along the 2nd axis, an empty sub-array is returned correspondingly.
+
+    Returns
+    -------
+    sub_arrays : list of DNDarrays
+        A list of sub-DNDarrays as views into ary.
+
+    Raises
+    ------
+    ValueError
+        If indices_or_sections is given as integer, but a split does not result in equal division.
+
+    Examples
+    --------
+    >>> x = ht.arange(24).reshape((2, 4, 3))
+    >>> ht.hsplit(x, 2)
+        [
+            DNDarray([[[ 0,  1,  2],
+                       [ 3,  4,  5]],
+
+                      [[12, 13, 14],
+                       [15, 16, 17]]]),
+            DNDarray([[[ 6,  7,  8],
+                       [ 9, 10, 11]],
+
+                      [[18, 19, 20],
+                       [21, 22, 23]]])
+        ]
+
+    >>> ht.hsplit(x, [1, 3])
+        [
+            DNDarray([[[ 0,  1,  2]],
+
+                      [[12, 13, 14]]]),
+            DNDarray([[[ 3,  4,  5],
+                       [ 6,  7,  8]],
+
+                      [[15, 16, 17],
+                       [18, 19, 20]]]),
+            DNDarray([[[ 9, 10, 11]],
+
+                      [[21, 22, 23]]])]
+       """
+    sanitation.sanitize_input(ary)
+
+    if len(ary.lshape) < 2:
+        ary = ary.reshape(ary, (1, ary.lshape[0]))
+    return split(ary, indices_or_sections, 1)
 
 
 def hstack(tup):
@@ -2593,8 +2655,73 @@ def unique(a, sorted=False, return_inverse=False, axis=None):
     return return_value
 
 
-def vsplit(ary, indices_or_sections):  # TODO
-    pass
+def vsplit(ary, indices_or_sections):
+    """
+    Split array into multiple sub-arrays along the 1st axis (vertically/row-wise).
+
+    Please refer to the split documentation. hsplit is equivalent to split with axis=0,
+    the array is always split along the first axis regardless of the array dimension.
+
+    Parameters
+    ----------
+    ary : DNDarray
+        DNDArray to be divided into sub-DNDarrays.
+    indices_or_sections : int or 1-dimensional array_like (i.e. undistributed DNDarray, list or tuple)
+        If indices_or_sections is an integer, N, the DNDarray will be divided into N equal DNDarrays along the 1st axis.
+        If such a split is not possible, an error is raised.
+        If indices_or_sections is a 1-D DNDarray of sorted integers, the entries indicate where along the 1st axis
+        the array is split.
+        If an index exceeds the dimension of the array along the 1st axis, an empty sub-array is returned correspondingly.
+
+    Returns
+    -------
+    sub_arrays : list of DNDarrays
+        A list of sub-DNDarrays as views into ary.
+
+    Raises
+    ------
+    ValueError
+        If indices_or_sections is given as integer, but a split does not result in equal division.
+
+    Examples
+    --------
+    >>> x = ht.arange(24).reshape((4, 3, 2))
+    >>> ht.vsplit(x, 2)
+        [
+            DNDarray([[[ 0,  1],
+                       [ 2,  3],
+                       [ 4,  5]],
+
+                      [[ 6,  7],
+                       [ 8,  9],
+                       [10, 11]]]),
+            DNDarray([[[12, 13],
+                       [14, 15],
+                       [16, 17]],
+
+                      [[18, 19],
+                       [20, 21],
+                       [22, 23]]])
+        ]
+
+        >>> ht.vsplit(x, [1, 3])
+        [
+            DNDarray([[[0, 1],
+                       [2, 3],
+                       [4, 5]]]),
+            DNDarray([[[ 6,  7],
+                       [ 8,  9],
+                       [10, 11]],
+
+                      [[12, 13],
+                       [14, 15],
+                       [16, 17]]]),
+            DNDarray([[[18, 19],
+                       [20, 21],
+                       [22, 23]]])]
+
+           """
+    return split(ary, indices_or_sections, 0)
 
 
 def resplit(arr, axis=None):

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -2166,7 +2166,7 @@ def sort(a, axis=None, descending=False, out=None):
 
 def split(ary, indices_or_sections, axis=0):
     """
-    Split a DNDarray into multiple sub-DNDarrays as views into ary.
+    Split a DNDarray into multiple sub-DNDarrays as copies of parts of ary.
 
     Parameters
     ----------
@@ -2279,7 +2279,7 @@ def split(ary, indices_or_sections, axis=0):
 
     # start of actual algorithm
 
-    if ary.split == axis and ary.split is not None and ary.comm.size > 1:
+    if ary.split == axis and ary.is_distributed():
 
         if isinstance(indices_or_sections, int):
             # CASE 1 number of processes == indices_or_selections -> split already done due to distribution

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1001,8 +1001,13 @@ def hsplit(ary, indices_or_sections):
     sanitation.sanitize_input(ary)
 
     if len(ary.lshape) < 2:
-        ary = ary.reshape(ary, (1, ary.lshape[0]))
-    return split(ary, indices_or_sections, 1)
+        ary = reshape(ary, (1, ary.lshape[0]))
+        result = split(ary, indices_or_sections, 1)
+        result = [flatten(sub_array) for sub_array in result]
+    else:
+        result = split(ary, indices_or_sections, 1)
+
+    return result
 
 
 def hstack(tup):

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -668,7 +668,7 @@ def dsplit(ary, indices_or_sections):
 
     See Also
     ------
-    :function:`split <heat.core.manipulations.split>`
+    :function:`split`
 
     Examples
     --------
@@ -955,7 +955,7 @@ def hsplit(ary, indices_or_sections):
 
     See Also
     --------
-    :function:`split <heat.core.manipulations.split>`
+    :function:`split`
 
     Examples
     --------
@@ -1944,8 +1944,7 @@ def split(ary, indices_or_sections, axis=0):
 
     See Also
     --------
-    :function:`dsplit <heat.core.manipulations.dsplit>`, :function:`hsplit <heat.core.manipulations.hsplit>`,
-    :function:`vsplit <heat.core.manipulations.vsplit>`
+    :function:`dsplit`, :function:`hsplit`, :function:`vsplit`
 
     Examples
     --------
@@ -2689,7 +2688,7 @@ def vsplit(ary, indices_or_sections):
 
     See Also
     --------
-    :function:`split <heat.core.manipulations.split>`
+    :function:`split`
 
     Examples
     --------

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1951,7 +1951,7 @@ def split(ary, indices_or_sections, axis=0):
 
     Examples
     --------
-    >>> x = ht.array(12).reshape((4,3))
+    >>> x = ht.arange(12).reshape((4,3))
     >>> ht.split(x, 2)
         [ DNDarray([[0, 1, 2],
                     [3, 4, 5]]),

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1799,7 +1799,7 @@ def split(ary, indices_or_sections, axis=0):
     ValueError
         If indices_or_sections is given as integer, but a split does not result in equal division.
 
-    Examples    #TODO
+    Examples
     --------
     >>> x = ht.array(12).reshape((4,3))
     >>> ht.split(x, 2)
@@ -1811,10 +1811,25 @@ def split(ary, indices_or_sections, axis=0):
     >>> ht.split(x, [2, 3, 5])
         [ DNDarray([[0, 1, 2],
                     [3, 4, 5]]),
-           DNDarray([[6, 7, 8]]
+          DNDarray([[6, 7, 8]]
           DNDarray([[ 9, 10, 11]]),
           DNDarray([])
         ]
+    >>> ht.split(x, [1, 2], 1)
+        [ DNDarray([[0],
+                    [3],
+                    [6],
+                    [9]]),
+          DNDarray([[ 1],
+                    [ 4],
+                    [ 7],
+                    [10]],
+          DNDarray([[ 2],
+                    [ 5],
+                    [ 8],
+                    [11]])
+        ]
+
     """
     # sanitize ary
     sanitation.sanitize_input(ary)
@@ -1860,9 +1875,7 @@ def split(ary, indices_or_sections, axis=0):
 
     if ary.split == axis and ary.split is not None and ary.comm.size > 1:
 
-        if isinstance(
-            indices_or_sections, int
-        ):  # TODO eventually use x.comm.counts_displs (easier solution)
+        if isinstance(indices_or_sections, int):
             # CASE 0 number of processes == indices_or_selections -> split already done due to distribution
             if ary.comm.size == indices_or_sections:
                 new_lshape = list(ary.lshape)
@@ -1943,6 +1956,7 @@ def split(ary, indices_or_sections, axis=0):
 
             left_data_process = ary.lshape[axis]
 
+            # TODO eventually restructure code and add if case here instead
             # 5. subtract already split data on a different process
             for i in range(len(indices_or_sections_t)):
                 if offset != 0 and offset - indices_or_sections_t[i] >= 0:

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -2029,7 +2029,7 @@ def split(ary, indices_or_sections, axis=0):
     if ary.split == axis and ary.split is not None and ary.comm.size > 1:
 
         if isinstance(indices_or_sections, int):
-            # CASE 0 number of processes == indices_or_selections -> split already done due to distribution
+            # CASE 1 number of processes == indices_or_selections -> split already done due to distribution
             if ary.comm.size == indices_or_sections:
                 new_lshape = list(ary.lshape)
                 new_lshape[axis] = 0
@@ -2038,35 +2038,34 @@ def split(ary, indices_or_sections, axis=0):
                     for i in range(indices_or_sections)
                 ]
 
-            # # CASE 1 number of processes > tensor-chunk size -> reorder (and split) chunks correctly
-            # # CASE 2 number of processes < tensor-chunk size -> reorder (and split) chunks correctly
+            # # CASE 2 number of processes != indices_or_selections -> reorder (and split) chunks correctly
             else:
                 # no data
                 if ary.lshape[axis] == 0:
                     sub_arrays_t = [torch.empty(ary.lshape) for i in range(indices_or_sections)]
                 else:
                     offset, local_shape, slices = ary.comm.chunk(ary.gshape, axis)
-                    idx_block = offset // indices_or_sections_t
-                    left_data_block = indices_or_sections_t - (offset % indices_or_sections_t)
+                    idx_frst_chunk_affctd = offset // indices_or_sections_t
+                    left_data_chunk = indices_or_sections_t - (offset % indices_or_sections_t)
                     left_data_process = ary.lshape[axis]
 
                     new_indices = torch.zeros(indices_or_sections, dtype=int)
 
-                    if left_data_block >= left_data_process:
-                        new_indices[idx_block] = left_data_process
+                    if left_data_chunk >= left_data_process:
+                        new_indices[idx_frst_chunk_affctd] = left_data_process
                     else:
-                        new_indices[idx_block] = left_data_block
-                        left_data_process -= left_data_block
-                        idx_block += 1
+                        new_indices[idx_frst_chunk_affctd] = left_data_chunk
+                        left_data_process -= left_data_chunk
+                        idx_frst_chunk_affctd += 1
 
-                        # calculate blocks which can be filled completely
-                        left_blocks_to_fill = left_data_process // indices_or_sections_t
+                        # calculate chunks which can be filled completely
+                        left_chunks_to_fill = left_data_process // indices_or_sections_t
                         new_indices[
-                            idx_block : (left_blocks_to_fill + idx_block)
+                            idx_frst_chunk_affctd : (left_chunks_to_fill + idx_frst_chunk_affctd)
                         ] = indices_or_sections_t
 
                         # assign residual to following process
-                        new_indices[left_blocks_to_fill + idx_block] = (
+                        new_indices[left_chunks_to_fill + idx_frst_chunk_affctd] = (
                             left_data_process % indices_or_sections_t
                         )
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1920,6 +1920,9 @@ def sort(a, axis=None, descending=False, out=None):
 def split(ary, indices_or_sections, axis=0):
     """
     Split a DNDarray into multiple sub-DNDarrays as views into ary.
+    ! Warning !
+    Though it is possible to distribute `ary`, this function has nothing to do with the split
+    parameter of a DNDarray.
 
     Parameters
     ----------

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1858,7 +1858,7 @@ def split(ary, indices_or_sections, axis=0):
 
     # start of actual algorithm
 
-    if ary.split == axis and ary.split is not None:
+    if ary.split == axis and ary.split is not None and ary.comm.size > 1:
         # CASE 0 number of processes == indices_or_selections -> split already done due to distribution
         if isinstance(indices_or_sections, int) and ary.comm.size == indices_or_sections:
             new_lshape = list(ary.lshape)
@@ -1868,20 +1868,31 @@ def split(ary, indices_or_sections, axis=0):
                 for i in range(indices_or_sections)
             ]
 
-        # CASE 1 number of processes > tensor-chunk size -> reorder chunks correctly
+        # CASE 1 number of processes > tensor-chunk size -> reorder (and split) chunks correctly
         elif isinstance(indices_or_sections, int) and ary.comm.size > indices_or_sections:
             # no data
             if ary.lshape[axis] == 0:
                 sub_arrays_t = [torch.empty(ary.lshape) for i in range(indices_or_sections_t)]
-            # already correctly split
-            elif indices_or_sections_t == ary.lshape[axis]:
-                sub_arrays_t = [
-                    torch.empty(ary.lshape) if i != ary.comm.rank else ary._DNDarray__array
-                    for i in range(indices_or_sections)
-                ]
-            # chunks too small
+            # calculate mapped list
             else:
-                pass
+                offset, local_shape, slices = ary.comm.chunk(ary.gshape, axis)
+                idx_block = offset // indices_or_sections_t
+                left_data_block = indices_or_sections_t - (offset % indices_or_sections_t)
+
+                # put all available data on process on concerned block
+                if left_data_block >= ary.lshape[axis]:
+                    new_lshape = list(ary.lshape)
+                    new_lshape[axis] = 0
+                    sub_arrays_t = [
+                        torch.empty(new_lshape) if i != idx_block else ary._DNDarray__array
+                        for i in range(indices_or_sections)
+                    ]
+                else:
+                    new_indices = torch.zeros(indices_or_sections, dtype=int)
+                    new_indices[idx_block] = left_data_block
+                    new_indices[idx_block + 1] = ary.gshape[axis] - left_data_block
+
+                    sub_arrays_t = torch.split(ary._DNDarray__array, new_indices.tolist(), axis)
 
         else:
             raise ValueError(

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -664,6 +664,10 @@ def dsplit(ary, indices_or_sections):
     ValueError
         If indices_or_sections is given as integer, but a split does not result in equal division.
 
+    See Also
+    ------
+    :function:`split <heat.core.manipulations.split>`
+
     Examples
     --------
     >>> x = ht.array(24).reshape((2, 3, 4))
@@ -948,6 +952,10 @@ def hsplit(ary, indices_or_sections):
     ------
     ValueError
         If indices_or_sections is given as integer, but a split does not result in equal division.
+
+    See Also
+    ------
+    :function:`split <heat.core.manipulations.split>`
 
     Examples
     --------
@@ -2669,6 +2677,10 @@ def vsplit(ary, indices_or_sections):
     ------
     ValueError
         If indices_or_sections is given as integer, but a split does not result in equal division.
+
+    See Also
+    ------
+    :function:`split <heat.core.manipulations.split>`
 
     Examples
     --------

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -632,23 +632,24 @@ def diagonal(a, offset=0, dim1=0, dim2=1):
 
 def dsplit(ary, indices_or_sections):
     """
-    Split array into multiple sub-arrays along the 3rd axis (depth).
+    Split array into multiple sub-DNDarrays along the 3rd axis (depth).
+    Note that this function returns copies and not views into `ary`.
 
     Parameters
     ----------
     ary : DNDarray
         DNDArray to be divided into sub-DNDarrays.
     indices_or_sections : int or 1-dimensional array_like (i.e. undistributed DNDarray, list or tuple)
-        If indices_or_sections is an integer, N, the DNDarray will be divided into N equal DNDarrays along the 3rd axis.
+        If `indices_or_sections` is an integer, N, the DNDarray will be divided into N equal DNDarrays along the 3rd axis.
         If such a split is not possible, an error is raised.
-        If indices_or_sections is a 1-D DNDarray of sorted integers, the entries indicate where along the 3rd axis
+        If `indices_or_sections` is a 1-D DNDarray of sorted integers, the entries indicate where along the 3rd axis
         the array is split.
-        If an index exceeds the dimension of the array along the 3rd axis, an empty sub-array is returned correspondingly.
+        If an index exceeds the dimension of the array along the 3rd axis, an empty sub-DNDarray is returned correspondingly.
 
     Returns
     -------
     sub_arrays : list of DNDarrays
-        A list of sub-DNDarrays as views into ary.
+        A list of sub-DNDarrays as copies of parts of `ary`.
 
     Notes
     -----
@@ -658,7 +659,7 @@ def dsplit(ary, indices_or_sections):
     Raises
     ------
     ValueError
-        If indices_or_sections is given as integer, but a split does not result in equal division.
+        If `indices_or_sections` is given as integer, but a split does not result in equal division.
 
     See Also
     ------
@@ -919,23 +920,24 @@ def flipud(a):
 
 def hsplit(ary, indices_or_sections):
     """
-    Split array into multiple sub-arrays along the 2nd axis (horizontally/column-wise).
+    Split array into multiple sub-DNDarrays along the 2nd axis (horizontally/column-wise).
+    Note that this function returns copies and not views into `ary`.
 
     Parameters
     ----------
     ary : DNDarray
         DNDArray to be divided into sub-DNDarrays.
     indices_or_sections : int or 1-dimensional array_like (i.e. undistributed DNDarray, list or tuple)
-        If indices_or_sections is an integer, N, the DNDarray will be divided into N equal DNDarrays along the 2nd axis.
+        If `indices_or_sections` is an integer, N, the DNDarray will be divided into N equal DNDarrays along the 2nd axis.
         If such a split is not possible, an error is raised.
-        If indices_or_sections is a 1-D DNDarray of sorted integers, the entries indicate where along the 2nd axis
+        If `indices_or_sections` is a 1-D DNDarray of sorted integers, the entries indicate where along the 2nd axis
         the array is split.
-        If an index exceeds the dimension of the array along the 2nd axis, an empty sub-array is returned correspondingly.
+        If an index exceeds the dimension of the array along the 2nd axis, an empty sub-DNDarray is returned correspondingly.
 
     Returns
     -------
     sub_arrays : list of DNDarrays
-        A list of sub-DNDarrays as views into ary.
+        A list of sub-DNDarrays as copies of parts of `ary`
 
     Notes
     -----
@@ -945,7 +947,7 @@ def hsplit(ary, indices_or_sections):
     Raises
     ------
     ValueError
-        If indices_or_sections is given as integer, but a split does not result in equal division.
+        If `indices_or_sections` is given as integer, but a split does not result in equal division.
 
     See Also
     --------
@@ -982,7 +984,7 @@ def hsplit(ary, indices_or_sections):
 
                       [[21, 22, 23]]])]
        """
-    sanitation.sanitize_input(ary)
+    sanitation.sanitize_in(ary)
 
     if len(ary.lshape) < 2:
         ary = reshape(ary, (1, ary.lshape[0]))
@@ -2159,30 +2161,30 @@ def sort(a, axis=None, descending=False, out=None):
 
 def split(ary, indices_or_sections, axis=0):
     """
-    Split a DNDarray into multiple sub-DNDarrays as copies of parts of ary.
+    Split a DNDarray into multiple sub-DNDarrays as copies of parts of `ary`.
 
     Parameters
     ----------
     ary : DNDarray
         DNDArray to be divided into sub-DNDarrays.
     indices_or_sections : int or 1-dimensional array_like (i.e. undistributed DNDarray, list or tuple)
-        If indices_or_sections is an integer, N, the DNDarray will be divided into N equal DNDarrays along axis.
+        If `indices_or_sections` is an integer, N, the DNDarray will be divided into N equal DNDarrays along axis.
         If such a split is not possible, an error is raised.
-        If indices_or_sections is a 1-D DNDarray of sorted integers, the entries indicate where along axis
+        If `indices_or_sections` is a 1-D DNDarray of sorted integers, the entries indicate where along axis
         the array is split.
-        For example, indices_or_sections = [2, 3] would, for axis = 0, result in
-        - ary[:2]
-        - ary[2:3]
-        - ary[3:]
+        For example, `indices_or_sections = [2, 3]` would, for `axis = 0`, result in
+        - `ary[:2]`
+        - `ary[2:3]`
+        - `ary[3:]`
         If an index exceeds the dimension of the array along axis, an empty sub-array is returned correspondingly.
     axis : int, optional
         The axis along which to split, default is 0.
-        axis is not allowed to equal ary.split if ary is distributed.
+        `axis` is not allowed to equal `ary.split` if `ary` is distributed.
 
     Returns
     -------
     sub_arrays : list of DNDarrays
-        A list of sub-DNDarrays as views into ary.
+        A list of sub-DNDarrays as copies of parts of `ary`.
 
     Warnings
     --------
@@ -2192,7 +2194,7 @@ def split(ary, indices_or_sections, axis=0):
     Raises
     ------
     ValueError
-        If indices_or_sections is given as integer, but a split does not result in equal division.
+        If `indices_or_sections` is given as integer, but a split does not result in equal division.
 
     See Also
     --------
@@ -2231,7 +2233,7 @@ def split(ary, indices_or_sections, axis=0):
 
     """
     # sanitize ary
-    sanitation.sanitize_input(ary)
+    sanitation.sanitize_in(ary)
 
     # sanitize axis
     if not isinstance(axis, int):
@@ -2893,33 +2895,34 @@ def unique(a, sorted=False, return_inverse=False, axis=None):
 
 def vsplit(ary, indices_or_sections):
     """
-    Split array into multiple sub-arrays along the 1st axis (vertically/row-wise).
+    Split array into multiple sub-DNDNarrays along the 1st axis (vertically/row-wise).
+    Note that this function returns copies and not views into `ary`.
 
     Parameters
     ----------
     ary : DNDarray
         DNDArray to be divided into sub-DNDarrays.
     indices_or_sections : int or 1-dimensional array_like (i.e. undistributed DNDarray, list or tuple)
-        If indices_or_sections is an integer, N, the DNDarray will be divided into N equal DNDarrays along the 1st axis.
+        If `indices_or_sections` is an integer, N, the DNDarray will be divided into N equal DNDarrays along the 1st axis.
         If such a split is not possible, an error is raised.
-        If indices_or_sections is a 1-D DNDarray of sorted integers, the entries indicate where along the 1st axis
+        If `indices_or_sections` is a 1-D DNDarray of sorted integers, the entries indicate where along the 1st axis
         the array is split.
-        If an index exceeds the dimension of the array along the 1st axis, an empty sub-array is returned correspondingly.
+        If an index exceeds the dimension of the array along the 1st axis, an empty sub-DNDarray is returned correspondingly.
 
     Returns
     -------
     sub_arrays : list of DNDarrays
-        A list of sub-DNDarrays as views into ary.
+        A list of sub-DNDarrays as copies of parts of `ary`.
 
     Notes
     -----
-    Please refer to the split documentation. hsplit is equivalent to split with axis=0,
+    Please refer to the split documentation. hsplit is equivalent to split with `axis=0`,
     the array is always split along the first axis regardless of the array dimension.
 
     Raises
     ------
     ValueError
-        If indices_or_sections is given as integer, but a split does not result in equal division.
+        If `indices_or_sections` is given as integer, but a split does not result in equal division.
 
     See Also
     --------

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -640,9 +640,6 @@ def dsplit(ary, indices_or_sections):
     """
     Split array into multiple sub-arrays along the 3rd axis (depth).
 
-    Please refer to the split documentation. dsplit is equivalent to split with axis=2,
-    the array is always split along the third axis provided the array dimension is greater than or equal to 3.
-
     Parameters
     ----------
     ary : DNDarray
@@ -658,6 +655,11 @@ def dsplit(ary, indices_or_sections):
     -------
     sub_arrays : list of DNDarrays
         A list of sub-DNDarrays as views into ary.
+
+    Notes
+    -----
+    Please refer to the split documentation. dsplit is equivalent to split with axis=2,
+    the array is always split along the third axis provided the array dimension is greater than or equal to 3.
 
     Raises
     ------
@@ -676,14 +678,12 @@ def dsplit(ary, indices_or_sections):
             DNDarray([[[ 0,  1],
                        [ 4,  5],
                        [ 8,  9]],
-
                        [[12, 13],
                        [16, 17],
                        [20, 21]]]),
             DNDarray([[[ 2,  3],
                        [ 6,  7],
                        [10, 11]],
-
                        [[14, 15],
                        [18, 19],
                        [22, 23]]])
@@ -693,14 +693,12 @@ def dsplit(ary, indices_or_sections):
             DNDarray([[[ 0],
                         [ 4],
                         [ 8]],
-
                        [[12],
                         [16],
                         [20]]]),
             DNDarray([[[ 1,  2,  3],
                         [ 5,  6,  7],
                         [ 9, 10, 11]],
-
                         [[13, 14, 15],
                          [17, 18, 19],
                          [21, 22, 23]]]),
@@ -929,9 +927,6 @@ def hsplit(ary, indices_or_sections):
     """
     Split array into multiple sub-arrays along the 2nd axis (horizontally/column-wise).
 
-    Please refer to the split documentation. hsplit is nearly equivalent to split with axis=1,
-    the array is always split along the second axis though, in contrary to split, regardless of the array dimension.
-
     Parameters
     ----------
     ary : DNDarray
@@ -948,13 +943,18 @@ def hsplit(ary, indices_or_sections):
     sub_arrays : list of DNDarrays
         A list of sub-DNDarrays as views into ary.
 
+    Notes
+    -----
+    Please refer to the split documentation. hsplit is nearly equivalent to split with axis=1,
+    the array is always split along the second axis though, in contrary to split, regardless of the array dimension.
+
     Raises
     ------
     ValueError
         If indices_or_sections is given as integer, but a split does not result in equal division.
 
     See Also
-    ------
+    --------
     :function:`split <heat.core.manipulations.split>`
 
     Examples
@@ -1908,9 +1908,6 @@ def sort(a, axis=None, descending=False, out=None):
 def split(ary, indices_or_sections, axis=0):
     """
     Split a DNDarray into multiple sub-DNDarrays as views into ary.
-    ! Warning !
-    Though it is possible to distribute `ary`, this function has nothing to do with the split
-    parameter of a DNDarray.
 
     Parameters
     ----------
@@ -1935,10 +1932,20 @@ def split(ary, indices_or_sections, axis=0):
     sub_arrays : list of DNDarrays
         A list of sub-DNDarrays as views into ary.
 
+    Warnings
+    --------
+    Though it is possible to distribute `ary`, this function has nothing to do with the split
+    parameter of a DNDarray.
+
     Raises
     ------
     ValueError
         If indices_or_sections is given as integer, but a split does not result in equal division.
+
+    See Also
+    --------
+    :function:`dsplit <heat.core.manipulations.dsplit>`, :function:`hsplit <heat.core.manipulations.hsplit>`,
+    :function:`vsplit <heat.core.manipulations.vsplit>`
 
     Examples
     --------
@@ -2654,9 +2661,6 @@ def vsplit(ary, indices_or_sections):
     """
     Split array into multiple sub-arrays along the 1st axis (vertically/row-wise).
 
-    Please refer to the split documentation. hsplit is equivalent to split with axis=0,
-    the array is always split along the first axis regardless of the array dimension.
-
     Parameters
     ----------
     ary : DNDarray
@@ -2673,13 +2677,18 @@ def vsplit(ary, indices_or_sections):
     sub_arrays : list of DNDarrays
         A list of sub-DNDarrays as views into ary.
 
+    Notes
+    -----
+    Please refer to the split documentation. hsplit is equivalent to split with axis=0,
+    the array is always split along the first axis regardless of the array dimension.
+
     Raises
     ------
     ValueError
         If indices_or_sections is given as integer, but a split does not result in equal division.
 
     See Also
-    ------
+    --------
     :function:`split <heat.core.manipulations.split>`
 
     Examples
@@ -2690,14 +2699,12 @@ def vsplit(ary, indices_or_sections):
             DNDarray([[[ 0,  1],
                        [ 2,  3],
                        [ 4,  5]],
-
                       [[ 6,  7],
                        [ 8,  9],
                        [10, 11]]]),
             DNDarray([[[12, 13],
                        [14, 15],
                        [16, 17]],
-
                       [[18, 19],
                        [20, 21],
                        [22, 23]]])
@@ -2711,7 +2718,6 @@ def vsplit(ary, indices_or_sections):
             DNDarray([[[ 6,  7],
                        [ 8,  9],
                        [10, 11]],
-
                       [[12, 13],
                        [14, 15],
                        [16, 17]]]),

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1442,7 +1442,7 @@ def split(ary, indices_or_sections, axis=0):
 
     Returns
     -------
-    sub-arrays : list of DNDarrays
+    sub_arrays : list of DNDarrays
         A list of sub-DNDarrays as views into ary.
 
     Raises
@@ -1477,6 +1477,8 @@ def split(ary, indices_or_sections, axis=0):
                     ary.gshape, indices_or_sections, axis
                 )
             )
+        # to adapt torch syntax
+        indices_or_sections -= 1
     elif isinstance(indices_or_sections, (list, tuple, dndarray.DNDarray)):
         if isinstance(indices_or_sections, (list, tuple)):
             indices_or_sections = factories.array(indices_or_sections)
@@ -1492,6 +1494,13 @@ def split(ary, indices_or_sections, axis=0):
                 type(indices_or_sections)
             )
         )
+
+    if ary.split is None:
+        sub_arrays_t = torch.split(ary, indices_or_sections, axis)
+
+    return factories.array(
+        sub_arrays_t, dtype=ary.dtype, is_split=ary.split, device=ary.device, comm=ary.comm
+    )
 
 
 def squeeze(x, axis=None):

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1354,7 +1354,30 @@ class TestManipulations(TestCase):
                     )
 
     def test_split(self):
-        pass
+        # ====================================
+        # UNDISTRIBUTED CASE
+        # ====================================
+        data_ht = ht.arange(24).reshape((2, 3, 4))
+        data_np = data_ht.numpy()
+
+        # indices_or_sections = int
+        result = ht.split(data_ht, 2)
+        comparison = np.split(data_np, 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = tuple
+        # result = ht.split(data_ht, )
+
+        # indices_or_sections = list
+
+        # indices_or_sections = undistributed DNDarray
+
+        # indices_or_sections = distributed DNDarray
 
     def test_resplit(self):
         if ht.MPI_WORLD.size > 1:

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1459,8 +1459,19 @@ class TestManipulations(TestCase):
         data_ht = ht.arange(120, split=0).reshape((4, 5, 6))
         data_np = data_ht.numpy()
 
+        if data_ht.comm.size == 2:  # TODO generalize
+            result = ht.split(data_ht, 2)
+            comparison = np.split(data_np, 2)
+
+            self.assertTrue(len(result) == len(comparison))
+
+            for i in range(len(result)):
+                self.assertIsInstance(result[i], ht.DNDarray)
+                self.assertTrue((ht.array(comparison[i]) == result[i]).all())
+                # self.assert_array_equal(result[i], comparison[i])
+
         with self.assertRaises(ValueError):
-            ht.split(data_ht, 2, 0)
+            ht.split(data_ht, [0, 2], 0)
 
         # ====================================
         # axis != ary.split

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1475,6 +1475,37 @@ class TestManipulations(TestCase):
             self.assertIsInstance(result[i], ht.DNDarray)
             self.assert_array_equal(result[i], comparison[i])
 
+        # indices_or_sections = list
+        result = ht.split(data_ht, [3, 4, 6], 2)
+        comparison = np.split(data_np, [3, 4, 6], 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = undistributed DNDarray
+        result = ht.split(data_ht, ht.array([3, 4, 6]), 2)
+        comparison = np.split(data_np, np.array([3, 4, 6]), 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = distributed DNDarray
+        indices = ht.array([3, 4, 6], split=0)
+        result = ht.split(data_ht, indices, 2)
+        comparison = np.split(data_np, np.array([3, 4, 6]), 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
     def test_resplit(self):
         if ht.MPI_WORLD.size > 1:
             # resplitting with same axis, should leave everything unchanged

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1371,7 +1371,14 @@ class TestManipulations(TestCase):
             self.assert_array_equal(result[i], comparison[i])
 
         # indices_or_sections = tuple
-        # result = ht.split(data_ht, )
+        result = ht.split(data_ht, [0, 1])
+        comparison = np.split(data_np, [0, 1])
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
 
         # indices_or_sections = list
 

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1796,9 +1796,45 @@ class TestManipulations(TestCase):
             self.assertIsInstance(result[i], ht.DNDarray)
             self.assertTrue((ht.array(comparison[i]) == result[i]).all())
 
-        if data_ht.comm.size > 1:
-            with self.assertRaises(ValueError):
-                ht.split(data_ht, [0, 2], 0)
+        # indices_or_sections = tuple
+        result = ht.split(data_ht, (1, 3, 5))
+        comparison = np.split(data_np, (1, 3, 5))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = list
+        result = ht.split(data_ht, [1, 3, 5])
+        comparison = np.split(data_np, [1, 3, 5])
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = undistributed DNDarray
+        result = ht.split(data_ht, ht.array([1, 3, 5]))
+        comparison = np.split(data_np, np.array([1, 3, 5]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = distributed DNDarray
+        result = ht.split(data_ht, ht.array([1, 3, 5], split=0))
+        comparison = np.split(data_np, np.array([1, 3, 5]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
 
         # ====================================
         # axis != ary.split

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1353,6 +1353,9 @@ class TestManipulations(TestCase):
                         ).all()
                     )
 
+    def test_split(self):
+        pass
+
     def test_resplit(self):
         if ht.MPI_WORLD.size > 1:
             # resplitting with same axis, should leave everything unchanged

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -739,7 +739,59 @@ class TestManipulations(TestCase):
         )
 
     def test_dsplit(self):
-        pass  # TODO
+        # for further testing, see test_split
+        data_ht = ht.arange(24).reshape((2, 3, 4))
+        data_np = data_ht.numpy()
+
+        # indices_or_sections = int
+        result = ht.dsplit(data_ht, 2)
+        comparison = np.dsplit(data_np, 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = tuple
+        result = ht.dsplit(data_ht, (0, 1))
+        comparison = np.dsplit(data_np, (0, 1))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = list
+        result = ht.dsplit(data_ht, [0, 1])
+        comparison = np.dsplit(data_np, [0, 1])
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = undistributed DNDarray
+        result = ht.dsplit(data_ht, ht.array([0, 1]))
+        comparison = np.dsplit(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = distributed DNDarray
+        result = ht.dsplit(data_ht, ht.array([0, 1], split=0))
+        comparison = np.dsplit(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
 
     def test_expand_dims(self):
         # vector data
@@ -966,6 +1018,115 @@ class TestManipulations(TestCase):
             dtype=ht.int8,
         )
         self.assertTrue(ht.equal(ht.resplit(ht.flipud(c), 0), r_c))
+
+    def test_hsplit(self):
+        # for further testing, see test_split
+        # 1-dimensional array (as forbidden in split)
+        data_ht = ht.arange(24)
+        data_np = data_ht.numpy()
+
+        # indices_or_sections = int
+        result = ht.hsplit(data_ht, 2)
+        comparison = np.hsplit(data_np, 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = tuple
+        result = ht.hsplit(data_ht, (0, 1))
+        comparison = np.hsplit(data_np, (0, 1))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = list
+        result = ht.hsplit(data_ht, [0, 1])
+        comparison = np.hsplit(data_np, [0, 1])
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = undistributed DNDarray
+        result = ht.hsplit(data_ht, ht.array([0, 1]))
+        comparison = np.hsplit(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = distributed DNDarray
+        result = ht.hsplit(data_ht, ht.array([0, 1], split=0))
+        comparison = np.hsplit(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        data_ht = ht.arange(24).reshape((2, 4, 3))
+        data_np = data_ht.numpy()
+
+        # indices_or_sections = int
+        result = ht.hsplit(data_ht, 2)
+        comparison = np.hsplit(data_np, 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = tuple
+        result = ht.hsplit(data_ht, (0, 1))
+        comparison = np.hsplit(data_np, (0, 1))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = list
+        result = ht.hsplit(data_ht, [0, 1])
+        comparison = np.hsplit(data_np, [0, 1])
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = undistributed DNDarray
+        result = ht.hsplit(data_ht, ht.array([0, 1]))
+        comparison = np.hsplit(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = distributed DNDarray
+        result = ht.hsplit(data_ht, ht.array([0, 1], split=0))
+        comparison = np.hsplit(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
 
     def test_hstack(self):
         # cases to test:
@@ -2350,6 +2511,61 @@ class TestManipulations(TestCase):
         data_split_zero = ht.array(torch_array, split=0)
         res, inv = ht.unique(data_split_zero, return_inverse=True, sorted=True)
         self.assertTrue(torch.equal(inv, exp_inv.to(dtype=inv.dtype)))
+
+    def test_vsplit(self):
+        # for further testing, see test_split
+        data_ht = ht.arange(24).reshape((4, 3, 2))
+        data_np = data_ht.numpy()
+
+        # indices_or_sections = int
+        result = ht.vsplit(data_ht, 2)
+        comparison = np.vsplit(data_np, 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = tuple
+        result = ht.vsplit(data_ht, (0, 1))
+        comparison = np.vsplit(data_np, (0, 1))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = list
+        result = ht.vsplit(data_ht, [0, 1])
+        comparison = np.vsplit(data_np, [0, 1])
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = undistributed DNDarray
+        result = ht.vsplit(data_ht, ht.array([0, 1]))
+        comparison = np.vsplit(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = distributed DNDarray
+        result = ht.vsplit(data_ht, ht.array([0, 1], split=0))
+        comparison = np.vsplit(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
 
     def test_vstack(self):
         # cases to test:

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1451,6 +1451,30 @@ class TestManipulations(TestCase):
         with self.assertRaises(ValueError):
             ht.split(data_ht, [[0, 1]])
 
+        # ====================================
+        # DISTRIBUTED CASE
+        # ====================================
+        # axis == ary.split
+        # ====================================
+        data_ht = ht.arange(120, split=0).reshape((4, 5, 6))
+        data_np = data_ht.numpy()
+
+        with self.assertRaises(ValueError):
+            ht.split(data_ht, 2, 0)
+
+        # ====================================
+        # axis != ary.split
+        # ====================================
+        # indices_or_sections = int
+        result = ht.split(data_ht, 2, 2)
+        comparison = np.split(data_np, 2, 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
     def test_resplit(self):
         if ht.MPI_WORLD.size > 1:
             # resplitting with same axis, should leave everything unchanged

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1357,6 +1357,8 @@ class TestManipulations(TestCase):
         # ====================================
         # UNDISTRIBUTED CASE
         # ====================================
+        # axis = 0
+        # ====================================
         data_ht = ht.arange(24).reshape((2, 3, 4))
         data_np = data_ht.numpy()
 
@@ -1371,6 +1373,16 @@ class TestManipulations(TestCase):
             self.assert_array_equal(result[i], comparison[i])
 
         # indices_or_sections = tuple
+        result = ht.split(data_ht, (0, 1))
+        comparison = np.split(data_np, (0, 1))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = list
         result = ht.split(data_ht, [0, 1])
         comparison = np.split(data_np, [0, 1])
 
@@ -1380,11 +1392,56 @@ class TestManipulations(TestCase):
             self.assertIsInstance(result[i], ht.DNDarray)
             self.assert_array_equal(result[i], comparison[i])
 
-        # indices_or_sections = list
-
         # indices_or_sections = undistributed DNDarray
+        result = ht.split(data_ht, ht.array([0, 1]))
+        comparison = np.split(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
 
         # indices_or_sections = distributed DNDarray
+
+        # ====================================
+        # axis != 0 (2 in this case)
+        # ====================================
+        # indices_or_sections = int
+        result = ht.split(data_ht, 2, 2)
+        comparison = np.split(data_np, 2, 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # indices_or_sections = tuple
+        result = ht.split(data_ht, (0, 1))
+        comparison = np.split(data_np, (0, 1))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
+
+        # exceptions
+        with self.assertRaises(TypeError):
+            ht.split([1, 2, 3, 4], 2)
+        with self.assertRaises(TypeError):
+            ht.split(data_ht, "2")
+        with self.assertRaises(TypeError):
+            ht.split(data_ht, 2, "0")
+        with self.assertRaises(ValueError):
+            ht.split(data_ht, 2, -1)
+        with self.assertRaises(ValueError):
+            ht.split(data_ht, 2, 3)
+        with self.assertRaises(ValueError):
+            ht.split(data_ht, 5)
+        with self.assertRaises(ValueError):
+            ht.split(data_ht, [[0, 1]])
 
     def test_resplit(self):
         if ht.MPI_WORLD.size > 1:

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1796,6 +1796,15 @@ class TestManipulations(TestCase):
                 self.assertIsInstance(result[i], ht.DNDarray)
                 self.assertTrue((ht.array(comparison[i]) == result[i]).all())
                 # self.assert_array_equal(result[i], comparison[i])
+        if data_ht.comm.size > 2:  # TODO generalize
+            result = ht.split(data_ht, 2)
+            comparison = np.split(data_np, 2)
+
+            self.assertTrue(len(result) == len(comparison))
+
+            for i in range(len(result)):
+                self.assertIsInstance(result[i], ht.DNDarray)
+                self.assertTrue((ht.array(comparison[i]) == result[i]).all())
 
         with self.assertRaises(ValueError):
             ht.split(data_ht, [0, 2], 0)

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1403,6 +1403,14 @@ class TestManipulations(TestCase):
             self.assert_array_equal(result[i], comparison[i])
 
         # indices_or_sections = distributed DNDarray
+        result = ht.split(data_ht, ht.array([0, 1], split=0))
+        comparison = np.split(data_np, np.array([0, 1]))
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assert_array_equal(result[i], comparison[i])
 
         # ====================================
         # axis != 0 (2 in this case)

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -738,6 +738,9 @@ class TestManipulations(TestCase):
             numpy_args={"axis1": 0, "axis2": 1},
         )
 
+    def test_dsplit(self):
+        pass  # TODO
+
     def test_expand_dims(self):
         # vector data
         a = ht.arange(10)
@@ -1789,6 +1792,20 @@ class TestManipulations(TestCase):
         # indices = int
         result = ht.split(data_ht, 2)
         comparison = np.split(data_np, 2)
+
+        self.assertTrue(len(result) == len(comparison))
+
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assertTrue((ht.array(comparison[i]) == result[i]).all())
+
+        # larger example
+        data_ht_large = ht.arange(160, split=0).reshape((8, 5, 4))
+        data_np_large = data_ht_large.numpy()
+
+        # indices = int
+        result = ht.split(data_ht_large, 2)
+        comparison = np.split(data_np_large, 2)
 
         self.assertTrue(len(result) == len(comparison))
 

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1786,28 +1786,19 @@ class TestManipulations(TestCase):
         data_ht = ht.arange(120, split=0).reshape((4, 5, 6))
         data_np = data_ht.numpy()
 
-        if data_ht.comm.size == 2:  # TODO generalize
-            result = ht.split(data_ht, 2)
-            comparison = np.split(data_np, 2)
+        # indices = int
+        result = ht.split(data_ht, 2)
+        comparison = np.split(data_np, 2)
 
-            self.assertTrue(len(result) == len(comparison))
+        self.assertTrue(len(result) == len(comparison))
 
-            for i in range(len(result)):
-                self.assertIsInstance(result[i], ht.DNDarray)
-                self.assertTrue((ht.array(comparison[i]) == result[i]).all())
-                # self.assert_array_equal(result[i], comparison[i])
-        if data_ht.comm.size > 2:  # TODO generalize
-            result = ht.split(data_ht, 2)
-            comparison = np.split(data_np, 2)
+        for i in range(len(result)):
+            self.assertIsInstance(result[i], ht.DNDarray)
+            self.assertTrue((ht.array(comparison[i]) == result[i]).all())
 
-            self.assertTrue(len(result) == len(comparison))
-
-            for i in range(len(result)):
-                self.assertIsInstance(result[i], ht.DNDarray)
-                self.assertTrue((ht.array(comparison[i]) == result[i]).all())
-
-        with self.assertRaises(ValueError):
-            ht.split(data_ht, [0, 2], 0)
+        if data_ht.comm.size > 1:
+            with self.assertRaises(ValueError):
+                ht.split(data_ht, [0, 2], 0)
 
         # ====================================
         # axis != ary.split


### PR DESCRIPTION
## Description

Implementation of functions `split()`, `vsplit()`, `hsplit()`, `dsplit()` based on np analogues.
For process-local operations, I use `torch.split`

Docs numpy: 
- split: https://numpy.org/doc/stable/reference/generated/numpy.split.html
- vsplit: https://numpy.org/doc/stable/reference/generated/numpy.vsplit.html
- hsplit: https://numpy.org/doc/stable/reference/generated/numpy.hsplit.html
- dsplit: https://numpy.org/doc/stable/reference/generated/numpy.dsplit.html

Docs pytorch: https://pytorch.org/docs/stable/generated/torch.split.html

### differences numpy and torch 
This affects the input parameter `indices_or_sections` (np) / `split_size_or_sections` (torch).
As the variations in the given names might already reveal, the parameters contain different types of information depending on the used library.

_Numpy_:
- _integer_:
  In this case, `indices_or_sections` indicates in how many parts the input `ary` shall be split. 
  Therefore, `indices_or_sections = 2` will result into a list containing 2 DNDarrays.
- _array_like_
  On the other hand, `indices_or_sections` can be handled as a list containing the boundaries of a series of slices
  For instance, `indices_or_sections = [1, 3, 4]` will indicate the following data chunks:
      - [: 1]
      - [1: 3]
      - [3: 4]
      - [4: ]

_Torch_:
In contrary to numpy, the torch analogue always contains the size(s) of the resulting tensor(s).
If _integer_, all (function-)split tensors will have the same size, otherwise the possibly varying split sizes might be defined in an _array_like_.

According to these differences, the parameter semantics of _numpy_ are mapped to those of _torch_ as explained in the following.


### Strategy
As `vsplit, dsplit, hsplit` are no more than calls of `split` with a specific axis, I'll reduce the explanation to the algorithm of the latter.

Depending on whether `ary` is distributed in the same dimension as it is split within the function (therefore `ary.split == axis`), the strategy varies, as the data chunks on each node have to be reorganized correctly in the resulting list of (function-) split DNDarrays. (Challenge: Data of (function-) split DNDarrays is split via MPI)

#### axis != ary.split
Mapping np -> torch:
If `indices_or_sections` is _integer_, the resulting size for all DNDarrays will be calculated using the size of the affected axis.
If `indices_or_sections` is _array_like_, the resulting split sizes are calculated using`ht.diff` (1st discrete difference).


#### axis == ary.split
- `indices_or_sections` is _integer_:
   - **CASE 1** : number of processes == _indices_or_selections_
     In this case, the split matches the distribution and the data on the node can be used directly and inserted into the resulting list.
     The remaining DNDarrays are filled with empty DNDarrays of the needed shape.
   - **CASE 2**: number of processes != _indices_or_selections_
      The goal is, to use `torch.split` with the process-adapted/correctly calculated `indices_or_sections` parameter (`new_indices`)
      1. Calculate the index of the first element in the resulting list which needs data of the current process
      2. Calculate the amount of data which is needed to fill this chunk up
      3. Use the remaining data of the process for the following chunks
- `indices_or_sections` is _array_like_ / _DNDarray_ after sanitation
   The goal is, to use `torch.split` with the process-adapted/correctly calculated `indices_or_sections` parameter.
   Therefore, reduce the input information of `indices_or_sections` to the process relevant/ the given indices (of the global DNDarray) which correspond to the (local) data on the node. The needed information is provided via the slice out of `ht.comm.chunk`
   Afterwards, map the _numpy_ to the _torch_ semantics, as described above in `axis != ary.split`

      
In all cases, every DNDarray within the list is balanced before being returned.

#### Overview split functions and related axis
| Function       | Axis     | 
| :------------- | :----------: | 
|  _vsplit_ | 0   | 
| _hsplit_   | 1 | 
|  _dsplit_ | 2   | 

Hint: In contrary to the corresponding general split function call with axis 1, the input within `hsplit` is allowed to be 1-dimensional.
This results into some dimension changing operations in the HeAT version, more specifically a reshape adding one dimension and a flattening afterwards, to meet full consistency with numpy.


Issue/s resolved: #510 

## Changes proposed:
- Implemented new functions: `manipulations.split()`, `manipulations.hsplit()`, `manipulations.vsplit()`, `manipulations.dsplit()`
- Implemented corresponding tests


## Type of change
- New feature (non-breaking change which adds functionality)


## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

