### PR TITLE
Features/547 histc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Pending additions
 
-- [#679](https://github.com/helmholtz-analytics/heat/pull/679) New feature: distributed `histc()`
-
 ## New features
 - [#680](https://github.com/helmholtz-analytics/heat/pull/680) New property: larray
 - [#683](https://github.com/helmholtz-analytics/heat/pull/683) New properties: nbytes, gnbytes, lnbytes
 ### Manipulations
 ### Statistical Functions
+- [#679](https://github.com/helmholtz-analytics/heat/pull/679) New feature: ``histc()`` and ``histogram()``
 ### Linear Algebra
 ### ...
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Pending additions
+
+- [#679](https://github.com/helmholtz-analytics/heat/pull/679) New feature: distributed `histc()`
+
 ## New features
 ### Manipulations
 ### Statistical Functions

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -553,8 +553,8 @@ def histc(input, bins: int = 100, min: int = 0, max: int = 0, out=None):
     """
 
     if min == max:
-        min = int(input.min())
-        max = int(input.max())
+        min = float(input.min())
+        max = float(input.max())
 
     hist = torch.histc(
         input._DNDarray__array,

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -592,9 +592,9 @@ def histogram(
               number of histogram bins
     range   : Tuple[int,int], optional
               lower and upper end of the bins. If not provided, range is simply (a.min(), a.max()).
-    normed  : Not used
-    weights : Not used
-    density : Not used
+    normed  : Not supported
+    weights : Not supported
+    density : Not supported
 
     Returns
     -------

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -22,6 +22,7 @@ __all__ = [
     "bincount",
     "cov",
     "histc",
+    "histogram",
     "kurtosis",
     "max",
     "maximum",
@@ -528,11 +529,11 @@ def histc(input, bins: int = 100, min: int = 0, max: int = 0, out=None):
     ----------
     input : DNDarray
             the input array, must be of float type
-    bins  : int
+    bins  : int, optional
             number of histogram bins
-    min   : int
+    min   : int, optional
             lower end of the range (inclusive)
-    max   : int
+    max   : int, optional
             upper end of the range (inclusive)
     out   : DNDarray, optional
             the output tensor, same dtype as input
@@ -575,6 +576,51 @@ def histc(input, bins: int = 100, min: int = 0, max: int = 0, out=None):
         input.comm.Allreduce(hist, out, op=MPI.SUM)
 
     return out
+
+
+def histogram(
+    a, bins: int = 10, range: Tuple[int, int] = (0, 0), normed=None, weights=None, density=None
+):
+    """
+    Compute the histogram of a DNDarray.
+
+    Parameters
+    ----------
+    a       : DNDarray
+              the input array, must be of float type
+    bins    : int, optional
+              number of histogram bins
+    range   : Tuple[int,int], optional
+              lower and upper end of the bins. If not provided, range is simply (a.min(), a.max()).
+    normed  : Not used
+    weights : Not used
+    density : Not used
+
+    Returns
+    -------
+    hist : DNDarray
+           The values of the histogram.
+
+    Notes
+    -----
+    This is a wrapper function of :function:`~heat.core.statistics.histc` for some basic compatibility with the NumPy API.
+
+    See Also
+    --------
+    :function:`~heat.core.statistics.histc`
+    """
+    # TODO: Rewrite to make it a proper implementation of the NumPy function
+
+    if normed is not None:
+        raise NotImplementedError("'normed' is not supported")
+    if weights is not None:
+        raise NotImplementedError("'weights' is not supported")
+    if density is not None:
+        raise NotImplementedError("'density' is not supported")
+    if not isinstance(bins, int):
+        raise NotImplementedError("'bins' only supports integer values")
+
+    return histc(a, bins, range[0], range[1])
 
 
 def kurtosis(x, axis=None, unbiased=True, Fischer=True):

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -456,7 +456,7 @@ class TestStatistics(TestCase):
 
         self.assertEqual(res.shape, (7,))
         self.assertEqual(res.dtype, ht.float64)
-        self.assertTrue(ht.equal(res, comp))
+        self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         # matrix and splits
         c = torch.rand([10, 10, 10])
@@ -466,25 +466,25 @@ class TestStatistics(TestCase):
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
-        self.assertTrue(ht.equal(res, comp))
+        self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         a = ht.array(c, split=0)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
-        self.assertTrue(ht.equal(res, comp))
+        self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         a = ht.array(c, split=1)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
-        self.assertTrue(ht.equal(res, comp))
+        self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         a = ht.array(c, split=2)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
-        self.assertTrue(ht.equal(res, comp))
+        self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         # out parameter, min max
         out = ht.empty(20, dtype=ht.float32)
@@ -495,13 +495,13 @@ class TestStatistics(TestCase):
         ht.histc(a, bins=20, min=0, max=20, out=out)
         self.assertEqual(out.shape, (20,))
         self.assertEqual(out.dtype, ht.float32)
-        self.assertTrue(ht.equal(out, comp))
+        self.assertTrue(torch.equal(out._DNDarray__array, comp))
 
         a = ht.array(c, split=0)
         ht.histc(a, bins=20, min=0, max=20, out=out)
         self.assertEqual(out.shape, (20,))
         self.assertEqual(out.dtype, ht.float32)
-        self.assertTrue(ht.equal(out, comp))
+        self.assertTrue(torch.equal(out._DNDarray__array, comp))
 
     def test_kurtosis(self):
         x = ht.zeros((2, 3, 4))

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -447,6 +447,62 @@ class TestStatistics(TestCase):
         with self.assertRaises(ValueError):
             ht.cov(htdata, ddof=10000)
 
+    def test_histc(self):
+        # few entries and float64
+        c = torch.arange(4, dtype=torch.float64)
+        comp = torch.histc(c, 7)
+        a = ht.array(c)
+        res = ht.histc(a, 7)
+
+        self.assertEqual(res.shape, (7,))
+        self.assertEqual(res.dtype, ht.float64)
+        self.assertTrue(ht.equal(res, comp))
+
+        # matrix and splits
+        c = torch.rand([10, 10, 10])
+        comp = torch.histc(c)
+
+        a = ht.array(c)
+        res = ht.histc(a)
+        self.assertEqual(res.shape, (100,))
+        self.assertEqual(res.dtype, ht.float32)
+        self.assertTrue(ht.equal(res, comp))
+
+        a = ht.array(c, split=0)
+        res = ht.histc(a)
+        self.assertEqual(res.shape, (100,))
+        self.assertEqual(res.dtype, ht.float32)
+        self.assertTrue(ht.equal(res, comp))
+
+        a = ht.array(c, split=1)
+        res = ht.histc(a)
+        self.assertEqual(res.shape, (100,))
+        self.assertEqual(res.dtype, ht.float32)
+        self.assertTrue(ht.equal(res, comp))
+
+        a = ht.array(c, split=2)
+        res = ht.histc(a)
+        self.assertEqual(res.shape, (100,))
+        self.assertEqual(res.dtype, ht.float32)
+        self.assertTrue(ht.equal(res, comp))
+
+        # out parameter, min max
+        out = ht.empty(20, dtype=ht.float32)
+        c = torch.randint(10, size=(8,), dtype=torch.float32)
+        comp = torch.histc(c, bins=20, min=0, max=20)
+
+        a = ht.array(c)
+        ht.histc(a, bins=20, min=0, max=20, out=out)
+        self.assertEqual(out.shape, (20,))
+        self.assertEqual(out.dtype, ht.float32)
+        self.assertTrue(ht.equal(out, comp))
+
+        a = ht.array(c, split=0)
+        ht.histc(a, bins=20, min=0, max=20, out=out)
+        self.assertEqual(out.shape, (20,))
+        self.assertEqual(out.dtype, ht.float32)
+        self.assertTrue(ht.equal(out, comp))
+
     def test_kurtosis(self):
         x = ht.zeros((2, 3, 4))
         with self.assertRaises(ValueError):

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -451,7 +451,7 @@ class TestStatistics(TestCase):
         self.assertEqual(res.shape, (7,))
         self.assertEqual(res.dtype, ht.float64)
         self.assertEqual(res.device, self.device)
-        self.assertTrue(torch.equal(res._DNDarray__array, comp))
+        self.assertTrue(torch.equal(res.larray, comp))
 
         # matrix and splits
         c = torch.rand([10, 10, 10], device=self.device.torch_device)
@@ -462,28 +462,28 @@ class TestStatistics(TestCase):
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
-        self.assertTrue(torch.equal(res._DNDarray__array, comp))
+        self.assertTrue(torch.equal(res.larray, comp))
 
         a = ht.array(c, split=0)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
-        self.assertTrue(torch.equal(res._DNDarray__array, comp))
+        self.assertTrue(torch.equal(res.larray, comp))
 
         a = ht.array(c, split=1)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
-        self.assertTrue(torch.equal(res._DNDarray__array, comp))
+        self.assertTrue(torch.equal(res.larray, comp))
 
         a = ht.array(c, split=2)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
-        self.assertTrue(torch.equal(res._DNDarray__array, comp))
+        self.assertTrue(torch.equal(res.larray, comp))
 
         # out parameter, min max
         out = ht.empty(20, dtype=ht.float32, device=self.device)
@@ -495,14 +495,33 @@ class TestStatistics(TestCase):
         self.assertEqual(out.shape, (20,))
         self.assertEqual(out.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
-        self.assertTrue(torch.equal(out._DNDarray__array, comp))
+        self.assertTrue(torch.equal(out.larray, comp))
 
         a = ht.array(c, split=0)
         ht.histc(a, bins=20, min=0, max=20, out=out)
         self.assertEqual(out.shape, (20,))
         self.assertEqual(out.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
-        self.assertTrue(torch.equal(out._DNDarray__array, comp))
+        self.assertTrue(torch.equal(out.larray, comp))
+
+        # Alias
+        a = ht.arange(10, dtype=ht.float)
+        hist = ht.histc(a, 10)
+        alias = ht.histogram(a)
+
+        self.assertEqual(alias.gnumel, hist.gnumel)
+        self.assertTrue(ht.equal(alias, hist))
+
+        with self.assertRaises(NotImplementedError):
+            ht.histogram(a, "str")
+        with self.assertRaises(NotImplementedError):
+            ht.histogram(a, [1, 2, 3])
+        with self.assertRaises(NotImplementedError):
+            ht.histogram(a, weights=[1, 2, 3])
+        with self.assertRaises(NotImplementedError):
+            ht.histogram(a, normed=True)
+        with self.assertRaises(NotImplementedError):
+            ht.histogram(a, density=True)
 
     def test_kurtosis(self):
         x = ht.zeros((2, 3, 4))

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -449,58 +449,65 @@ class TestStatistics(TestCase):
 
     def test_histc(self):
         # few entries and float64
-        c = torch.arange(4, dtype=torch.float64)
+        c = torch.arange(4, dtype=torch.float64, device=self.device.torch_device)
         comp = torch.histc(c, 7)
         a = ht.array(c)
         res = ht.histc(a, 7)
 
         self.assertEqual(res.shape, (7,))
         self.assertEqual(res.dtype, ht.float64)
+        self.assertEqual(res.device, self.device)
         self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         # matrix and splits
-        c = torch.rand([10, 10, 10])
+        c = torch.rand([10, 10, 10], device=self.device.torch_device)
         comp = torch.histc(c)
 
         a = ht.array(c)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
+        self.assertEqual(res.device, self.device)
         self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         a = ht.array(c, split=0)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
+        self.assertEqual(res.device, self.device)
         self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         a = ht.array(c, split=1)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
+        self.assertEqual(res.device, self.device)
         self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         a = ht.array(c, split=2)
         res = ht.histc(a)
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
+        self.assertEqual(res.device, self.device)
         self.assertTrue(torch.equal(res._DNDarray__array, comp))
 
         # out parameter, min max
-        out = ht.empty(20, dtype=ht.float32)
-        c = torch.randint(10, size=(8,), dtype=torch.float32)
+        out = ht.empty(20, dtype=ht.float32, device=self.device)
+        c = torch.randint(10, size=(8,), dtype=torch.float32, device=self.device.torch_device)
         comp = torch.histc(c, bins=20, min=0, max=20)
 
         a = ht.array(c)
         ht.histc(a, bins=20, min=0, max=20, out=out)
         self.assertEqual(out.shape, (20,))
         self.assertEqual(out.dtype, ht.float32)
+        self.assertEqual(res.device, self.device)
         self.assertTrue(torch.equal(out._DNDarray__array, comp))
 
         a = ht.array(c, split=0)
         ht.histc(a, bins=20, min=0, max=20, out=out)
         self.assertEqual(out.shape, (20,))
         self.assertEqual(out.dtype, ht.float32)
+        self.assertEqual(res.device, self.device)
         self.assertTrue(torch.equal(out._DNDarray__array, comp))
 
     def test_kurtosis(self):


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Introduction of a histogram function. It adds the histograms returned by torch.histc() from all processes.

Note: This function is equivalent to torch.histc(). A NumPy like histogram function still needs to be implemented as it offers much more options.

Issue/s resolved: #547 (partially)


## Changes proposed:
- histc function

## Type of change
- New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
