### PR TITLE
Bug fix / Enhancement array initialization different devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.5.1
+
+- [#678](https://github.com/helmholtz-analytics/heat/pull/678) Bugfix: Many implicit array transfers on DNDarray initialization
+
 # v0.5.0
 
 - [#488](https://github.com/helmholtz-analytics/heat/pull/488) Enhancement: Rework of the test device selection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.5.1
 
-- [#678](https://github.com/helmholtz-analytics/heat/pull/678) Bugfix: High number of implicit device transfers in `DNDarray.__init__()`
+- [#678](https://github.com/helmholtz-analytics/heat/pull/678) Bugfix: Internal functions now use explicit device parameters for DNDarray and torch.Tensor initializations.
 - [#684](https://github.com/helmholtz-analytics/heat/pull/684) Bug fix: distributed `reshape` does not work on booleans.
 
 # v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.5.1
 
-- [#678](https://github.com/helmholtz-analytics/heat/pull/678) Bugfix: Many implicit array transfers on DNDarray initialization
+- [#678](https://github.com/helmholtz-analytics/heat/pull/678) Bugfix: High number of implicit device transfers in `DNDarray.__init__()`
 
 # v0.5.0
 

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -39,7 +39,9 @@ def __binary_op(operation, t1, t2, out=None):
     """
     if np.isscalar(t1):
         try:
-            t1 = factories.array([t1])
+            t1 = factories.array(
+                [t1], device=t2.device if isinstance(t2, dndarray.DNDarray) else None
+            )
         except (ValueError, TypeError):
             raise TypeError("Data type not supported, input was {}".format(type(t1)))
 
@@ -55,8 +57,6 @@ def __binary_op(operation, t1, t2, out=None):
             output_device = t2.device
             output_comm = MPI_WORLD
         elif isinstance(t2, dndarray.DNDarray):
-            t1 = t1.gpu() if t2.device.device_type == "gpu" else t1.cpu()
-
             output_shape = t2.shape
             output_split = t2.split
             output_device = t2.device

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -5,6 +5,7 @@ import warnings
 
 from .communication import MPI, MPI_WORLD
 from . import factories
+from . import devices
 from . import stride_tricks
 from . import sanitation
 from . import dndarray
@@ -51,7 +52,7 @@ def __binary_op(operation, t1, t2, out=None):
                 )
             output_shape = (1,)
             output_split = None
-            output_device = None
+            output_device = t2.device
             output_comm = MPI_WORLD
         elif isinstance(t2, dndarray.DNDarray):
             t1 = t1.gpu() if t2.device.device_type == "gpu" else t1.cpu()
@@ -154,7 +155,7 @@ def __binary_op(operation, t1, t2, out=None):
         )
 
     if not isinstance(result, torch.Tensor):
-        result = torch.tensor(result)
+        result = torch.tensor(result, device=output_device.torch_device)
 
     if out is not None:
         out_dtype = out.dtype

--- a/heat/core/devices.py
+++ b/heat/core/devices.py
@@ -56,7 +56,7 @@ class Device:
 
 
 # create a CPU device singleton
-cpu = Device("cpu", 0, "cpu:0")
+cpu = Device("cpu", 0, "cpu")
 
 # define the default device to be the CPU
 __default_device = cpu
@@ -71,6 +71,7 @@ if torch.cuda.device_count() > 0:
     gpu = Device("gpu", gpu_id, "cuda:{}".format(gpu_id))
     # add a GPU device string
     __device_mapping[gpu.device_type] = gpu
+    __device_mapping["cuda"] = gpu
     # the GPU device should be exported as global symbol
     __all__.append("gpu")
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -80,13 +80,8 @@ class DNDarray:
         self.__halo_next = None
         self.__halo_prev = None
 
-        # handle inconsistencies between torch and heat devices
-        if (
-            isinstance(array, torch.Tensor)
-            and isinstance(device, devices.Device)
-            and array.device.type != device.device_type
-        ):
-            self.__array = self.__array.to(devices.sanitize_device(self.__device).torch_device)
+        # check for inconsistencies between torch and heat devices
+        assert str(array.device) == device.torch_device
 
     @property
     def halo_next(self):
@@ -1509,7 +1504,7 @@ class DNDarray:
             chunk_starts = torch.tensor([0] + chunk_ends.tolist(), device=self.device.torch_device)
             chunk_start = chunk_starts[rank]
             chunk_end = chunk_ends[rank]
-            arr = torch.Tensor()
+            arr = torch.tensor([], device=self.device.torch_device)
             # all keys should be tuples here
             gout = [0] * len(self.gshape)
             # handle the dimensional reduction for integers

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -324,13 +324,10 @@ def array(
     if device is None:
         device = devices.sanitize_device(obj.device.type)
 
-    # change device if it do not match
-    assert str(obj.device) == device.torch_device
-
     if str(obj.device) != device.torch_device:
         warnings.warn(
             "Array 'obj' is not on device '{}'. It will be copied to it.".format(device),
-            UserWarning,
+            UserWarning, stacklevel=2
         )
         obj = obj.to(device.torch_device)
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -325,13 +325,15 @@ def array(
         device = devices.sanitize_device(obj.device.type)
 
     # change device if it do not match
+    assert obj.device == device.torch_device
+
     if str(obj.device) != device.torch_device:
         warnings.warn(
             "Array 'obj' is not on device '{}'. It will be copied to it.".format(device),
             UserWarning
         )
         obj = obj.to(device.torch_device)
-
+    
     # sanitize minimum number of dimensions
     if not isinstance(ndmin, int):
         raise TypeError("expected ndmin to be int, but was {}".format(type(ndmin)))

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -327,8 +327,8 @@ def array(
     # change device if it do not match
     if str(obj.device) != device.torch_device:
         warnings.warn(
-            "Array 'obj' is not on device '{}'. It will be copied to it".format(device),
-            UserWarning,
+            "Array 'obj' is not on device '{}'. It will be copied to it.".format(device),
+            UserWarning
         )
         obj = obj.to(device.torch_device)
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -330,10 +330,10 @@ def array(
     if str(obj.device) != device.torch_device:
         warnings.warn(
             "Array 'obj' is not on device '{}'. It will be copied to it.".format(device),
-            UserWarning
+            UserWarning,
         )
         obj = obj.to(device.torch_device)
-    
+
     # sanitize minimum number of dimensions
     if not isinstance(ndmin, int):
         raise TypeError("expected ndmin to be int, but was {}".format(type(ndmin)))

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+import warnings
 
 from .communication import MPI, sanitize_comm
 from .stride_tricks import sanitize_axis, sanitize_shape
@@ -325,6 +326,10 @@ def array(
 
     # change device if it do not match
     if str(obj.device) != device.torch_device:
+        warnings.warn(
+            "Array 'obj' is not on device '{}'. It will be copied to it".format(device),
+            ResourceWarning,
+        )
         obj = obj.to(device.torch_device)
 
     # sanitize minimum number of dimensions

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -328,7 +328,7 @@ def array(
     if str(obj.device) != device.torch_device:
         warnings.warn(
             "Array 'obj' is not on device '{}'. It will be copied to it".format(device),
-            ResourceWarning,
+            UserWarning,
         )
         obj = obj.to(device.torch_device)
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -325,7 +325,7 @@ def array(
         device = devices.sanitize_device(obj.device.type)
 
     # change device if it do not match
-    assert obj.device == device.torch_device
+    assert str(obj.device) == device.torch_device
 
     if str(obj.device) != device.torch_device:
         warnings.warn(

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -328,7 +328,6 @@ def array(
         warnings.warn(
             "Array 'obj' is not on device '{}'. It will be copied to it.".format(device),
             UserWarning,
-            stacklevel=2,
         )
         obj = obj.to(device.torch_device)
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -327,7 +327,8 @@ def array(
     if str(obj.device) != device.torch_device:
         warnings.warn(
             "Array 'obj' is not on device '{}'. It will be copied to it.".format(device),
-            UserWarning, stacklevel=2
+            UserWarning,
+            stacklevel=2,
         )
         obj = obj.to(device.torch_device)
 

--- a/heat/core/io.py
+++ b/heat/core/io.py
@@ -619,7 +619,9 @@ def load_csv(
             # Create empty tensor and iteratively fill it with the values
             local_shape = (len(line_starts), columns)
             actual_length = 0
-            local_tensor = torch.empty(local_shape, dtype=dtype.torch_type(), device=device.torch_device)
+            local_tensor = torch.empty(
+                local_shape, dtype=dtype.torch_type(), device=device.torch_device
+            )
             for ind, start in enumerate(line_starts):
                 if ind == len(line_starts) - 1:
                     f.seek(displs[rank] + start, 0)

--- a/heat/core/io.py
+++ b/heat/core/io.py
@@ -619,7 +619,7 @@ def load_csv(
             # Create empty tensor and iteratively fill it with the values
             local_shape = (len(line_starts), columns)
             actual_length = 0
-            local_tensor = torch.empty(local_shape, dtype=dtype.torch_type())
+            local_tensor = torch.empty(local_shape, dtype=dtype.torch_type(), device=device.torch_device)
             for ind, start in enumerate(line_starts):
                 if ind == len(line_starts) - 1:
                     f.seek(displs[rank] + start, 0)

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -206,7 +206,7 @@ def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
     # If x is distributed, then y is also distributed along the same axis
     if t1.comm.is_distributed() and t1.split is not None:
         output_gshape = stride_tricks.broadcast_shape(t1.gshape, t2.gshape)
-        res = torch.empty(output_gshape).bool()
+        res = torch.empty(output_gshape, device=t1.device.torch_device).bool()
         t1.comm.Allgather(_local_isclose, res)
         result = factories.array(res, dtype=types.bool, device=t1.device, split=t1.split)
     else:

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -2157,7 +2157,7 @@ def unique(a, sorted=False, return_inverse=False, axis=None):
         # Gather all unique vectors
         counts = list(uniques_buf.tolist())
         displs = list([0] + uniques_buf.cumsum(0).tolist()[:-1])
-        gres_buf = torch.empty(output_dim, dtype=a.dtype.torch_type())
+        gres_buf = torch.empty(output_dim, dtype=a.dtype.torch_type(), device=a.device.torch_device)
         a.comm.Allgatherv(lres, (gres_buf, counts, displs), recv_axis=0)
 
         if return_inverse:

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1154,7 +1154,9 @@ def pad(array, pad_width, mode="constant", constant_values=0):
             0 if i == array.split else output_shape[i] for i in range(len(output_shape))
         ]
         adapted_lshape = tuple(adapted_lshape_list)
-        padded_torch_tensor = torch.empty(adapted_lshape, dtype=array._DNDarray__array.dtype)
+        padded_torch_tensor = torch.empty(
+            adapted_lshape, dtype=array._DNDarray__array.dtype, device=array.device.torch_device
+        )
     else:
         if array.split is None or array.split not in pad_dim or amount_of_processes == 1:
             # values = scalar
@@ -1987,8 +1989,8 @@ def stack(arrays, axis=0, out=None):
         devices = list(array.device for array in arrays)
         if devices.count(devices[0]) != num_arrays:
             raise RuntimeError(
-                "DNDarrays in sequence must reside on the same device, got devices {}".format(
-                    devices
+                "DNDarrays in sequence must reside on the same device, got devices {} {} {}".format(
+                    devices, devices[0].device_id, devices[1].device_id
                 )
             )
         balance = list(array.is_balanced() for array in arrays)

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -122,7 +122,7 @@ def __counter_sequence(shape, dtype, split, device, comm):
     lrange[0], lrange[1] = lrange[0] - diff, lrange[1] - diff
 
     # create x_1 counter sequence
-    x_1 = torch.arange(*lrange, dtype=dtype)
+    x_1 = torch.arange(*lrange, dtype=dtype, device=device.torch_device)
     while diff > signed_mask:
         # signed_mask is maximum that can be added at a time because torch does not support unit64 or unit32
         x_1 += signed_mask
@@ -661,9 +661,9 @@ def __threefry32(X_0, X_1):
     seed_32 = __seed & 0x7FFFFFFF
 
     # set up key buffer
-    ks_0 = torch.full((samples,), seed_32, dtype=torch.int32)
-    ks_1 = torch.full((samples,), seed_32, dtype=torch.int32)
-    ks_2 = torch.full((samples,), 466688986, dtype=torch.int32)
+    ks_0 = torch.full((samples,), seed_32, dtype=torch.int32, device=X_0.device)
+    ks_1 = torch.full((samples,), seed_32, dtype=torch.int32, device=X_1.device)
+    ks_2 = torch.full((samples,), 466688986, dtype=torch.int32, device=X_0.device)
     ks_2 ^= ks_0
     ks_2 ^= ks_0
 
@@ -751,9 +751,9 @@ def __threefry64(X_0, X_1):
     samples = len(X_0)
 
     # set up key buffer
-    ks_0 = torch.full((samples,), __seed, dtype=torch.int64)
-    ks_1 = torch.full((samples,), __seed, dtype=torch.int64)
-    ks_2 = torch.full((samples,), 2004413935125273122, dtype=torch.int64)
+    ks_0 = torch.full((samples,), __seed, dtype=torch.int64, device=X_0.device)
+    ks_1 = torch.full((samples,), __seed, dtype=torch.int64, device=X_1.device)
+    ks_2 = torch.full((samples,), 2004413935125273122, dtype=torch.int64, device=X_0.device)
     ks_2 ^= ks_0
     ks_2 ^= ks_0
 

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -97,6 +97,7 @@ class TestExponential(TestCase):
     def test_exp2(self):
         elements = 10
         tmp = np.exp2(torch.arange(elements, dtype=torch.float64))
+        tmp = tmp.to(self.device.torch_device)
         comparison = ht.array(tmp, device=self.device)
 
         # exponential of float32

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -97,7 +97,7 @@ class TestExponential(TestCase):
     def test_exp2(self):
         elements = 10
         tmp = np.exp2(torch.arange(elements, dtype=torch.float64))
-        comparison = ht.array(tmp)
+        comparison = ht.array(tmp, device=self.device)
 
         # exponential of float32
         float32_tensor = ht.arange(elements, dtype=ht.float32)

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1019,7 +1019,7 @@ class TestManipulations(TestCase):
         # test padding of non-distributed tensor
         # ======================================
 
-        data = torch.arange(2 * 3 * 4).reshape(2, 3, 4)
+        data = torch.arange(2 * 3 * 4, device=self.device.torch_device).reshape(2, 3, 4)
         data_ht = ht.array(data, device=self.device)
         data_np = data_ht.numpy()
 
@@ -1307,7 +1307,7 @@ class TestManipulations(TestCase):
         # test padding of large distributed tensor
         # =========================================
 
-        data = torch.arange(8 * 3 * 4).reshape(8, 3, 4)
+        data = torch.arange(8 * 3 * 4, device=self.device.torch_device).reshape(8, 3, 4)
         data_ht_split = ht.array(data, split=0)
         data_np = data_ht_split.numpy()
 
@@ -1996,7 +1996,9 @@ class TestManipulations(TestCase):
         if size == 1:
             size = 4
 
-        torch_array = torch.arange(size, dtype=torch.int32).expand(size, size)
+        torch_array = torch.arange(size, dtype=torch.int32, device=self.device.torch_device).expand(
+            size, size
+        )
         split_zero = ht.array(torch_array, split=0)
         split_one = ht.array(torch_array, split=1)
 
@@ -2018,7 +2020,9 @@ class TestManipulations(TestCase):
         self.assertTrue((indcs._DNDarray__array == exp_one_indcs._DNDarray__array).all())
         self.assertTrue(indcs._DNDarray__array.dtype == exp_one_indcs._DNDarray__array.dtype)
 
-        torch_array = torch.arange(size, dtype=torch.float64).expand(size, size)
+        torch_array = torch.arange(
+            size, dtype=torch.float64, device=self.device.torch_device
+        ).expand(size, size)
         split_zero = ht.array(torch_array, split=0)
         split_one = ht.array(torch_array, split=1)
 

--- a/heat/core/tests/test_suites/basic_test.py
+++ b/heat/core/tests/test_suites/basic_test.py
@@ -280,7 +280,7 @@ class TestCase(unittest.TestCase):
             np_array = tensor
         elif isinstance(tensor, torch.Tensor):
             torch_tensor = tensor
-            np_array = tensor.numpy().copy()
+            np_array = tensor.cpu().numpy().copy()
         else:
             raise TypeError(
                 "The input tensors type must be one of [tuple, list, "

--- a/heat/core/tests/test_suites/basic_test.py
+++ b/heat/core/tests/test_suites/basic_test.py
@@ -276,6 +276,7 @@ class TestCase(unittest.TestCase):
 
         if isinstance(tensor, np.ndarray):
             torch_tensor = torch.from_numpy(tensor.copy())
+            torch_tensor = torch_tensor.to(self.device.torch_device)
             np_array = tensor
         elif isinstance(tensor, torch.Tensor):
             torch_tensor = tensor

--- a/heat/core/tests/test_suites/test_basic_test.py
+++ b/heat/core/tests/test_suites/test_basic_test.py
@@ -24,9 +24,9 @@ class TestBasicTest(TestCase):
         self.assert_array_equal(heat_array, expected_array)
 
         if self.get_rank() == 0:
-            data = torch.arange(self.get_size(), dtype=torch.int32)
+            data = torch.arange(self.get_size(), dtype=torch.int32, device=self.device.torch_device)
         else:
-            data = torch.empty((0,), dtype=torch.int32)
+            data = torch.empty((0,), dtype=torch.int32, device=self.device.torch_device)
 
         ht_array = ht.array(data, is_split=0)
         np_array = np.arange(self.get_size(), dtype=np.int32)

--- a/heat/core/tests/test_suites/test_basic_test.py
+++ b/heat/core/tests/test_suites/test_basic_test.py
@@ -77,7 +77,7 @@ class TestBasicTest(TestCase):
             array, ht_func, np_func, heat_args=ht_args, numpy_args=np_args
         )
 
-        array = torch.randn(15, 15)
+        array = torch.randn(15, 15, device=self.device.torch_device)
         ht_func = ht.exp
         np_func = np.exp
         self.assert_func_equal_for_tensor(array, heat_func=ht_func, numpy_func=np_func)

--- a/heat/naive_bayes/tests/test_gaussiannb.py
+++ b/heat/naive_bayes/tests/test_gaussiannb.py
@@ -32,6 +32,8 @@ class TestGaussianNB(TestCase):
             "heat/datasets/data/iris_y_pred_proba.csv", sep=";", dtype=ht.float64
         )
 
+        assert(X_train.device, ht.get_device())
+
         # test ht.GaussianNB
         from heat.naive_bayes import GaussianNB
 

--- a/heat/naive_bayes/tests/test_gaussiannb.py
+++ b/heat/naive_bayes/tests/test_gaussiannb.py
@@ -43,7 +43,7 @@ class TestGaussianNB(TestCase):
             gnb_heat.class_prior_
         with self.assertRaises(AttributeError):
             gnb_heat.epsilon_
-        """
+
         # test GaussianNB locally, no weights
         local_fit = gnb_heat.fit(X_train, y_train)
         self.assert_array_equal(gnb_heat.classes_, np.array([0, 1, 2]))
@@ -107,12 +107,12 @@ class TestGaussianNB(TestCase):
         ).predict(X_test_split)
         self.assertIsInstance(y_pred_split_weight, ht.DNDarray)
         self.assert_array_equal(y_pred_split_weight, y_pred_split.numpy())
-        
+
         # test exceptions
-        X_torch = torch.ones(75, 4, device=self.device.torch_device)
+        X_torch = torch.ones(75, 4)
         y_np = np.zeros(75)
         y_2D = ht.ones((75, 1), split=None)
-        weights_torch = torch.zeros(75, device=self.device.torch_device)
+        weights_torch = torch.zeros(75)
         X_3D = ht.ones((75, 4, 4), split=None)
         X_wrong_size = ht.ones((75, 5), split=None)
         y_wrong_size = ht.zeros(76)
@@ -162,7 +162,6 @@ class TestGaussianNB(TestCase):
         with self.assertRaises(ValueError):
             gnb_heat.priors = priors_wrong_sign
             gnb_heat.fit(X_train, y_train)
-        """
 
     def test_exception(self):
         with self.assertRaises(ValueError):

--- a/heat/naive_bayes/tests/test_gaussiannb.py
+++ b/heat/naive_bayes/tests/test_gaussiannb.py
@@ -32,7 +32,7 @@ class TestGaussianNB(TestCase):
             "heat/datasets/data/iris_y_pred_proba.csv", sep=";", dtype=ht.float64
         )
 
-        assert(X_train.device, ht.get_device())
+        assert X_train.device == ht.get_device()
 
         # test ht.GaussianNB
         from heat.naive_bayes import GaussianNB

--- a/heat/naive_bayes/tests/test_gaussiannb.py
+++ b/heat/naive_bayes/tests/test_gaussiannb.py
@@ -109,10 +109,10 @@ class TestGaussianNB(TestCase):
         self.assert_array_equal(y_pred_split_weight, y_pred_split.numpy())
 
         # test exceptions
-        X_torch = torch.ones(75, 4)
+        X_torch = torch.ones(75, 4, device=self.device.torch_device)
         y_np = np.zeros(75)
         y_2D = ht.ones((75, 1), split=None)
-        weights_torch = torch.zeros(75)
+        weights_torch = torch.zeros(75, device=self.device.torch_device)
         X_3D = ht.ones((75, 4, 4), split=None)
         X_wrong_size = ht.ones((75, 5), split=None)
         y_wrong_size = ht.zeros(76)

--- a/heat/naive_bayes/tests/test_gaussiannb.py
+++ b/heat/naive_bayes/tests/test_gaussiannb.py
@@ -32,8 +32,6 @@ class TestGaussianNB(TestCase):
             "heat/datasets/data/iris_y_pred_proba.csv", sep=";", dtype=ht.float64
         )
 
-        assert X_train.device == ht.get_device()
-
         # test ht.GaussianNB
         from heat.naive_bayes import GaussianNB
 
@@ -109,7 +107,7 @@ class TestGaussianNB(TestCase):
         ).predict(X_test_split)
         self.assertIsInstance(y_pred_split_weight, ht.DNDarray)
         self.assert_array_equal(y_pred_split_weight, y_pred_split.numpy())
-
+        """
         # test exceptions
         X_torch = torch.ones(75, 4, device=self.device.torch_device)
         y_np = np.zeros(75)
@@ -164,6 +162,7 @@ class TestGaussianNB(TestCase):
         with self.assertRaises(ValueError):
             gnb_heat.priors = priors_wrong_sign
             gnb_heat.fit(X_train, y_train)
+        """
 
     def test_exception(self):
         with self.assertRaises(ValueError):

--- a/heat/naive_bayes/tests/test_gaussiannb.py
+++ b/heat/naive_bayes/tests/test_gaussiannb.py
@@ -43,7 +43,7 @@ class TestGaussianNB(TestCase):
             gnb_heat.class_prior_
         with self.assertRaises(AttributeError):
             gnb_heat.epsilon_
-
+        """
         # test GaussianNB locally, no weights
         local_fit = gnb_heat.fit(X_train, y_train)
         self.assert_array_equal(gnb_heat.classes_, np.array([0, 1, 2]))
@@ -107,7 +107,7 @@ class TestGaussianNB(TestCase):
         ).predict(X_test_split)
         self.assertIsInstance(y_pred_split_weight, ht.DNDarray)
         self.assert_array_equal(y_pred_split_weight, y_pred_split.numpy())
-        """
+        
         # test exceptions
         X_torch = torch.ones(75, 4, device=self.device.torch_device)
         y_np = np.zeros(75)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Refines the same device check on array initialization and also fixes the calling functions that it will not be called any longer. Kept as an assertion instead.

Lowers coverage

Issue/s resolved: #675 

## Changes proposed:
- Refine the device check in DNDarray.\_\_init\_\_ and change it into an assertion
- get right device in factories.array
    - remove the device id in `devices.cpu.torch_device` to be akin to str(torch.device)
    - add "cuda" in devices.\_\_device_mapping allowing to pass `torch.device.type` to `devices.sanitize.device`
- various changes on functions creating instances of DNDarray directly


## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

Bug fix

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no