### PR TITLE
Features/538 larray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Pending additions
 ## New features
+- [#680](https://github.com/helmholtz-analytics/heat/pull/680) Introduction of property larray
 ### Manipulations
 ### Statistical Functions
 ### Linear Algebra

--- a/heat/cluster/kmedians.py
+++ b/heat/cluster/kmedians.py
@@ -58,7 +58,7 @@ class KMedians(_KCluster):
             # Remove 0-element lines to avoid spoiling of median
             assigned_points = X * selection
             rows = (assigned_points.abs()).sum(axis=1) != 0
-            local = assigned_points._DNDarray__array[rows._DNDarray__array]
+            local = assigned_points.larray[rows._DNDarray__array]
             clean = ht.array(local, is_split=X.split)
             clean.balance_()
             # failsafe in case no point is assigned to this cluster

--- a/heat/cluster/kmedoids.py
+++ b/heat/cluster/kmedoids.py
@@ -59,7 +59,7 @@ class KMedoids(_KCluster):
             # Remove 0-element lines to avoid spoiling of median
             assigned_points = X * selection
             rows = (assigned_points.abs()).sum(axis=1) != 0
-            local = assigned_points._DNDarray__array[rows._DNDarray__array]
+            local = assigned_points.larray[rows._DNDarray__array]
             clean = ht.array(local, is_split=X.split)
             clean.balance_()
             # failsafe in case no point is assigned to this cluster

--- a/heat/cluster/spectral.py
+++ b/heat/cluster/spectral.py
@@ -117,7 +117,7 @@ class Spectral(ht.ClusteringMixin, ht.BaseEstimator):
         V, T = ht.lanczos(L, self.n_lanczos, v0)
 
         # 4. Calculate and Sort Eigenvalues and Eigenvectors of tridiagonal matrix T
-        eval, evec = torch.eig(T._DNDarray__array, eigenvectors=True)
+        eval, evec = torch.eig(T.larray, eigenvectors=True)
         # If x is an Eigenvector of T, then y = V@x is the corresponding Eigenvector of L
         eval, idx = torch.sort(eval[:, 0], dim=0)
         eigenvalues = ht.array(eval)

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -105,7 +105,7 @@ def __binary_op(operation, t1, t2, out=None):
                         "Broadcasting requires transferring data of first operator between MPI ranks!"
                     )
                     if t1.comm.rank > 0:
-                        t1._DNDarray__array = torch.zeros(
+                        t1.larray = torch.zeros(
                             t1.shape, dtype=t1.dtype.torch_type(), device=t1.device.torch_device
                         )
                     t1.comm.Bcast(t1)
@@ -116,7 +116,7 @@ def __binary_op(operation, t1, t2, out=None):
                         "Broadcasting requires transferring data of second operator between MPI ranks!"
                     )
                     if t2.comm.rank > 0:
-                        t2._DNDarray__array = torch.zeros(
+                        t2.larray = torch.zeros(
                             t2.shape, dtype=t2.dtype.torch_type(), device=t2.device.torch_device
                         )
                     t2.comm.Bcast(t2)
@@ -135,30 +135,24 @@ def __binary_op(operation, t1, t2, out=None):
     promoted_type = types.promote_types(t1.dtype, t2.dtype).torch_type()
     if t1.split is not None:
         if len(t1.lshape) > t1.split and t1.lshape[t1.split] == 0:
-            result = t1._DNDarray__array.type(promoted_type)
+            result = t1.larray.type(promoted_type)
         else:
-            result = operation(
-                t1._DNDarray__array.type(promoted_type), t2._DNDarray__array.type(promoted_type)
-            )
+            result = operation(t1.larray.type(promoted_type), t2.larray.type(promoted_type))
     elif t2.split is not None:
 
         if len(t2.lshape) > t2.split and t2.lshape[t2.split] == 0:
-            result = t2._DNDarray__array.type(promoted_type)
+            result = t2.larray.type(promoted_type)
         else:
-            result = operation(
-                t1._DNDarray__array.type(promoted_type), t2._DNDarray__array.type(promoted_type)
-            )
+            result = operation(t1.larray.type(promoted_type), t2.larray.type(promoted_type))
     else:
-        result = operation(
-            t1._DNDarray__array.type(promoted_type), t2._DNDarray__array.type(promoted_type)
-        )
+        result = operation(t1.larray.type(promoted_type), t2.larray.type(promoted_type))
 
     if not isinstance(result, torch.Tensor):
         result = torch.tensor(result)
 
     if out is not None:
         out_dtype = out.dtype
-        out._DNDarray__array = result
+        out.larray = result
         out._DNDarray__comm = output_comm
         out = out.astype(out_dtype)
         return out
@@ -237,9 +231,9 @@ def __cum_op(x, partial_op, exscan_op, final_op, neutral, axis, dtype, out):
         dtype = out.dtype
 
     cumop = partial_op(
-        x._DNDarray__array,
+        x.larray,
         axis,
-        out=None if out is None else out._DNDarray__array,
+        out=None if out is None else out.larray,
         dtype=None if dtype is None else dtype.torch_type(),
     )
 
@@ -314,11 +308,11 @@ def __local_op(operation, x, out, no_cast=False, **kwargs):
         promoted_type = types.promote_types(x.dtype, types.float32)
         torch_type = promoted_type.torch_type()
     else:
-        torch_type = x._DNDarray__array.dtype
+        torch_type = x.larray.dtype
 
     # no defined output tensor, return a freshly created one
     if out is None:
-        result = operation(x._DNDarray__array.type(torch_type), **kwargs)
+        result = operation(x.larray.type(torch_type), **kwargs)
         return dndarray.DNDarray(
             result, x.gshape, types.canonical_heat_type(result.dtype), x.split, x.device, x.comm
         )
@@ -333,10 +327,8 @@ def __local_op(operation, x, out, no_cast=False, **kwargs):
     needs_repetition = builtins.any(multiple > 1 for multiple in multiples)
 
     # do an inplace operation into a provided buffer
-    casted = x._DNDarray__array.type(torch_type)
-    operation(
-        casted.repeat(multiples) if needs_repetition else casted, out=out._DNDarray__array, **kwargs
-    )
+    casted = x.larray.type(torch_type)
+    operation(casted.repeat(multiples) if needs_repetition else casted, out=out.larray, **kwargs)
 
     return out
 
@@ -402,7 +394,7 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
         )
 
     else:
-        partial = x._DNDarray__array
+        partial = x.larray
 
     # apply the partial reduction operation to the local tensor
     if axis is None:

--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -374,7 +374,7 @@ class MPICommunication(Communication):
 
     def Irecv(self, buf, source=MPI.ANY_SOURCE, tag=MPI.ANY_TAG):
         if isinstance(buf, dndarray.DNDarray):
-            buf = buf._DNDarray__array
+            buf = buf.larray
         if not isinstance(buf, torch.Tensor):
             return MPIRequest(self.handle.Irecv(buf, source, tag))
 
@@ -385,7 +385,7 @@ class MPICommunication(Communication):
 
     def Recv(self, buf, source=MPI.ANY_SOURCE, tag=MPI.ANY_TAG, status=None):
         if isinstance(buf, dndarray.DNDarray):
-            buf = buf._DNDarray__array
+            buf = buf.larray
         if not isinstance(buf, torch.Tensor):
             return self.handle.Recv(buf, source, tag, status)
 
@@ -400,7 +400,7 @@ class MPICommunication(Communication):
 
     def __send_like(self, func, buf, dest, tag):
         if isinstance(buf, dndarray.DNDarray):
-            buf = buf._DNDarray__array
+            buf = buf.larray
         if not isinstance(buf, torch.Tensor):
             return func(buf, dest, tag), None
 
@@ -451,7 +451,7 @@ class MPICommunication(Communication):
     def __broadcast_like(self, func, buf, root):
         # unpack the buffer if it is a HeAT tensor
         if isinstance(buf, dndarray.DNDarray):
-            buf = buf._DNDarray__array
+            buf = buf.larray
         # convert torch tensors to MPI memory buffers
         if not isinstance(buf, torch.Tensor):
             return func(buf, root), None, None, None
@@ -479,10 +479,10 @@ class MPICommunication(Communication):
         buf = None
         # unpack the send buffer if it is a HeAT tensor
         if isinstance(sendbuf, dndarray.DNDarray):
-            sendbuf = sendbuf._DNDarray__array
+            sendbuf = sendbuf.larray
         # unpack the receive buffer if it is a HeAT tensor
         if isinstance(recvbuf, dndarray.DNDarray):
-            recvbuf = recvbuf._DNDarray__array
+            recvbuf = recvbuf.larray
 
         # harmonize the input and output buffers
         # MPI requires send and receive buffers to be of same type and length. If the torch tensors are either not both
@@ -582,7 +582,7 @@ class MPICommunication(Communication):
         if isinstance(sendbuf, tuple):
             sendbuf, send_counts, send_displs = sendbuf
         if isinstance(sendbuf, dndarray.DNDarray):
-            sendbuf = sendbuf._DNDarray__array
+            sendbuf = sendbuf.larray
         if not isinstance(sendbuf, torch.Tensor):
             if axis != 0:
                 raise TypeError(
@@ -595,7 +595,7 @@ class MPICommunication(Communication):
         if isinstance(recvbuf, tuple):
             recvbuf, recv_counts, recv_displs = recvbuf
         if isinstance(recvbuf, dndarray.DNDarray):
-            recvbuf = recvbuf._DNDarray__array
+            recvbuf = recvbuf.larray
         if not isinstance(recvbuf, torch.Tensor):
             if axis != 0:
                 raise TypeError(
@@ -741,7 +741,7 @@ class MPICommunication(Communication):
         if isinstance(sendbuf, tuple):
             sendbuf, send_counts, send_displs = sendbuf
         if isinstance(sendbuf, dndarray.DNDarray):
-            sendbuf = sendbuf._DNDarray__array
+            sendbuf = sendbuf.larray
         if not isinstance(sendbuf, torch.Tensor) and send_axis != 0:
             raise TypeError(
                 "sendbuf of type {} does not support send_axis != 0".format(type(sendbuf))
@@ -751,7 +751,7 @@ class MPICommunication(Communication):
         if isinstance(recvbuf, tuple):
             recvbuf, recv_counts, recv_displs = recvbuf
         if isinstance(recvbuf, dndarray.DNDarray):
-            recvbuf = recvbuf._DNDarray__array
+            recvbuf = recvbuf.larray
         if not isinstance(recvbuf, torch.Tensor) and send_axis != 0:
             raise TypeError(
                 "recvbuf of type {} does not support send_axis != 0".format(type(recvbuf))
@@ -906,7 +906,7 @@ class MPICommunication(Communication):
         if isinstance(recvbuf, tuple):
             recvbuf, recv_counts, recv_displs = recvbuf
         if isinstance(recvbuf, dndarray.DNDarray):
-            recvbuf = recvbuf._DNDarray__array
+            recvbuf = recvbuf.larray
         if not isinstance(recvbuf, torch.Tensor) and send_axis != 0:
             raise TypeError(
                 "recvbuf of type {} does not support send_axis != 0".format(type(recvbuf))

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -2,6 +2,8 @@ import numpy as np
 import math
 import torch
 import warnings
+from inspect import stack
+from pathlib import Path
 from typing import List, Union
 
 from . import arithmetics
@@ -138,10 +140,17 @@ class DNDarray:
             raise TypeError(
                 "Expected larray to be a torch tensor, but was {} instead.".format(type(array))
             )
-        warnings.warn(
-            "!!! WARNING !!! Manipulating the local contents of a DNDarray needs to be done with care and "
-            "might corrupt/invalidate the metadata in a DNDarray instance"
-        )
+
+        # raise warning if function was called by user/not out of 'heat/core/*'
+        caller = stack()[1]
+        abs_heat_path = Path("heat", "core").resolve()
+        abs_path_caller = Path(caller.filename).resolve()
+
+        if not (abs_heat_path < abs_path_caller):
+            warnings.warn(
+                "!!! WARNING !!! Manipulating the local contents of a DNDarray needs to be done with care and "
+                "might corrupt/invalidate the metadata in a DNDarray instance"
+            )
         self.__array = array
 
     @property

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -131,7 +131,7 @@ class DNDarray:
 
         Parameters
         ----------
-        array : torch.tensor, float, int
+        array : torch.tensor
             The new underlying local torch tensor of the DNDarray
         """
         if not isinstance(array, torch.Tensor):

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -113,6 +113,37 @@ class DNDarray:
         return self.__gshape
 
     @property
+    def larray(self):
+        """
+        Returns
+        -------
+        larray : torch.Tensor
+                the underlying local torch tensor of the DNDarray
+        """
+        return self.__array
+
+    @larray.setter
+    def larray(self, array):
+        """
+        Setter for larray/ the underlying local torch tensor of the DNDarray.
+        Warning: Please use this function with care, as it might corrupt/invalidate the metadata in the DNDarray instance.
+
+        Parameters
+        ----------
+        array : torch.tensor
+            The new underlying local torch tensor of the DNDarray
+        """
+        if not isinstance(array, torch.Tensor):
+            raise TypeError(
+                "Expected larray to be a torch tensor, but was {} instead.".format(type(array))
+            )
+        self.__array = array
+        warnings.warn(
+            "!!! WARNING !!! Manipulating the local contents of a DNDarray needs to be done with care and "
+            "might corrupt/invalidate the metadata in a DNDarray instance"
+        )
+
+    @property
     def numdims(self):
         """
         Returns

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -126,7 +126,8 @@ class DNDarray:
     def larray(self, array):
         """
         Setter for larray/ the underlying local torch tensor of the DNDarray.
-        Warning: Please use this function with care, as it might corrupt/invalidate the metadata in the DNDarray instance.
+        Warning: Please use this function with care, as it might corrupt/invalidate the metadata in the
+        DNDarray instance.
 
         Parameters
         ----------
@@ -137,11 +138,11 @@ class DNDarray:
             raise TypeError(
                 "Expected larray to be a torch tensor, but was {} instead.".format(type(array))
             )
-        self.__array = array
         warnings.warn(
             "!!! WARNING !!! Manipulating the local contents of a DNDarray needs to be done with care and "
             "might corrupt/invalidate the metadata in a DNDarray instance"
         )
+        self.__array = array
 
     @property
     def numdims(self):

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -229,7 +229,7 @@ def array(
             [3, 4, 5]])
     >>> b.strides
     (24, 8)
-    >>> b._DNDarray__array.storage() #TODO: implement ht.view()
+    >>> b.larray.storage() #TODO: implement ht.view()
     0
     1
     2
@@ -243,7 +243,7 @@ def array(
             [3, 4, 5]])
     >>> c.strides
     (8, 16)
-    >>> c._DNDarray__array.storage() #TODO: implement ht.view()
+    >>> c.larray.storage() #TODO: implement ht.view()
     0
     3
     1
@@ -265,7 +265,7 @@ def array(
     >>> b.strides
     (0/2) (8, 16)
     (1/2) (8, 16)
-    >>> b._DNDarray__array.storage() #TODO: implement ht.view()
+    >>> b.larray.storage() #TODO: implement ht.view()
     (0/2) 0
           3
           1
@@ -283,7 +283,7 @@ def array(
     """
     # extract the internal tensor in case of a heat tensor
     if isinstance(obj, dndarray.DNDarray):
-        obj = obj._DNDarray__array
+        obj = obj.larray
 
     # sanitize the data type
     if dtype is not None:

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -59,16 +59,16 @@ def nonzero(a):
     [1/1] tensor([[7, 8, 9]])
     """
     if a.dtype == types.bool:
-        a._DNDarray__array = a._DNDarray__array.float()
+        a.larray = a.larray.float()
     if a.split is None:
         # if there is no split then just return the values from torch
-        # print(a._DNDarray__array)
-        lcl_nonzero = torch.nonzero(input=a._DNDarray__array, as_tuple=False)
+        # print(a.larray)
+        lcl_nonzero = torch.nonzero(input=a.larray, as_tuple=False)
         gout = list(lcl_nonzero.size())
         is_split = None
     else:
         # a is split
-        lcl_nonzero = torch.nonzero(input=a._DNDarray__array, as_tuple=False)
+        lcl_nonzero = torch.nonzero(input=a.larray, as_tuple=False)
         _, _, slices = a.comm.chunk(a.shape, a.split)
         lcl_nonzero[..., a.split] += slices[a.split].start
         gout = list(lcl_nonzero.size())

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -43,7 +43,7 @@ def dot(a, b, out=None):
             sl = slice(None)
         else:  # at least one of them is split
             sl = a.comm.chunk(a.shape, a.split if a.split is not None else b.split)[2]
-        ret = torch.dot(a[sl]._DNDarray__array, b[sl]._DNDarray__array)
+        ret = torch.dot(a[sl].larray, b[sl].larray)
         if a.is_distributed() or b.is_distributed():
             a.comm.Allreduce(MPI.IN_PLACE, ret, MPI.SUM)
 
@@ -56,7 +56,7 @@ def dot(a, b, out=None):
         ret = matmul(a, b)
         if out is not None:
             if out is not None:
-                out._DNDarray__array = ret._DNDarray__array
+                out.larray = ret.larray
                 out._DNDarray__dtype = ret.dtype
                 out._DNDarray__split = ret.split
                 out._DNDarray__device = ret.device
@@ -155,16 +155,14 @@ def matmul(a, b, allow_resplit=False):
     if a.split is None and b.split is None:  # matmul from torch
         if len(a.gshape) < 2 or len(b.gshape) < 2 or not allow_resplit:
             # if either of A or B is a vector
-            return factories.array(
-                torch.matmul(a._DNDarray__array, b._DNDarray__array), device=a.device
-            )
+            return factories.array(torch.matmul(a.larray, b.larray), device=a.device)
         else:
             a.resplit_(0)
             slice_0 = a.comm.chunk(a.shape, a.split)[2][0]
-            hold = a._DNDarray__array @ b._DNDarray__array
+            hold = a.larray @ b.larray
 
             c = factories.zeros((a.gshape[-2], b.gshape[1]), dtype=c_type, device=a.device)
-            c._DNDarray__array[slice_0.start : slice_0.stop, :] += hold
+            c.larray[slice_0.start : slice_0.stop, :] += hold
             c.comm.Allreduce(MPI.IN_PLACE, c, MPI.SUM)
             return c
 
@@ -174,7 +172,7 @@ def matmul(a, b, allow_resplit=False):
         # make both split 0, do a local mm then a sum
         a.resplit_(0)
         b.resplit_(0)
-        res = a._DNDarray__array @ b._DNDarray__array
+        res = a.larray @ b.larray
         a.comm.Allreduce(MPI.IN_PLACE, res, MPI.SUM)
         return factories.array(res, split=None, device=a.device)
     elif len(a.gshape) < 2:
@@ -195,7 +193,7 @@ def matmul(a, b, allow_resplit=False):
         split = a.split if a.split is not None else b.split
         split = split if not vector_flag else 0
         c = factories.zeros((a.gshape[-2], b.gshape[1]), split=split, dtype=c_type, device=a.device)
-        c._DNDarray__array += a._DNDarray__array @ b._DNDarray__array
+        c.larray += a.larray @ b.larray
 
         return c if not vector_flag else c.squeeze()
 
@@ -205,10 +203,7 @@ def matmul(a, b, allow_resplit=False):
         )
 
         a_idx = a.comm.chunk(a.shape, a.split)[2]
-        c += (
-            a._DNDarray__array
-            @ b._DNDarray__array[a_idx[1].start : a_idx[1].start + a.lshape[-1], :]
-        )
+        c += a.larray @ b.larray[a_idx[1].start : a_idx[1].start + a.lshape[-1], :]
         a.comm.Allreduce(MPI.IN_PLACE, c, MPI.SUM)
         c = c if not vector_flag else c.squeeze()
         c = factories.array(c, split=a.split if b.gshape[1] > 1 else 0, device=a.device)
@@ -219,10 +214,7 @@ def matmul(a, b, allow_resplit=False):
             (a.gshape[-2], b.gshape[1]), dtype=c_type.torch_type(), device=a.device.torch_device
         )
         b_idx = b.comm.chunk(b.shape, b.split)[2]
-        c += (
-            a._DNDarray__array[:, b_idx[0].start : b_idx[0].start + b.lshape[0]]
-            @ b._DNDarray__array
-        )
+        c += a.larray[:, b_idx[0].start : b_idx[0].start + b.lshape[0]] @ b.larray
         b.comm.Allreduce(MPI.IN_PLACE, c, MPI.SUM)
         c = c if not vector_flag else c.squeeze()
         c = factories.array(c, split=b.split if a.gshape[-2] > 1 else 0, device=a.device)
@@ -235,7 +227,7 @@ def matmul(a, b, allow_resplit=False):
             (a.gshape[-2], b.lshape[1]), dtype=c_type.torch_type(), device=a.device.torch_device
         )
         a_idx = a.comm.chunk(a.shape, a.split)[2]
-        c[a_idx[0]] += a._DNDarray__array @ b._DNDarray__array
+        c[a_idx[0]] += a.larray @ b.larray
         a.comm.Allreduce(MPI.IN_PLACE, c, MPI.SUM)
         c = c if not vector_flag else c.squeeze()
         split = a.split if b.gshape[1] > 1 else 0
@@ -247,7 +239,7 @@ def matmul(a, b, allow_resplit=False):
         c = torch.zeros(
             (a.gshape[-2], b.lshape[1]), dtype=c_type.torch_type(), device=a.device.torch_device
         )
-        c += a._DNDarray__array @ b._DNDarray__array
+        c += a.larray @ b.larray
         c = c if not vector_flag else c.squeeze()
         split = b.split if a.gshape[1] > 1 else 0
         split = split if not vector_flag else 0
@@ -310,25 +302,25 @@ def matmul(a, b, allow_resplit=False):
     # rem_map dims guide -> {process number, a/b (0/1), True/False (1/0)
     #   if there is a remainder in this dimension
     rem_map = torch.zeros((a.comm.size, 2, 2))
-    rem_map[a.comm.rank, 0, :] = torch.tensor((rem_a_out, rem_a), device=a._DNDarray__array.device)
-    rem_map[a.comm.rank, 1, :] = torch.tensor((rem_b, rem_b_out), device=a._DNDarray__array.device)
+    rem_map[a.comm.rank, 0, :] = torch.tensor((rem_a_out, rem_a), device=a.larray.device)
+    rem_map[a.comm.rank, 1, :] = torch.tensor((rem_b, rem_b_out), device=a.larray.device)
     rem_map_comm = a.comm.Iallreduce(MPI.IN_PLACE, rem_map, MPI.SUM)
 
     # index_map dims guide -> {process number, a=0/b=1, relevent 1st index, 2nd index}
-    index_map = torch.zeros((a.comm.size, 2, 2, 2), dtype=int, device=b._DNDarray__array.device)
+    index_map = torch.zeros((a.comm.size, 2, 2, 2), dtype=int, device=b.larray.device)
     a_idx = a.comm.chunk(a.shape, a.split)[2]
     index_map[a.comm.rank, 0, 0] = torch.tensor(
-        (a_idx[0].start, a_idx[0].stop), device=b._DNDarray__array.device
+        (a_idx[0].start, a_idx[0].stop), device=b.larray.device
     )
     index_map[a.comm.rank, 0, 1] = torch.tensor(
-        (a_idx[1].start, a_idx[1].stop), device=b._DNDarray__array.device
+        (a_idx[1].start, a_idx[1].stop), device=b.larray.device
     )
     b_idx = b.comm.chunk(b.shape, b.split)[2]
     index_map[b.comm.rank, 1, 0] = torch.tensor(
-        (b_idx[0].start, b_idx[0].stop), device=b._DNDarray__array.device
+        (b_idx[0].start, b_idx[0].stop), device=b.larray.device
     )
     index_map[b.comm.rank, 1, 1] = torch.tensor(
-        (b_idx[1].start, b_idx[1].stop), device=b._DNDarray__array.device
+        (b_idx[1].start, b_idx[1].stop), device=b.larray.device
     )
     index_map_comm = a.comm.Iallreduce(MPI.IN_PLACE, index_map, MPI.SUM)
 
@@ -380,7 +372,7 @@ def matmul(a, b, allow_resplit=False):
             ):
                 # loop over the number of blocks in the 1st dimension
                 a_block_map[pr, dim0, dim1] = torch.tensor(
-                    (dim0 * mB, dim1 * kB), dtype=torch.int, device=a._DNDarray__array.device
+                    (dim0 * mB, dim1 * kB), dtype=torch.int, device=a.larray.device
                 )
     rem_map_comm.Wait()
     if b.split == 0:
@@ -428,7 +420,7 @@ def matmul(a, b, allow_resplit=False):
                 (stop1 - start1) // nB // b.comm.size if b_d1_1s_flag else (stop1 - start1) // nB
             ):
                 b_block_map[pr, dim0, dim1] = torch.tensor(
-                    (dim0 * kB, dim1 * nB), dtype=torch.int, device=b._DNDarray__array.device
+                    (dim0 * kB, dim1 * nB), dtype=torch.int, device=b.larray.device
                 )
 
     if a.split == 1:
@@ -449,7 +441,7 @@ def matmul(a, b, allow_resplit=False):
         b_rem_locs0 = torch.nonzero(rem_map[:, 1, 0] == 1, as_tuple=False)
         a_rem_locs0 = torch.nonzero(rem_map[:, 0, 0] == 1, as_tuple=False)
         # remainders for a in the
-        a_node_rem_s0 = a._DNDarray__array[:mB, kB : (kB + 1) * b_rem_locs0.numel() : kB + 1]
+        a_node_rem_s0 = a.larray[:mB, kB : (kB + 1) * b_rem_locs0.numel() : kB + 1]
         b_rem = torch.empty(
             b_rem_locs0.numel(),
             b.lshape[-1],
@@ -460,7 +452,7 @@ def matmul(a, b, allow_resplit=False):
         # this if/elif/else loop is for the handling of
         if a.comm.rank in a_rem_locs0:
             # if A is split in dim0 and the rank has a remainder in this direction
-            r = a._DNDarray__array[-1]
+            r = a.larray[-1]
             r_loc = index_map[a.comm.rank, 0, 0, 1] - index_map[a.comm.rank, 0, 0, 0] - 1
         else:
             r = None
@@ -471,7 +463,7 @@ def matmul(a, b, allow_resplit=False):
         for pr in range(b.comm.size):
             # ibcast data on node first
             if b.comm.rank == pr:
-                b_lp_data[pr] = b._DNDarray__array.clone()
+                b_lp_data[pr] = b.larray.clone()
             else:
                 b_lp_data[pr] = torch.zeros(
                     (lshape_map[pr, 1, 0].item(), lshape_map[pr, 1, 1].item()),
@@ -489,7 +481,7 @@ def matmul(a, b, allow_resplit=False):
                 __mm_c_block_setter(
                     b_proc=pr - 1,
                     a_proc=a.comm.rank,
-                    a_data=a._DNDarray__array,
+                    a_data=a.larray,
                     b_data=b_lp_data[pr - 1],
                     b_block_map=b_block_map,
                     a_block_map=a_block_map,
@@ -498,7 +490,7 @@ def matmul(a, b, allow_resplit=False):
                     mB=mB,
                     kB=kB,
                     nB=nB,
-                    c=c._DNDarray__array,
+                    c=c.larray,
                 )
 
                 # check if there is a remainder on b in the previous node
@@ -512,7 +504,7 @@ def matmul(a, b, allow_resplit=False):
                     if r_loc is not None:
                         st = index_map[pr - 1, 1, 0, 0].item()
                         sp = index_map[pr - 1, 1, 0, 1].item()
-                        c._DNDarray__array[r_loc.item(), :] += r[st:sp] @ b_lp_data[pr - 1]
+                        c.larray[r_loc.item(), :] += r[st:sp] @ b_lp_data[pr - 1]
 
                 del b_lp_data[pr - 1]
 
@@ -522,7 +514,7 @@ def matmul(a, b, allow_resplit=False):
                 __mm_c_block_setter(
                     b_proc=pr,
                     a_proc=a.comm.rank,
-                    a_data=a._DNDarray__array,
+                    a_data=a.larray,
                     b_data=b_lp_data[pr],
                     b_block_map=b_block_map,
                     a_block_map=a_block_map,
@@ -531,7 +523,7 @@ def matmul(a, b, allow_resplit=False):
                     mB=mB,
                     kB=kB,
                     nB=nB,
-                    c=c._DNDarray__array,
+                    c=c.larray,
                 )
                 # check if there is a remainder on b on the last node (there shouldnt be)
                 if pr in b_rem_locs0:
@@ -547,21 +539,21 @@ def matmul(a, b, allow_resplit=False):
                         if split_01_flag:
                             st1 = index_map[pr, 1, 1, 0].item()
                             sp1 = index_map[pr, 1, 1, 1].item()
-                            c._DNDarray__array[r_loc.item(), st1:sp1] += r[st:sp] @ b_lp_data[pr]
+                            c.larray[r_loc.item(), st1:sp1] += r[st:sp] @ b_lp_data[pr]
                         else:
-                            c._DNDarray__array[r_loc.item(), :] += r[st:sp] @ b_lp_data[pr]
+                            c.larray[r_loc.item(), :] += r[st:sp] @ b_lp_data[pr]
 
                 # set the final blocks on the last loop, then adjust for the
                 # the remainders which were collected in b_rem
                 if b_rem_locs0.numel():
-                    c._DNDarray__array[: a_node_rem_s0.shape[0]] += a_node_rem_s0 @ b_rem
+                    c.larray[: a_node_rem_s0.shape[0]] += a_node_rem_s0 @ b_rem
 
                 del b_lp_data[pr]
 
         if vector_flag:
-            c_loc = c._DNDarray__array.squeeze()
+            c_loc = c.larray.squeeze()
             if c_loc.nelement() == 1:
-                c = torch.tensor(c_loc, device=c._DNDarray__array.device)
+                c = torch.tensor(c_loc, device=c.larray.device)
             c = factories.array(c_loc, is_split=0, device=a.device)
 
         return c
@@ -572,7 +564,7 @@ def matmul(a, b, allow_resplit=False):
         # locations of the remainders in b
         b_rem_locs1 = torch.nonzero(rem_map[:, 1, 1] == 1, as_tuple=False)
         a_rem_locs1 = torch.nonzero(rem_map[:, 0, 1] == 1, as_tuple=False)
-        b_node_rem_s1 = b._DNDarray__array[
+        b_node_rem_s1 = b.larray[
             kB : (kB + 1) * a_rem_locs1.numel() : kB + 1, :nB
         ]  # remainders for a in the
         a_rem = torch.empty(
@@ -585,7 +577,7 @@ def matmul(a, b, allow_resplit=False):
         # this if/elif/else loop is for the handling of
         if b.comm.rank in b_rem_locs1:
             # if b is split in dim1 and the rank has a remainder in this direction
-            r = b._DNDarray__array[:, -1]
+            r = b.larray[:, -1]
             r_loc = index_map[a.comm.rank, 1, 1, 1] - index_map[a.comm.rank, 1, 1, 0] - 1
         else:
             r = None
@@ -596,7 +588,7 @@ def matmul(a, b, allow_resplit=False):
         for pr in range(a.comm.size):
             # ibcast data on node first
             if a.comm.rank == pr:
-                a_lp_data[pr] = a._DNDarray__array.clone()
+                a_lp_data[pr] = a.larray.clone()
             else:
                 a_lp_data[pr] = torch.zeros(
                     (lshape_map[pr, 0, 0].item(), lshape_map[pr, 0, 1].item()),
@@ -615,7 +607,7 @@ def matmul(a, b, allow_resplit=False):
                     a_proc=pr - 1,
                     b_proc=b.comm.rank,
                     a_data=a_lp_data[pr - 1],
-                    b_data=b._DNDarray__array,
+                    b_data=b.larray,
                     b_block_map=b_block_map,
                     a_block_map=a_block_map,
                     b_split=b.split,
@@ -623,7 +615,7 @@ def matmul(a, b, allow_resplit=False):
                     mB=mB,
                     kB=kB,
                     nB=nB,
-                    c=c._DNDarray__array,
+                    c=c.larray,
                 )
 
                 # check if there is a remainder on b in the previous node
@@ -637,9 +629,7 @@ def matmul(a, b, allow_resplit=False):
                     if r_loc is not None:
                         st = index_map[pr - 1, 0, 1, 0].item()
                         sp = index_map[pr - 1, 0, 1, 1].item()
-                        c._DNDarray__array[:, r_loc.item()] += (
-                            a_lp_data[pr - 1] @ r[st:sp, None]
-                        ).flatten()
+                        c.larray[:, r_loc.item()] += (a_lp_data[pr - 1] @ r[st:sp, None]).flatten()
 
                 del a_lp_data[pr - 1]
 
@@ -650,7 +640,7 @@ def matmul(a, b, allow_resplit=False):
                     a_proc=pr,
                     b_proc=a.comm.rank,
                     a_data=a_lp_data[pr],
-                    b_data=b._DNDarray__array,
+                    b_data=b.larray,
                     b_block_map=b_block_map,
                     a_block_map=a_block_map,
                     b_split=b.split,
@@ -658,7 +648,7 @@ def matmul(a, b, allow_resplit=False):
                     mB=mB,
                     kB=kB,
                     nB=nB,
-                    c=c._DNDarray__array,
+                    c=c.larray,
                 )
                 # check if there is a remainder on b on the last node (there shouldnt be)
                 if pr in a_rem_locs1:
@@ -670,19 +660,17 @@ def matmul(a, b, allow_resplit=False):
                     if r_loc is not None:
                         st = index_map[pr, 0, 1, 0].item()
                         sp = index_map[pr, 0, 1, 1].item()
-                        c._DNDarray__array[:, r_loc.item()] += (
-                            a_lp_data[pr] @ r[st:sp, None]
-                        ).flatten()
+                        c.larray[:, r_loc.item()] += (a_lp_data[pr] @ r[st:sp, None]).flatten()
 
                 # set the final blocks on the last loop, then adjust for the the remainders which were collected in b_rem
                 if a_rem_locs1.numel():
-                    c._DNDarray__array[:, : b_node_rem_s1.shape[1]] += a_rem @ b_node_rem_s1
+                    c.larray[:, : b_node_rem_s1.shape[1]] += a_rem @ b_node_rem_s1
 
                 del a_lp_data[pr]
         c = (
             c
             if not vector_flag
-            else factories.array(c._DNDarray__array.squeeze(), is_split=0, device=a.device)
+            else factories.array(c.larray.squeeze(), is_split=0, device=a.device)
         )
         return c
 
@@ -693,7 +681,7 @@ def matmul(a, b, allow_resplit=False):
         for pr in range(a.comm.size):
             # ibcast data on node first
             if b.comm.rank == pr:
-                b_lp_data[pr] = b._DNDarray__array.clone()
+                b_lp_data[pr] = b.larray.clone()
             else:
                 b_lp_data[pr] = torch.empty(
                     (lshape_map[pr, 1, 0].item(), lshape_map[pr, 1, 1].item()),
@@ -712,7 +700,7 @@ def matmul(a, b, allow_resplit=False):
                 sp0 = index_map[pr - 1, 0, 0, 1].item() + 1
                 st1 = index_map[pr - 1, 1, 1, 0].item()
                 sp1 = index_map[pr - 1, 1, 1, 1].item()
-                c._DNDarray__array[: sp0 - st0, st1:sp1] += a._DNDarray__array @ b_lp_data[pr - 1]
+                c.larray[: sp0 - st0, st1:sp1] += a.larray @ b_lp_data[pr - 1]
 
                 del b_lp_data[pr - 1]
 
@@ -722,14 +710,14 @@ def matmul(a, b, allow_resplit=False):
                 sp0 = index_map[pr, 0, 0, 1].item() + 1
                 st1 = index_map[pr, 1, 1, 0].item()
                 sp1 = index_map[pr, 1, 1, 1].item()
-                c._DNDarray__array[: sp0 - st0, st1:sp1] += a._DNDarray__array @ b_lp_data[pr]
+                c.larray[: sp0 - st0, st1:sp1] += a.larray @ b_lp_data[pr]
 
                 del b_lp_data[pr]
 
         c = (
             c
             if not vector_flag
-            else factories.array(c._DNDarray__array.squeeze(), is_split=0, device=a.device)
+            else factories.array(c.larray.squeeze(), is_split=0, device=a.device)
         )
         return c
 
@@ -743,13 +731,10 @@ def matmul(a, b, allow_resplit=False):
             (a.gshape[-2], b.gshape[1]), dtype=c_type.torch_type(), device=c.device.torch_device
         )
         for i in range(a.lshape[-1] // kB):
-            res += (
-                a._DNDarray__array[:mB, i * kB : i * kB + kB]
-                @ b._DNDarray__array[i * kB : i * kB + kB, :nB]
-            )
+            res += a.larray[:mB, i * kB : i * kB + kB] @ b.larray[i * kB : i * kB + kB, :nB]
         if a.comm.rank in a_rem_locs1 and b.comm.rank in b_rem_locs0 and kB > 1:
             # these Nones are used to change the dims if the full process is not covered
-            res += a._DNDarray__array[:, -1, None] @ b._DNDarray__array[None, -1, :]
+            res += a.larray[:, -1, None] @ b.larray[None, -1, :]
 
         a.comm.Allreduce(MPI.IN_PLACE, res, MPI.SUM)
         split = a.split if b.gshape[1] > 1 else 0
@@ -957,8 +942,8 @@ def outer(a, b, out=None, split=None):
         )
 
     outer_gshape = (a.gshape[0], b.gshape[0])
-    t_a = a._DNDarray__array
-    t_b = b._DNDarray__array
+    t_a = a.larray
+    t_b = b.larray
     t_outer_dtype = torch.promote_types(t_a.dtype, t_b.dtype)
     t_a, t_b = t_a.type(t_outer_dtype), t_b.type(t_outer_dtype)
     outer_dtype = types.canonical_heat_type(t_outer_dtype)
@@ -986,10 +971,10 @@ def outer(a, b, out=None, split=None):
 
         if a.split is None:
             a.resplit_(axis=0)
-            t_a = a._DNDarray__array.type(t_outer_dtype)
+            t_a = a.larray.type(t_outer_dtype)
         if b.split is None:
             b.resplit_(axis=0)
-            t_b = b._DNDarray__array.type(t_outer_dtype)
+            t_b = b.larray.type(t_outer_dtype)
         if split is None:
             # Split semantics: default out.split = a.split
             split = a.split
@@ -1056,7 +1041,7 @@ def outer(a, b, out=None, split=None):
     )
 
     if out is not None:
-        out._DNDarray__array = outer._DNDarray__array
+        out.larray = outer.larray
         return out
 
     return outer
@@ -1138,7 +1123,7 @@ def transpose(a, axes=None):
 
     # try to rearrange the tensor and return a new transposed variant
     try:
-        transposed_data = a._DNDarray__array.permute(*axes)
+        transposed_data = a.larray.permute(*axes)
         transposed_shape = tuple(a.shape[axis] for axis in axes)
 
         return dndarray.DNDarray(
@@ -1191,7 +1176,7 @@ def __tri_op(m, k, op):
 
     # manually repeat the input for vectors
     if dimensions == 1:
-        triangle = m._DNDarray__array.expand(m.shape[0], -1)
+        triangle = m.larray.expand(m.shape[0], -1)
         if torch.numel(triangle > 0):
             triangle = op(triangle, k - offset)
 
@@ -1204,7 +1189,7 @@ def __tri_op(m, k, op):
             m.comm,
         )
 
-    original = m._DNDarray__array
+    original = m.larray
     output = original.clone()
 
     # modify k to account for tensor splits

--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -92,7 +92,7 @@ def qr(a, tiles_per_proc=1, calc_q=True, overwrite_a=False):
     QR = collections.namedtuple("QR", "Q, R")
 
     if a.split is None:
-        q, r = a._DNDarray__array.qr(some=False)
+        q, r = a.larray.qr(some=False)
         q = factories.array(q, device=a.device)
         r = factories.array(r, device=a.device)
         ret = QR(q if calc_q else None, r)
@@ -201,12 +201,11 @@ def __split0_global_q_dict_set(q_dict_col, col, r_tiles, q_tiles, global_merge_d
     # q is already created, the job of this function is to create the group the merging q's together
     # it takes the merge qs, splits them, then puts them into a new dictionary
     proc_tile_start = torch.cumsum(
-        torch.tensor(r_tiles.tile_rows_per_process, device=r_tiles.arr._DNDarray__array.device),
-        dim=0,
+        torch.tensor(r_tiles.tile_rows_per_process, device=r_tiles.arr.larray.device), dim=0
     )
     diag_proc = torch.nonzero(input=proc_tile_start > col, as_tuple=False)[0].item()
     proc_tile_start = torch.cat(
-        (torch.tensor([0], device=r_tiles.arr._DNDarray__array.device), proc_tile_start[:-1]), dim=0
+        (torch.tensor([0], device=r_tiles.arr.larray.device), proc_tile_start[:-1]), dim=0
     )
 
     # 1: create caqr dictionary
@@ -392,7 +391,7 @@ def __split0_r_calc(r_tiles, q_dict, q_dict_waits, col_num, diag_pr, not_complet
                 key=str(loop) + "p0" + str(pr0) + "p1" + str(pr1) + "e",
                 q_dict_waits=q_dict_waits,
                 q_dtype=r_tiles.arr.dtype.torch_type(),
-                q_device=r_tiles.arr._DNDarray__array.device,
+                q_device=r_tiles.arr.larray.device,
             )
 
         loop_size_remaining = loop_size_remaining[: -1 * (half_prs_rem)]
@@ -423,7 +422,7 @@ def __split0_r_calc(r_tiles, q_dict, q_dict_waits, col_num, diag_pr, not_complet
                 comm=comm,
                 q_dict_waits=q_dict_waits,
                 q_dtype=r_tiles.arr.dtype.torch_type(),
-                q_device=r_tiles.arr._DNDarray__array.device,
+                q_device=r_tiles.arr.larray.device,
             )
             rem1 = rem2
             rem2 = None
@@ -454,7 +453,7 @@ def __split0_r_calc(r_tiles, q_dict, q_dict_waits, col_num, diag_pr, not_complet
                 comm=comm,
                 q_dict_waits=q_dict_waits,
                 q_dtype=r_tiles.arr.dtype.torch_type(),
-                q_device=r_tiles.arr._DNDarray__array.device,
+                q_device=r_tiles.arr.larray.device,
             )
             rem1 = None
 
@@ -499,7 +498,7 @@ def __split0_merge_tile_rows(pr0, pr1, column, rank, r_tiles, diag_process, key,
     upper_size = (upper_inds[1] - upper_inds[0], upper_inds[3] - upper_inds[2])
     lower_size = (lower_inds[1] - lower_inds[0], lower_inds[3] - lower_inds[2])
 
-    a_torch_device = r_tiles.arr._DNDarray__array.device
+    a_torch_device = r_tiles.arr.larray.device
 
     # upper adjustments
     if upper_size[0] < upper_size[1] and r_tiles.tile_rows_per_process[pr0] > 1:
@@ -780,7 +779,7 @@ def __split0_q_loop(col, r_tiles, proc_tile_start, active_procs, q0_tiles, q_dic
         # have all the q_merge in one place, now just do the mm with q0
         # get all the keys which are in a column (qi_mult[column])
         row_inds = q0_tiles.row_indices + [q0_tiles.arr.gshape[0]]
-        q_copy = q0_tiles.arr._DNDarray__array.clone()
+        q_copy = q0_tiles.arr.larray.clone()
         for qi_col in qi_mult.keys():
             # multiply q0 rows with qi cols
             # the result of this will take the place of the row height and the column width
@@ -838,8 +837,8 @@ def __split1_qr_loop(dcol, r_tiles, q0_tiles, calc_q):
     -------
     None
     """
-    r_torch_device = r_tiles.arr._DNDarray__array.device
-    q0_torch_device = q0_tiles.arr._DNDarray__array.device if calc_q else None
+    r_torch_device = r_tiles.arr.larray.device
+    q0_torch_device = q0_tiles.arr.larray.device if calc_q else None
     # ==================================== R Calculation - single tile =========================
     # loop over each column, need to do the QR for each tile in the column(should be rows)
     # need to get the diagonal process

--- a/heat/core/linalg/solver.py
+++ b/heat/core/linalg/solver.py
@@ -135,12 +135,12 @@ def lanczos(A, m, v0=None, V_out=None, T_out=None):
             vr = ht.random.rand(n, dtype=A.dtype, split=V.split)
             # orthogonalize v_r with respect to all vectors v[i]
             for j in range(i):
-                vi_loc = V._DNDarray__array[:, j]
-                a = torch.dot(vr._DNDarray__array, vi_loc)
+                vi_loc = V.larray[:, j]
+                a = torch.dot(vr.larray, vi_loc)
                 b = torch.dot(vi_loc, vi_loc)
                 A.comm.Allreduce(ht.communication.MPI.IN_PLACE, a, ht.communication.MPI.SUM)
                 A.comm.Allreduce(ht.communication.MPI.IN_PLACE, b, ht.communication.MPI.SUM)
-                vr._DNDarray__array = vr._DNDarray__array - a / b * vi_loc
+                vr.larray = vr.larray - a / b * vi_loc
             # normalize v_r to Euclidian norm 1 and set as ith vector v
             vi = vr / ht.norm(vr)
         else:
@@ -150,7 +150,7 @@ def lanczos(A, m, v0=None, V_out=None, T_out=None):
             # ToDo: Rethink this; mask torch calls, See issue #494
             # This is the fast solution, using item access on the ht.dndarray level is way slower
             for j in range(i):
-                vi_loc = V._DNDarray__array[:, j]
+                vi_loc = V.larray[:, j]
                 a = torch.dot(vr._DNDarray__array, vi_loc)
                 b = torch.dot(vi_loc, vi_loc)
                 A.comm.Allreduce(ht.communication.MPI.IN_PLACE, a, ht.communication.MPI.SUM)

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -485,9 +485,9 @@ class TestLinalgBasics(TestCase):
         b = ht.arange(8, dtype=ht.float32)
         ht_outer = ht.outer(a, b, split=None)
         np_outer = np.outer(a.numpy(), b.numpy())
-        t_outer = torch.einsum("i,j->ij", a._DNDarray__array, b._DNDarray__array)
+        t_outer = torch.einsum("i,j->ij", a.larray, b.larray)
         self.assertTrue((ht_outer.numpy() == np_outer).all())
-        self.assertTrue(ht_outer._DNDarray__array.dtype is t_outer.dtype)
+        self.assertTrue(ht_outer.larray.dtype is t_outer.dtype)
 
         # test outer, a and b distributed, no data on some ranks
         a_split = ht.arange(3, dtype=ht.float32, split=0)
@@ -593,7 +593,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(simple_matrix_t.dtype, ht.float32)
         self.assertEqual(simple_matrix_t.split, None)
         self.assertEqual(simple_matrix_t.shape, (4, 2))
-        self.assertEqual(simple_matrix_t._DNDarray__array.shape, (4, 2))
+        self.assertEqual(simple_matrix_t.larray.shape, (4, 2))
 
         # 4D array, not distributed, with given axis
         array_4d = ht.zeros((2, 3, 4, 5))
@@ -602,7 +602,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(array_4d_t.dtype, ht.float32)
         self.assertEqual(array_4d_t.split, None)
         self.assertEqual(array_4d_t.shape, (5, 2, 4, 3))
-        self.assertEqual(array_4d_t._DNDarray__array.shape, (5, 2, 4, 3))
+        self.assertEqual(array_4d_t.larray.shape, (5, 2, 4, 3))
 
         # vector transpose, distributed
         vector_split = ht.arange(10, split=0)
@@ -660,7 +660,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (5, 5))
         self.assertEqual(result.lshape, (5, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         # 1D case, positive offset, data is not split, module-level call
         result = ht.tril(local_ones, k=2)
@@ -669,7 +669,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (5, 5))
         self.assertEqual(result.lshape, (5, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         # 1D case, negative offset, data is not split, module-level call
         result = ht.tril(local_ones, k=-2)
@@ -678,7 +678,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (5, 5))
         self.assertEqual(result.lshape, (5, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         local_ones = ht.ones((4, 5))
 
@@ -689,7 +689,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         # 2D case, positive offset, data is not split, method
         result = local_ones.tril(k=2)
@@ -698,7 +698,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         # 2D case, negative offset, data is not split, method
         result = local_ones.tril(k=-2)
@@ -707,7 +707,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         local_ones = ht.ones((3, 4, 5, 6))
 
@@ -720,7 +720,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.split, None)
         for i in range(3):
             for j in range(4):
-                self.assertTrue((result._DNDarray__array[i, j] == comparison).all())
+                self.assertTrue((result.larray[i, j] == comparison).all())
 
         # 2D+ case, positive offset, data is not split, module-level call
         result = local_ones.tril(k=2)
@@ -731,7 +731,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.split, None)
         for i in range(3):
             for j in range(4):
-                self.assertTrue((result._DNDarray__array[i, j] == comparison).all())
+                self.assertTrue((result.larray[i, j] == comparison).all())
 
         # # 2D+ case, negative offset, data is not split, module-level call
         result = local_ones.tril(k=-2)
@@ -742,7 +742,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.split, None)
         for i in range(3):
             for j in range(4):
-                self.assertTrue((result._DNDarray__array[i, j] == comparison).all())
+                self.assertTrue((result.larray[i, j] == comparison).all())
 
         distributed_ones = ht.ones((5,), split=0)
 
@@ -755,9 +755,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertTrue(result.sum(), 15)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 1)
+            self.assertTrue(result.larray[-1, 0] == 1)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 0)
+            self.assertTrue(result.larray[0, -1] == 0)
 
         # 1D case, positive offset, data is split, method
         result = distributed_ones.tril(k=2)
@@ -768,9 +768,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 22)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 1)
+            self.assertTrue(result.larray[-1, 0] == 1)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 0)
+            self.assertTrue(result.larray[0, -1] == 0)
 
         # 1D case, negative offset, data is split, method
         result = distributed_ones.tril(k=-2)
@@ -781,9 +781,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 6)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 1)
+            self.assertTrue(result.larray[-1, 0] == 1)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 0)
+            self.assertTrue(result.larray[0, -1] == 0)
 
         distributed_ones = ht.ones((4, 5), split=0)
 
@@ -796,9 +796,9 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 10)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[0, -1] == 0)
+            self.assertTrue(result.larray[0, -1] == 0)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 1)
+            self.assertTrue(result.larray[-1, 0] == 1)
 
         # 2D case, positive offset, data is horizontally split, method
         result = distributed_ones.tril(k=2)
@@ -809,9 +809,9 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 17)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[0, -1] == 0)
+            self.assertTrue(result.larray[0, -1] == 0)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 1)
+            self.assertTrue(result.larray[-1, 0] == 1)
 
         # 2D case, negative offset, data is horizontally split, method
         result = distributed_ones.tril(k=-2)
@@ -822,9 +822,9 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 3)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[0, -1] == 0)
+            self.assertTrue(result.larray[0, -1] == 0)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 1)
+            self.assertTrue(result.larray[-1, 0] == 1)
 
         distributed_ones = ht.ones((4, 5), split=1)
 
@@ -837,9 +837,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 10)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 1)
+            self.assertTrue(result.larray[-1, 0] == 1)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 0)
+            self.assertTrue(result.larray[0, -1] == 0)
 
         # 2D case, positive offset, data is horizontally split, method
         result = distributed_ones.tril(k=2)
@@ -850,9 +850,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 17)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 1)
+            self.assertTrue(result.larray[-1, 0] == 1)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 0)
+            self.assertTrue(result.larray[0, -1] == 0)
 
         # 2D case, negative offset, data is horizontally split, method
         result = distributed_ones.tril(k=-2)
@@ -863,9 +863,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 3)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 1)
+            self.assertTrue(result.larray[-1, 0] == 1)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 0)
+            self.assertTrue(result.larray[0, -1] == 0)
 
         with self.assertRaises(TypeError):
             ht.tril("asdf")
@@ -882,7 +882,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (5, 5))
         self.assertEqual(result.lshape, (5, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         # 1D case, positive offset, data is not split, module-level call
         result = ht.triu(local_ones, k=2)
@@ -891,7 +891,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (5, 5))
         self.assertEqual(result.lshape, (5, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         # 1D case, negative offset, data is not split, module-level call
         result = ht.triu(local_ones, k=-2)
@@ -900,7 +900,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (5, 5))
         self.assertEqual(result.lshape, (5, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         local_ones = ht.ones((4, 5))
 
@@ -911,7 +911,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         # 2D case, positive offset, data is not split, method
         result = local_ones.triu(k=2)
@@ -920,7 +920,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         # 2D case, negative offset, data is not split, method
         result = local_ones.triu(k=-2)
@@ -929,7 +929,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == comparison).all())
+        self.assertTrue((result.larray == comparison).all())
 
         local_ones = ht.ones((3, 4, 5, 6))
 
@@ -942,7 +942,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.split, None)
         for i in range(3):
             for j in range(4):
-                self.assertTrue((result._DNDarray__array[i, j] == comparison).all())
+                self.assertTrue((result.larray[i, j] == comparison).all())
 
         # 2D+ case, positive offset, data is not split, module-level call
         result = local_ones.triu(k=2)
@@ -953,7 +953,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.split, None)
         for i in range(3):
             for j in range(4):
-                self.assertTrue((result._DNDarray__array[i, j] == comparison).all())
+                self.assertTrue((result.larray[i, j] == comparison).all())
 
         # # 2D+ case, negative offset, data is not split, module-level call
         result = local_ones.triu(k=-2)
@@ -964,7 +964,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.split, None)
         for i in range(3):
             for j in range(4):
-                self.assertTrue((result._DNDarray__array[i, j] == comparison).all())
+                self.assertTrue((result.larray[i, j] == comparison).all())
 
         distributed_ones = ht.ones((5,), split=0)
 
@@ -977,9 +977,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertTrue(result.sum(), 15)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 0)
+            self.assertTrue(result.larray[-1, 0] == 0)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 1)
+            self.assertTrue(result.larray[0, -1] == 1)
 
         # 1D case, positive offset, data is split, method
         result = distributed_ones.triu(k=2)
@@ -990,9 +990,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 6)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 0)
+            self.assertTrue(result.larray[-1, 0] == 0)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 1)
+            self.assertTrue(result.larray[0, -1] == 1)
 
         # 1D case, negative offset, data is split, method
         result = distributed_ones.triu(k=-2)
@@ -1003,9 +1003,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 22)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 0)
+            self.assertTrue(result.larray[-1, 0] == 0)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 1)
+            self.assertTrue(result.larray[0, -1] == 1)
 
         distributed_ones = ht.ones((4, 5), split=0)
 
@@ -1018,9 +1018,9 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 14)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[0, -1] == 1)
+            self.assertTrue(result.larray[0, -1] == 1)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 0)
+            self.assertTrue(result.larray[-1, 0] == 0)
 
         # # 2D case, positive offset, data is horizontally split, method
         result = distributed_ones.triu(k=2)
@@ -1031,9 +1031,9 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 6)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[0, -1] == 1)
+            self.assertTrue(result.larray[0, -1] == 1)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 0)
+            self.assertTrue(result.larray[-1, 0] == 0)
 
         # # 2D case, negative offset, data is horizontally split, method
         result = distributed_ones.triu(k=-2)
@@ -1044,9 +1044,9 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 19)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[0, -1] == 1)
+            self.assertTrue(result.larray[0, -1] == 1)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 0)
+            self.assertTrue(result.larray[-1, 0] == 0)
 
         distributed_ones = ht.ones((4, 5), split=1)
 
@@ -1059,9 +1059,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 14)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 0)
+            self.assertTrue(result.larray[-1, 0] == 0)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 1)
+            self.assertTrue(result.larray[0, -1] == 1)
 
         # 2D case, positive offset, data is horizontally split, method
         result = distributed_ones.triu(k=2)
@@ -1072,9 +1072,9 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 6)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 0)
+            self.assertTrue(result.larray[-1, 0] == 0)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 1)
+            self.assertTrue(result.larray[0, -1] == 1)
 
         # 2D case, negative offset, data is horizontally split, method
         result = distributed_ones.triu(k=-2)
@@ -1085,6 +1085,6 @@ class TestLinalgBasics(TestCase):
         self.assertLessEqual(result.lshape[1], 5)
         self.assertEqual(result.sum(), 19)
         if result.comm.rank == 0:
-            self.assertTrue(result._DNDarray__array[-1, 0] == 0)
+            self.assertTrue(result.larray[-1, 0] == 0)
         if result.comm.rank == result.shape[0] - 1:
-            self.assertTrue(result._DNDarray__array[0, -1] == 1)
+            self.assertTrue(result.larray[0, -1] == 1)

--- a/heat/core/logical.py
+++ b/heat/core/logical.py
@@ -121,9 +121,7 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
     t1, t2 = __sanitize_close_input(x, y)
 
     # no sanitation for shapes of x and y needed, torch.allclose raises relevant errors
-    _local_allclose = torch.tensor(
-        torch.allclose(t1._DNDarray__array, t2._DNDarray__array, rtol, atol, equal_nan)
-    )
+    _local_allclose = torch.tensor(torch.allclose(t1.larray, t2.larray, rtol, atol, equal_nan))
 
     # If x is distributed, then y is also distributed along the same axis
     if t1.comm.is_distributed():
@@ -201,7 +199,7 @@ def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False):
     t1, t2 = __sanitize_close_input(x, y)
 
     # no sanitation for shapes of x and y needed, torch.isclose raises relevant errors
-    _local_isclose = torch.isclose(t1._DNDarray__array, t2._DNDarray__array, rtol, atol, equal_nan)
+    _local_isclose = torch.isclose(t1.larray, t2.larray, rtol, atol, equal_nan)
 
     # If x is distributed, then y is also distributed along the same axis
     if t1.comm.is_distributed() and t1.split is not None:

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -71,7 +71,7 @@ def column_stack(arrays):
     >>> # 1-D tensors
     >>> a = ht.array([1, 2, 3])
     >>> b = ht.array([2, 3, 4])
-    >>> ht.column_stack((a, b))._DNDarray__array
+    >>> ht.column_stack((a, b)).larray
     tensor([[1, 2],
         [2, 3],
         [3, 4]])
@@ -79,7 +79,7 @@ def column_stack(arrays):
     >>> a = ht.array([1, 2, 3])
     >>> b = ht.array([[2, 5], [3, 6], [4, 7]])
     >>> c = ht.array([[7, 10], [8, 11], [9, 12]])
-    >>> ht.column_stack((a, b, c))._DNDarray__array
+    >>> ht.column_stack((a, b, c)).larray
     tensor([[ 1,  2,  5,  7, 10],
             [ 2,  3,  6,  8, 11],
             [ 3,  4,  7,  9, 12]])
@@ -87,7 +87,7 @@ def column_stack(arrays):
     >>> a = ht.arange(10, split=0).reshape((5, 2))
     >>> b = ht.arange(5, 20, split=0).reshape((5, 3))
     >>> c = ht.arange(20, 40, split=0).reshape((5, 4))
-    >>> ht_column_stack((a, b, c))._DNDarray__array
+    >>> ht_column_stack((a, b, c)).larray
     [0/2] tensor([[ 0,  1,  5,  6,  7, 20, 21, 22, 23],
     [0/2]         [ 2,  3,  8,  9, 10, 24, 25, 26, 27]], dtype=torch.int32)
     [1/2] tensor([[ 4,  5, 11, 12, 13, 28, 29, 30, 31],
@@ -96,7 +96,7 @@ def column_stack(arrays):
     >>> # distributed 1-D and 2-D DNDarrays, 3 processes
     >>> a = ht.arange(5, split=0)
     >>> b = ht.arange(5, 20, split=1).reshape((5, 3))
-    >>> ht_column_stack((a, b))._DNDarray__array
+    >>> ht_column_stack((a, b)).larray
     [0/2] tensor([[ 0,  5],
     [0/2]         [ 1,  8],
     [0/2]         [ 2, 11],
@@ -253,9 +253,7 @@ def concatenate(arrays, axis=0):
     # no splits, local concat
     if s0 is None and s1 is None:
         return factories.array(
-            torch.cat((arr0._DNDarray__array, arr1._DNDarray__array), dim=axis),
-            device=arr0.device,
-            comm=arr0.comm,
+            torch.cat((arr0.larray, arr1.larray), dim=axis), device=arr0.device, comm=arr0.comm
         )
 
     # non-matching splits when both arrays are split
@@ -276,9 +274,7 @@ def concatenate(arrays, axis=0):
 
         _, _, arr0_slice = arr1.comm.chunk(arr0.shape, arr1.split)
         _, _, arr1_slice = arr0.comm.chunk(arr1.shape, arr0.split)
-        out._DNDarray__array = torch.cat(
-            (arr0._DNDarray__array[arr0_slice], arr1._DNDarray__array[arr1_slice]), dim=axis
-        )
+        out.larray = torch.cat((arr0.larray[arr0_slice], arr1.larray[arr1_slice]), dim=axis)
         out._DNDarray__comm = arr0.comm
 
         return out
@@ -292,9 +288,7 @@ def concatenate(arrays, axis=0):
                 for x in range(len(arr1.gshape))
             )
             out = factories.empty(out_shape, split=s0, dtype=out_dtype, device=arr0.device)
-            out._DNDarray__array = torch.cat(
-                (arr0._DNDarray__array, arr1._DNDarray__array), dim=axis
-            )
+            out.larray = torch.cat((arr0.larray, arr1.larray), dim=axis)
             out._DNDarray__comm = arr0.comm
             return out
 
@@ -341,7 +335,7 @@ def concatenate(arrays, axis=0):
                                     dest=pr,
                                     tag=pr + arr0.comm.size + spr,
                                 )
-                                arr0._DNDarray__array = arr0.lloc[keep_slice].clone()
+                                arr0.larray = arr0.lloc[keep_slice].clone()
                                 send.Wait()
                     for pr in range(spr):
                         snt = abs((chunk_map[pr, s0] - lshape_map[0, pr, s0]).item())
@@ -358,9 +352,7 @@ def concatenate(arrays, axis=0):
                             )
 
                             arr0.comm.Recv(data, source=spr, tag=pr + arr0.comm.size + spr)
-                            arr0._DNDarray__array = torch.cat(
-                                (arr0._DNDarray__array, data), dim=arr0.split
-                            )
+                            arr0.larray = torch.cat((arr0.larray, data), dim=arr0.split)
                         lshape_map[0, pr, arr0.split] += snt
                         lshape_map[0, spr, arr0.split] -= snt
 
@@ -388,7 +380,7 @@ def concatenate(arrays, axis=0):
                                     dest=pr,
                                     tag=pr + arr1.comm.size + spr,
                                 )
-                                arr1._DNDarray__array = arr1.lloc[keep_slice].clone()
+                                arr1.larray = arr1.lloc[keep_slice].clone()
                                 send.Wait()
                     for pr in range(arr1.comm.size - 1, spr, -1):
                         snt = abs((chunk_map[pr, axis] - lshape_map[1, pr, axis]).item())
@@ -405,9 +397,7 @@ def concatenate(arrays, axis=0):
                                 shp, dtype=out_dtype.torch_type(), device=arr1.device.torch_device
                             )
                             arr1.comm.Recv(data, source=spr, tag=pr + arr1.comm.size + spr)
-                            arr1._DNDarray__array = torch.cat(
-                                (data, arr1._DNDarray__array), dim=axis
-                            )
+                            arr1.larray = torch.cat((data, arr1.larray), dim=axis)
                         lshape_map[1, pr, axis] += snt
                         lshape_map[1, spr, axis] -= snt
 
@@ -424,18 +414,18 @@ def concatenate(arrays, axis=0):
                 if arr0.comm.rank == 0:
                     lcl_slice = [slice(None)] * arr0.ndim
                     lcl_slice[axis] = slice(chunk_map[0, axis].item())
-                    arr0._DNDarray__array = arr0._DNDarray__array[lcl_slice].clone().squeeze()
+                    arr0.larray = arr0.larray[lcl_slice].clone().squeeze()
                 ttl = chunk_map[0, axis].item()
                 for en in range(1, arr0.comm.size):
                     sz = chunk_map[en, axis]
                     if arr0.comm.rank == en:
                         lcl_slice = [slice(None)] * arr0.ndim
                         lcl_slice[axis] = slice(ttl, sz.item() + ttl, 1)
-                        arr0._DNDarray__array = arr0._DNDarray__array[lcl_slice].clone().squeeze()
+                        arr0.larray = arr0.larray[lcl_slice].clone().squeeze()
                     ttl += sz.item()
 
                 if len(arr0.lshape) < len(arr1.lshape):
-                    arr0._DNDarray__array.unsqueeze_(axis)
+                    arr0.larray.unsqueeze_(axis)
 
             if s1 is None:
                 arb_slice = [None] * len(arr0.shape)
@@ -449,7 +439,7 @@ def concatenate(arrays, axis=0):
                     lcl_slice[axis] = slice(
                         arr1.lshape[axis] - chunk_map[-1, axis].item(), arr1.lshape[axis], 1
                     )
-                    arr1._DNDarray__array = arr1._DNDarray__array[lcl_slice].clone().squeeze()
+                    arr1.larray = arr1.larray[lcl_slice].clone().squeeze()
                 ttl = chunk_map[-1, axis].item()
                 for en in range(arr1.comm.size - 2, -1, -1):
                     sz = chunk_map[en, axis]
@@ -458,10 +448,10 @@ def concatenate(arrays, axis=0):
                         lcl_slice[axis] = slice(
                             arr1.lshape[axis] - (sz.item() + ttl), arr1.lshape[axis] - ttl, 1
                         )
-                        arr1._DNDarray__array = arr1._DNDarray__array[lcl_slice].clone().squeeze()
+                        arr1.larray = arr1.larray[lcl_slice].clone().squeeze()
                     ttl += sz.item()
                 if len(arr1.lshape) < len(arr0.lshape):
-                    arr1._DNDarray__array.unsqueeze_(axis)
+                    arr1.larray.unsqueeze_(axis)
 
             # now that the data is in the proper shape, need to concatenate them on the nodes where they both exist for
             # the others, just set them equal
@@ -472,8 +462,8 @@ def concatenate(arrays, axis=0):
                 device=arr0.device,
                 comm=arr0.comm,
             )
-            res = torch.cat((arr0._DNDarray__array, arr1._DNDarray__array), dim=axis)
-            out._DNDarray__array = res
+            res = torch.cat((arr0.larray, arr1.larray), dim=axis)
+            out.larray = res
 
             return out
 
@@ -551,7 +541,7 @@ def diag(a, offset=0):
     a.balance_()
 
     local = torch.zeros(lshape, dtype=a.dtype.torch_type(), device=a.device.torch_device)
-    local[indices_x, indices_y] = a._DNDarray__array[indices_x]
+    local[indices_x, indices_y] = a.larray[indices_x]
 
     return factories.array(local, dtype=a.dtype, is_split=a.split, device=a.device, comm=a.comm)
 
@@ -632,11 +622,11 @@ def diagonal(a, offset=0, dim1=0, dim2=1):
         split = len(shape) - 1
 
     if a.split is None or a.split not in (dim1, dim2):
-        result = torch.diagonal(a._DNDarray__array, offset=offset, dim1=dim1, dim2=dim2)
+        result = torch.diagonal(a.larray, offset=offset, dim1=dim1, dim2=dim2)
     else:
         vz = 1 if a.split == dim1 else -1
         off, _, _ = a.comm.chunk(a.shape, a.split)
-        result = torch.diagonal(a._DNDarray__array, offset=offset + vz * off, dim1=dim1, dim2=dim2)
+        result = torch.diagonal(a.larray, offset=offset + vz * off, dim1=dim1, dim2=dim2)
     return factories.array(result, dtype=a.dtype, is_split=split, device=a.device, comm=a.comm)
 
 
@@ -690,7 +680,7 @@ def expand_dims(a, axis):
     axis = stride_tricks.sanitize_axis(a.shape + (1,), axis)
 
     return dndarray.DNDarray(
-        a._DNDarray__array.unsqueeze(dim=axis),
+        a.larray.unsqueeze(dim=axis),
         a.shape[:axis] + (1,) + a.shape[axis:],
         a.dtype,
         a.split if a.split is None or a.split < axis else a.split + 1,
@@ -720,22 +710,14 @@ def flatten(a):
     """
     if a.split is None:
         return factories.array(
-            torch.flatten(a._DNDarray__array),
-            dtype=a.dtype,
-            is_split=None,
-            device=a.device,
-            comm=a.comm,
+            torch.flatten(a.larray), dtype=a.dtype, is_split=None, device=a.device, comm=a.comm
         )
 
     if a.split > 0:
         a = resplit(a, 0)
 
     a = factories.array(
-        torch.flatten(a._DNDarray__array),
-        dtype=a.dtype,
-        is_split=a.split,
-        device=a.device,
-        comm=a.comm,
+        torch.flatten(a.larray), dtype=a.dtype, is_split=a.split, device=a.device, comm=a.comm
     )
     a.balance_()
 
@@ -780,7 +762,7 @@ def flip(a, axis=None):
     if isinstance(axis, int):
         axis = [axis]
 
-    flipped = torch.flip(a._DNDarray__array, axis)
+    flipped = torch.flip(a.larray, axis)
 
     if a.split not in axis:
         return factories.array(
@@ -795,7 +777,7 @@ def flip(a, axis=None):
 
     # Exchange local tensors
     req = a.comm.Isend(flipped, dest=dest_proc)
-    received = torch.empty(new_lshape, dtype=a._DNDarray__array.dtype, device=a.device.torch_device)
+    received = torch.empty(new_lshape, dtype=a.larray.dtype, device=a.device.torch_device)
     a.comm.Recv(received, source=dest_proc)
 
     res = factories.array(received, dtype=a.dtype, is_split=a.split, device=a.device, comm=a.comm)
@@ -883,17 +865,17 @@ def hstack(tup):
     --------
     >>> a = ht.array((1,2,3))
     >>> b = ht.array((2,3,4))
-    >>> ht.hstack((a,b))._DNDarray__array
+    >>> ht.hstack((a,b)).larray
     [0/1] tensor([1, 2, 3, 2, 3, 4])
     [1/1] tensor([1, 2, 3, 2, 3, 4])
     >>> a = ht.array((1,2,3), split=0)
     >>> b = ht.array((2,3,4), split=0)
-    >>> ht.hstack((a,b))._DNDarray__array
+    >>> ht.hstack((a,b)).larray
     [0/1] tensor([1, 2, 3])
     [1/1] tensor([2, 3, 4])
     >>> a = ht.array([[1],[2],[3]], split=0)
     >>> b = ht.array([[2],[3],[4]], split=0)
-    >>> ht.hstack((a,b))._DNDarray__array
+    >>> ht.hstack((a,b)).larray
     [0/1] tensor([[1, 2],
     [0/1]         [2, 3]])
     [1/1] tensor([[3, 4]])
@@ -1131,7 +1113,7 @@ def pad(array, pad_width, mode="constant", constant_values=0):
     amount_pad_dim = len(pad) // 2
     pad_dim = [rank_array - i for i in range(1, amount_pad_dim + 1)]
 
-    array_torch = array._DNDarray__array
+    array_torch = array.larray
 
     if array.split is not None:
         counts = array.comm.counts_displs_shape(array.gshape, array.split)[0]
@@ -1154,7 +1136,7 @@ def pad(array, pad_width, mode="constant", constant_values=0):
             0 if i == array.split else output_shape[i] for i in range(len(output_shape))
         ]
         adapted_lshape = tuple(adapted_lshape_list)
-        padded_torch_tensor = torch.empty(adapted_lshape, dtype=array._DNDarray__array.dtype)
+        padded_torch_tensor = torch.empty(adapted_lshape, dtype=array.larray.dtype)
     else:
         if array.split is None or array.split not in pad_dim or amount_of_processes == 1:
             # values = scalar
@@ -1346,7 +1328,7 @@ def reshape(a, shape, new_split=None):
     # Forward to Pytorch directly
     if a.split is None:
         return factories.array(
-            torch.reshape(a._DNDarray__array, shape), dtype=a.dtype, device=a.device, comm=a.comm
+            torch.reshape(a.larray, shape), dtype=a.dtype, device=a.device, comm=a.comm
         )
 
     # Create new flat result tensor
@@ -1368,7 +1350,7 @@ def reshape(a, shape, new_split=None):
     )
 
     # rearange order
-    send = a._DNDarray__array.flatten()[sendsort]
+    send = a.larray.flatten()[sendsort]
     a.comm.Alltoallv((send, sendcounts, senddispls), (data, recvcounts, recvdispls))
 
     # original order
@@ -1454,7 +1436,7 @@ def rot90(m, k=1, axes=(0, 1)):
 
     if m.split is None:
         return factories.array(
-            torch.rot90(m._DNDarray__array, k, axes), dtype=m.dtype, device=m.device, comm=m.comm
+            torch.rot90(m.larray, k, axes), dtype=m.dtype, device=m.device, comm=m.comm
         )
 
     try:
@@ -1557,14 +1539,12 @@ def sort(a, axis=None, descending=False, out=None):
 
     if a.split is None or axis != a.split:
         # sorting is not affected by split -> we can just sort along the axis
-        final_result, final_indices = torch.sort(
-            a._DNDarray__array, dim=axis, descending=descending
-        )
+        final_result, final_indices = torch.sort(a.larray, dim=axis, descending=descending)
 
     else:
         # sorting is affected by split, processes need to communicate results
         # transpose so we can work along the 0 axis
-        transposed = a._DNDarray__array.transpose(axis, 0)
+        transposed = a.larray.transpose(axis, 0)
         local_sorted, local_indices = torch.sort(transposed, dim=0, descending=descending)
 
         size = a.comm.Get_size()
@@ -1760,7 +1740,7 @@ def sort(a, axis=None, descending=False, out=None):
         final_indices, dtype=dndarray.types.int32, is_split=a.split, device=a.device, comm=a.comm
     )
     if out is not None:
-        out._DNDarray__array = final_result
+        out.larray = final_result
         return return_indices
     else:
         tensor = factories.array(
@@ -1857,7 +1837,7 @@ def squeeze(x, axis=None):
 
     out_lshape = tuple(x.lshape[dim] for dim in range(x.ndim) if dim not in axis)
     out_gshape = tuple(x.gshape[dim] for dim in range(x.ndim) if dim not in axis)
-    x_lsqueezed = x._DNDarray__array.reshape(out_lshape)
+    x_lsqueezed = x.larray.reshape(out_lshape)
 
     # Calculate new split axis according to squeezed shape
     if x.split is not None:
@@ -1917,7 +1897,7 @@ def stack(arrays, axis=0, out=None):
     --------
     >>> a = ht.arange(20).reshape(4, 5)
     >>> b = ht.arange(20, 40).reshape(4, 5)
-    >>> ht.stack((a,b), axis=0)._DNDarray__array
+    >>> ht.stack((a,b), axis=0).larray
     tensor([[[ 0,  1,  2,  3,  4],
              [ 5,  6,  7,  8,  9],
              [10, 11, 12, 13, 14],
@@ -1930,7 +1910,7 @@ def stack(arrays, axis=0, out=None):
     >>> # distributed DNDarrays, 3 processes, stack along last dimension
     >>> a = ht.arange(20, split=0).reshape(4, 5)
     >>> b = ht.arange(20, 40, split=0).reshape(4, 5)
-    >>> ht.stack((a,b), axis=-1)._DNDarray__array
+    >>> ht.stack((a,b), axis=-1).larray
     [0/2] tensor([[[ 0, 20],
     [0/2]          [ 1, 21],
     [0/2]          [ 2, 22],
@@ -2000,7 +1980,7 @@ def stack(arrays, axis=0, out=None):
     else:
         array_shape, array_split, array_device = arrays_metadata[0][:3]
         # extract torch tensors
-        t_arrays = list(array._DNDarray__array for array in arrays)
+        t_arrays = list(array.larray for array in arrays)
         # output dtype
         t_dtypes = list(t_array.dtype for t_array in t_arrays)
         t_array_dtype = t_dtypes[0]
@@ -2043,7 +2023,7 @@ def stack(arrays, axis=0, out=None):
 
     # return stacked DNDarrays
     if out is not None:
-        out._DNDarray__array = t_stacked
+        out.larray = t_stacked
         return out
 
     stacked = dndarray.DNDarray(
@@ -2102,7 +2082,7 @@ def unique(a, sorted=False, return_inverse=False, axis=None):
     """
     if a.split is None:
         torch_output = torch.unique(
-            a._DNDarray__array, sorted=sorted, return_inverse=return_inverse, dim=axis
+            a.larray, sorted=sorted, return_inverse=return_inverse, dim=axis
         )
         if isinstance(torch_output, tuple):
             heat_output = tuple(
@@ -2112,7 +2092,7 @@ def unique(a, sorted=False, return_inverse=False, axis=None):
             heat_output = factories.array(torch_output, dtype=a.dtype, split=None, device=a.device)
         return heat_output
 
-    local_data = a._DNDarray__array
+    local_data = a.larray
     unique_axis = None
     inverse_indices = None
 
@@ -2322,12 +2302,12 @@ def resplit(arr, axis=None):
             arr.shape, dtype=arr.dtype.torch_type(), device=arr.device.torch_device
         )
         counts, displs, _ = arr.comm.counts_displs_shape(arr.shape, arr.split)
-        arr.comm.Allgatherv(arr._DNDarray__array, (gathered, counts, displs), recv_axis=arr.split)
+        arr.comm.Allgatherv(arr.larray, (gathered, counts, displs), recv_axis=arr.split)
         new_arr = factories.array(gathered, is_split=axis, device=arr.device, dtype=arr.dtype)
         return new_arr
     # tensor needs be split/sliced locally
     if arr.split is None:
-        temp = arr._DNDarray__array[arr.comm.chunk(arr.shape, axis)[2]]
+        temp = arr.larray[arr.comm.chunk(arr.shape, axis)[2]]
         new_arr = factories.array(temp, is_split=axis, device=arr.device, dtype=arr.dtype)
         return new_arr
 
@@ -2392,14 +2372,14 @@ def row_stack(arrays):
     >>> # 1-D tensors
     >>> a = ht.array([1, 2, 3])
     >>> b = ht.array([2, 3, 4])
-    >>> ht.row_stack((a, b))._DNDarray__array
+    >>> ht.row_stack((a, b)).larray
     tensor([[1, 2, 3],
             [2, 3, 4]])
     >>> # 1-D and 2-D tensors
     >>> a = ht.array([1, 2, 3])
     >>> b = ht.array([[2, 3, 4], [5, 6, 7]])
     >>> c = ht.array([[7, 8, 9], [10, 11, 12]])
-    >>> ht.row_stack((a, b, c))._DNDarray__array
+    >>> ht.row_stack((a, b, c)).larray
     tensor([[ 1,  2,  3],
             [ 2,  3,  4],
             [ 5,  6,  7],
@@ -2409,7 +2389,7 @@ def row_stack(arrays):
     >>> a = ht.arange(10, split=0).reshape((2, 5))
     >>> b = ht.arange(5, 20, split=0).reshape((3, 5))
     >>> c = ht.arange(20, 40, split=0).reshape((4, 5))
-    >>> ht.row_stack((a, b, c))._DNDarray__array
+    >>> ht.row_stack((a, b, c)).larray
     [0/2] tensor([[0, 1, 2, 3, 4],
     [0/2]         [5, 6, 7, 8, 9],
     [0/2]         [5, 6, 7, 8, 9]], dtype=torch.int32)
@@ -2422,7 +2402,7 @@ def row_stack(arrays):
     >>> # distributed 1-D and 2-D DNDarrays, 3 processes
     >>> a = ht.arange(5, split=0)
     >>> b = ht.arange(5, 20, split=0).reshape((3, 5))
-    >>> ht.row_stack((a, b))._DNDarray__array
+    >>> ht.row_stack((a, b)).larray
     [0/2] tensor([[0, 1, 2, 3, 4],
     [0/2]         [5, 6, 7, 8, 9]])
     [1/2] tensor([[10, 11, 12, 13, 14]])
@@ -2470,21 +2450,21 @@ def vstack(tup):
     --------
     >>> a = ht.array([1, 2, 3])
     >>> b = ht.array([2, 3, 4])
-    >>> ht.vstack((a,b))._DNDarray__array
+    >>> ht.vstack((a,b)).larray
     [0/1] tensor([[1, 2, 3],
     [0/1]         [2, 3, 4]])
     [1/1] tensor([[1, 2, 3],
     [1/1]         [2, 3, 4]])
     >>> a = ht.array([1, 2, 3], split=0)
     >>> b = ht.array([2, 3, 4], split=0)
-    >>> ht.vstack((a,b))._DNDarray__array
+    >>> ht.vstack((a,b)).larray
     [0/1] tensor([[1, 2],
     [0/1]         [2, 3]])
     [1/1] tensor([[3],
     [1/1]         [4]])
     >>> a = ht.array([[1], [2], [3]], split=0)
     >>> b = ht.array([[2], [3], [4]], split=0)
-    >>> ht.vstack((a,b))._DNDarray__array
+    >>> ht.vstack((a,b)).larray
     [0/1] tensor([[1],
     [0/1]         [2],
     [0/1]         [3]])
@@ -2552,9 +2532,9 @@ def topk(a, k, dim=None, largest=True, sorted=True, out=None):
         dim = len(a.shape) - 1
 
     if largest:
-        neutral_value = -constants.sanitize_infinity(a._DNDarray__array.dtype)
+        neutral_value = -constants.sanitize_infinity(a.larray.dtype)
     else:
-        neutral_value = constants.sanitize_infinity(a._DNDarray__array.dtype)
+        neutral_value = constants.sanitize_infinity(a.larray.dtype)
 
     def local_topk(*args, **kwargs):
         shape = a.lshape
@@ -2608,7 +2588,7 @@ def topk(a, k, dim=None, largest=True, sorted=True, out=None):
     )
 
     # Split data again to return a tuple
-    local_result = gres._DNDarray__array
+    local_result = gres.larray
     shape_len = int(local_result[4])
 
     gres, gindices = local_result[5 + shape_len :].chunk(2)
@@ -2637,8 +2617,8 @@ def topk(a, k, dim=None, largest=True, sorted=True, out=None):
                     gres.shape, gindices.shape, out[0].shape, out[1].shape
                 )
             )
-        out[0]._DNDarray__array.storage().copy_(final_array._DNDarray__array.storage())
-        out[1]._DNDarray__array.storage().copy_(final_indices._DNDarray__array.storage())
+        out[0].larray.storage().copy_(final_array.larray.storage())
+        out[1].larray.storage().copy_(final_indices.larray.storage())
 
         out[0]._DNDarray__dtype = a.dtype
         out[1]._DNDarray__dtype = types.int64

--- a/heat/core/memory.py
+++ b/heat/core/memory.py
@@ -21,9 +21,7 @@ def copy(a):
     """
     if not isinstance(a, dndarray.DNDarray):
         raise TypeError("input needs to be a tensor")
-    return dndarray.DNDarray(
-        a._DNDarray__array.clone(), a.shape, a.dtype, a.split, a.device, a.comm
-    )
+    return dndarray.DNDarray(a.larray.clone(), a.shape, a.dtype, a.split, a.device, a.comm)
 
 
 def sanitize_memory_layout(x, order="C"):

--- a/heat/core/printing.py
+++ b/heat/core/printing.py
@@ -89,16 +89,16 @@ def _torch_data(dndarray, summarize):
         dndarray.balance_()
     # data is not split, we can use it as is
     if dndarray.split is None or dndarray.comm.size == 1:
-        data = dndarray._DNDarray__array
+        data = dndarray.larray
     # split, but no summary required, we collect it
     elif not summarize:
-        data = dndarray.copy().resplit_(None)._DNDarray__array
+        data = dndarray.copy().resplit_(None).larray
     # split, but summarized, collect the slices from all nodes and pass it on
     else:
         edgeitems = torch._tensor_str.PRINT_OPTS.edgeitems
         double_items = 2 * edgeitems
         ndims = dndarray.ndim
-        data = dndarray._DNDarray__array
+        data = dndarray.larray
 
         for i in range(ndims):
             # skip over dimensions that are smaller than twice the number of edge items to display

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -311,7 +311,7 @@ def permutation(x):
 
         data = torch.stack(buf)
     else:
-        data = torch.empty_like(x._DNDarray__array)
+        data = torch.empty_like(x.larray)
 
     return factories.array(data, dtype=x.dtype, is_split=x.split, device=x.device, comm=x.comm)
 
@@ -500,7 +500,7 @@ def randn(*args, dtype=types.float32, split=None, device=None, comm=None):
     # generate uniformly distributed random numbers first
     normal_tensor = rand(*args, dtype=dtype, split=split, device=device, comm=comm)
     # convert the the values to a normal distribution using the kundu transform
-    normal_tensor._DNDarray__array = __kundu_transform(normal_tensor._DNDarray__array)
+    normal_tensor.larray = __kundu_transform(normal_tensor.larray)
 
     return normal_tensor
 

--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -71,8 +71,8 @@ def equal(t1, t2):
     """
     result_tensor = _operations.__binary_op(torch.equal, t1, t2)
 
-    if result_tensor._DNDarray__array.numel() == 1:
-        result_value = result_tensor._DNDarray__array.item()
+    if result_tensor.larray.numel() == 1:
+        result_value = result_tensor.larray.item()
     else:
         result_value = True
 

--- a/heat/core/rounding.py
+++ b/heat/core/rounding.py
@@ -32,7 +32,7 @@ def abs(x, out=None, dtype=None):
 
     absolute_values = _operations.__local_op(torch.abs, x, out)
     if dtype is not None:
-        absolute_values._DNDarray__array = absolute_values._DNDarray__array.type(dtype.torch_type())
+        absolute_values.larray = absolute_values.larray.type(dtype.torch_type())
         absolute_values._DNDarray__dtype = dtype
 
     return absolute_values
@@ -120,12 +120,12 @@ def clip(a, a_min, a_max, out=None):
 
     if out is None:
         return dndarray.DNDarray(
-            a._DNDarray__array.clamp(a_min, a_max), a.shape, a.dtype, a.split, a.device, a.comm
+            a.larray.clamp(a_min, a_max), a.shape, a.dtype, a.split, a.device, a.comm
         )
     if not isinstance(out, dndarray.DNDarray):
         raise TypeError("out must be a tensor")
 
-    return a._DNDarray__array.clamp(a_min, a_max, out=out._DNDarray__array) and out
+    return a.larray.clamp(a_min, a_max, out=out.larray) and out
 
 
 def fabs(x, out=None):
@@ -230,8 +230,8 @@ def modf(x, out=None):
                     type(out[0]), type(out[1])
                 )
             )
-        out[0]._DNDarray__array = fractionalParts._DNDarray__array
-        out[1]._DNDarray__array = integralParts._DNDarray__array
+        out[0].larray = fractionalParts.larray
+        out[1].larray = integralParts.larray
         return out
 
     return (fractionalParts, integralParts)
@@ -279,7 +279,7 @@ def round(x, decimals=0, out=None, dtype=None):
         rounded_values /= 10 ** decimals
 
     if dtype is not None:
-        rounded_values._DNDarray__array = rounded_values._DNDarray__array.type(dtype.torch_type())
+        rounded_values.larray = rounded_values.larray.type(dtype.torch_type())
         rounded_values._DNDarray__dtype = dtype
 
     return rounded_values

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -79,7 +79,7 @@ def sanitize_sequence(seq):
         return list(seq)
     elif isinstance(seq, dndarray.DNDarray):
         if seq.split is None:
-            return seq._DNDarray__array.tolist()
+            return seq.larray.tolist()
         else:
             raise ValueError(
                 "seq is a distributed DNDarray, expected a list, a tuple, or a process-local array."
@@ -106,6 +106,4 @@ def scalar_to_1d(x):
     x : DNDarray
         where `x.ndim = 1` and `x.shape = (1,)`
     """
-    return factories.array(
-        x._DNDarray__array.unsqueeze(0), dtype=x.dtype, split=x.split, comm=x.comm
-    )
+    return factories.array(x.larray.unsqueeze(0), dtype=x.dtype, split=x.split, comm=x.comm)

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -325,7 +325,7 @@ def average(x, axis=None, weights=None, returned=False):
         result = mean(x, axis)
         num_elements = x.gnumel / result.gnumel
         cumwgt = factories.empty(1, dtype=result.dtype)
-        cumwgt.larray = num_elements
+        cumwgt.larray = torch.tensor(num_elements)
     else:
         # Weights sanitation:
         # weights (global) is either same size as x (global), or it is 1D and same size as x along chosen axis

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -442,13 +442,13 @@ class TestArithmetics(TestCase):
         self.assertEqual(no_axis_prod.shape, (1,))
         self.assertEqual(no_axis_prod.lshape, (1,))
         self.assertEqual(no_axis_prod.dtype, ht.float32)
-        self.assertEqual(no_axis_prod._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(no_axis_prod.larray.dtype, torch.float32)
         self.assertEqual(no_axis_prod.split, None)
-        self.assertEqual(no_axis_prod._DNDarray__array, 1)
+        self.assertEqual(no_axis_prod.larray, 1)
 
         out_noaxis = ht.zeros((1,))
         ht.prod(shape_noaxis, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 1)
+        self.assertEqual(out_noaxis.larray, 1)
 
         # check sum over all float elements of split 1d tensor
         shape_noaxis_split = ht.arange(1, array_len, split=0)
@@ -458,13 +458,13 @@ class TestArithmetics(TestCase):
         self.assertEqual(shape_noaxis_split_prod.shape, (1,))
         self.assertEqual(shape_noaxis_split_prod.lshape, (1,))
         self.assertEqual(shape_noaxis_split_prod.dtype, ht.int64)
-        self.assertEqual(shape_noaxis_split_prod._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(shape_noaxis_split_prod.larray.dtype, torch.int64)
         self.assertEqual(shape_noaxis_split_prod.split, None)
         self.assertEqual(shape_noaxis_split_prod, 3628800)
 
         out_noaxis = ht.zeros((1,))
         ht.prod(shape_noaxis_split, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 3628800)
+        self.assertEqual(out_noaxis.larray, 3628800)
 
         # check sum over all float elements of 3d tensor locally
         shape_noaxis = ht.full((3, 3, 3), 2)
@@ -474,13 +474,13 @@ class TestArithmetics(TestCase):
         self.assertEqual(no_axis_prod.shape, (1,))
         self.assertEqual(no_axis_prod.lshape, (1,))
         self.assertEqual(no_axis_prod.dtype, ht.float32)
-        self.assertEqual(no_axis_prod._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(no_axis_prod.larray.dtype, torch.float32)
         self.assertEqual(no_axis_prod.split, None)
-        self.assertEqual(no_axis_prod._DNDarray__array, 134217728)
+        self.assertEqual(no_axis_prod.larray, 134217728)
 
         out_noaxis = ht.zeros((1,))
         ht.prod(shape_noaxis, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 134217728)
+        self.assertEqual(out_noaxis.larray, 134217728)
 
         # check sum over all float elements of split 3d tensor
         shape_noaxis_split_axis = ht.full((3, 3, 3), 2, split=0)
@@ -489,14 +489,14 @@ class TestArithmetics(TestCase):
         self.assertIsInstance(split_axis_prod, ht.DNDarray)
         self.assertEqual(split_axis_prod.shape, (3, 3))
         self.assertEqual(split_axis_prod.dtype, ht.float32)
-        self.assertEqual(split_axis_prod._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(split_axis_prod.larray.dtype, torch.float32)
         self.assertEqual(split_axis_prod.split, None)
 
         out_axis = ht.ones((3, 3))
         ht.prod(shape_noaxis, axis=0, out=out_axis)
         self.assertTrue(
             (
-                out_axis._DNDarray__array
+                out_axis.larray
                 == torch.full((3,), 8, dtype=torch.float, device=self.device.torch_device)
             ).all()
         )
@@ -508,7 +508,7 @@ class TestArithmetics(TestCase):
         self.assertIsInstance(shape_noaxis_split_axis_neg_prod, ht.DNDarray)
         self.assertEqual(shape_noaxis_split_axis_neg_prod.shape, (1, 2, 3, 5))
         self.assertEqual(shape_noaxis_split_axis_neg_prod.dtype, ht.float32)
-        self.assertEqual(shape_noaxis_split_axis_neg_prod._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(shape_noaxis_split_axis_neg_prod.larray.dtype, torch.float32)
         self.assertEqual(shape_noaxis_split_axis_neg_prod.split, 1)
 
         out_noaxis = ht.zeros((1, 2, 3, 5))
@@ -522,7 +522,7 @@ class TestArithmetics(TestCase):
         self.assertIsInstance(shape_split_axis_tuple_prod, ht.DNDarray)
         self.assertEqual(shape_split_axis_tuple_prod.shape, (5,))
         self.assertEqual(shape_split_axis_tuple_prod.dtype, ht.float32)
-        self.assertEqual(shape_split_axis_tuple_prod._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(shape_split_axis_tuple_prod.larray.dtype, torch.float32)
         self.assertEqual(shape_split_axis_tuple_prod.split, None)
         self.assertTrue((shape_split_axis_tuple_prod == expected_result).all())
 
@@ -578,13 +578,13 @@ class TestArithmetics(TestCase):
         self.assertEqual(no_axis_sum.shape, (1,))
         self.assertEqual(no_axis_sum.lshape, (1,))
         self.assertEqual(no_axis_sum.dtype, ht.float32)
-        self.assertEqual(no_axis_sum._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(no_axis_sum.larray.dtype, torch.float32)
         self.assertEqual(no_axis_sum.split, None)
-        self.assertEqual(no_axis_sum._DNDarray__array, array_len)
+        self.assertEqual(no_axis_sum.larray, array_len)
 
         out_noaxis = ht.zeros((1,))
         ht.sum(shape_noaxis, out=out_noaxis)
-        self.assertTrue(out_noaxis._DNDarray__array == shape_noaxis._DNDarray__array.sum())
+        self.assertTrue(out_noaxis.larray == shape_noaxis.larray.sum())
 
         # check sum over all float elements of split 1d tensor
         shape_noaxis_split = ht.arange(array_len, split=0)
@@ -594,13 +594,13 @@ class TestArithmetics(TestCase):
         self.assertEqual(shape_noaxis_split_sum.shape, (1,))
         self.assertEqual(shape_noaxis_split_sum.lshape, (1,))
         self.assertEqual(shape_noaxis_split_sum.dtype, ht.int64)
-        self.assertEqual(shape_noaxis_split_sum._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(shape_noaxis_split_sum.larray.dtype, torch.int64)
         self.assertEqual(shape_noaxis_split_sum.split, None)
         self.assertEqual(shape_noaxis_split_sum, 55)
 
         out_noaxis = ht.zeros((1,))
         ht.sum(shape_noaxis_split, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 55)
+        self.assertEqual(out_noaxis.larray, 55)
 
         # check sum over all float elements of 3d tensor locally
         shape_noaxis = ht.ones((3, 3, 3))
@@ -610,13 +610,13 @@ class TestArithmetics(TestCase):
         self.assertEqual(no_axis_sum.shape, (1,))
         self.assertEqual(no_axis_sum.lshape, (1,))
         self.assertEqual(no_axis_sum.dtype, ht.float32)
-        self.assertEqual(no_axis_sum._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(no_axis_sum.larray.dtype, torch.float32)
         self.assertEqual(no_axis_sum.split, None)
-        self.assertEqual(no_axis_sum._DNDarray__array, 27)
+        self.assertEqual(no_axis_sum.larray, 27)
 
         out_noaxis = ht.zeros((1,))
         ht.sum(shape_noaxis, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 27)
+        self.assertEqual(out_noaxis.larray, 27)
 
         # check sum over all float elements of split 3d tensor
         shape_noaxis_split_axis = ht.ones((3, 3, 3), split=0)
@@ -625,14 +625,14 @@ class TestArithmetics(TestCase):
         self.assertIsInstance(split_axis_sum, ht.DNDarray)
         self.assertEqual(split_axis_sum.shape, (3, 3))
         self.assertEqual(split_axis_sum.dtype, ht.float32)
-        self.assertEqual(split_axis_sum._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(split_axis_sum.larray.dtype, torch.float32)
         self.assertEqual(split_axis_sum.split, None)
 
         out_noaxis = ht.zeros((3, 3))
         ht.sum(shape_noaxis, axis=0, out=out_noaxis)
         self.assertTrue(
             (
-                out_noaxis._DNDarray__array
+                out_noaxis.larray
                 == torch.full((3, 3), 3, dtype=torch.float, device=self.device.torch_device)
             ).all()
         )
@@ -644,7 +644,7 @@ class TestArithmetics(TestCase):
         self.assertIsInstance(shape_noaxis_split_axis_neg_sum, ht.DNDarray)
         self.assertEqual(shape_noaxis_split_axis_neg_sum.shape, (1, 2, 3, 5))
         self.assertEqual(shape_noaxis_split_axis_neg_sum.dtype, ht.float32)
-        self.assertEqual(shape_noaxis_split_axis_neg_sum._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(shape_noaxis_split_axis_neg_sum.larray.dtype, torch.float32)
         self.assertEqual(shape_noaxis_split_axis_neg_sum.split, 1)
 
         out_noaxis = ht.zeros((1, 2, 3, 5))
@@ -658,7 +658,7 @@ class TestArithmetics(TestCase):
         self.assertIsInstance(shape_split_axis_tuple_sum, ht.DNDarray)
         self.assertEqual(shape_split_axis_tuple_sum.shape, (5,))
         self.assertEqual(shape_split_axis_tuple_sum.dtype, ht.float32)
-        self.assertEqual(shape_split_axis_tuple_sum._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(shape_split_axis_tuple_sum.larray.dtype, torch.float32)
         self.assertEqual(shape_split_axis_tuple_sum.split, None)
         self.assertTrue((shape_split_axis_tuple_sum == expected_result).all())
 

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -75,9 +75,9 @@ class TestCommunication(TestCase):
         vector_out = ht.zeros_like(vector_data)
 
         # test that target and destination are not equal
-        self.assertTrue((vector_data._DNDarray__array != vector_out._DNDarray__array).all())
-        self.assertTrue(vector_data._DNDarray__array.is_contiguous())
-        self.assertTrue(vector_out._DNDarray__array.is_contiguous())
+        self.assertTrue((vector_data.larray != vector_out.larray).all())
+        self.assertTrue(vector_data.larray.is_contiguous())
+        self.assertTrue(vector_out.larray.is_contiguous())
 
         # send message to self that is received into a separate buffer afterwards
         req = vector_data.comm.Isend(vector_data, dest=vector_data.comm.rank)
@@ -86,8 +86,8 @@ class TestCommunication(TestCase):
         req.Wait()
 
         # check that after sending the data everything is equal
-        self.assertTrue((vector_data._DNDarray__array == vector_out._DNDarray__array).all())
-        self.assertTrue(vector_out._DNDarray__array.is_contiguous())
+        self.assertTrue((vector_data.larray == vector_out.larray).all())
+        self.assertTrue(vector_out.larray.is_contiguous())
 
         # multi-dimensional torch tensor
         tensor_data = (
@@ -117,11 +117,9 @@ class TestCommunication(TestCase):
         contiguous_out = ht.zeros_like(non_contiguous_data)
 
         # test that target and destination are not equal
-        self.assertTrue(
-            (non_contiguous_data._DNDarray__array != contiguous_out._DNDarray__array).all()
-        )
-        self.assertFalse(non_contiguous_data._DNDarray__array.is_contiguous())
-        self.assertTrue(contiguous_out._DNDarray__array.is_contiguous())
+        self.assertTrue((non_contiguous_data.larray != contiguous_out.larray).all())
+        self.assertFalse(non_contiguous_data.larray.is_contiguous())
+        self.assertTrue(contiguous_out.larray.is_contiguous())
 
         # send message to self that is received into a separate buffer afterwards
         req = non_contiguous_data.comm.Isend(
@@ -132,22 +130,18 @@ class TestCommunication(TestCase):
         req.Wait()
 
         # check that after sending the data everything is equal
-        self.assertTrue(
-            (non_contiguous_data._DNDarray__array == contiguous_out._DNDarray__array).all()
-        )
+        self.assertTrue((non_contiguous_data.larray == contiguous_out.larray).all())
         if ht.get_device().device_type == "cpu" or ht.communication.CUDA_AWARE_MPI:
-            self.assertTrue(contiguous_out._DNDarray__array.is_contiguous())
+            self.assertTrue(contiguous_out.larray.is_contiguous())
 
         # non-contiguous destination
         contiguous_data = ht.ones((3, 2))
         non_contiguous_out = ht.zeros((2, 3)).T
 
         # test that target and destination are not equal
-        self.assertTrue(
-            (contiguous_data._DNDarray__array != non_contiguous_out._DNDarray__array).all()
-        )
-        self.assertTrue(contiguous_data._DNDarray__array.is_contiguous())
-        self.assertFalse(non_contiguous_out._DNDarray__array.is_contiguous())
+        self.assertTrue((contiguous_data.larray != non_contiguous_out.larray).all())
+        self.assertTrue(contiguous_data.larray.is_contiguous())
+        self.assertFalse(non_contiguous_out.larray.is_contiguous())
 
         # send message to self that is received into a separate buffer afterwards
         req = contiguous_data.comm.Isend(contiguous_data, dest=contiguous_data.comm.rank)
@@ -155,25 +149,18 @@ class TestCommunication(TestCase):
 
         req.Wait()
         # check that after sending the data everything is equal
-        self.assertTrue(
-            (contiguous_data._DNDarray__array == non_contiguous_out._DNDarray__array).all()
-        )
+        self.assertTrue((contiguous_data.larray == non_contiguous_out.larray).all())
         if ht.get_device().device_type == "cpu" or ht.communication.CUDA_AWARE_MPI:
-            self.assertFalse(non_contiguous_out._DNDarray__array.is_contiguous())
+            self.assertFalse(non_contiguous_out.larray.is_contiguous())
 
         # non-contiguous destination
         both_non_contiguous_data = ht.ones((3, 2)).T
         both_non_contiguous_out = ht.zeros((3, 2)).T
 
         # test that target and destination are not equal
-        self.assertTrue(
-            (
-                both_non_contiguous_data._DNDarray__array
-                != both_non_contiguous_out._DNDarray__array
-            ).all()
-        )
-        self.assertFalse(both_non_contiguous_data._DNDarray__array.is_contiguous())
-        self.assertFalse(both_non_contiguous_out._DNDarray__array.is_contiguous())
+        self.assertTrue((both_non_contiguous_data.larray != both_non_contiguous_out.larray).all())
+        self.assertFalse(both_non_contiguous_data.larray.is_contiguous())
+        self.assertFalse(both_non_contiguous_out.larray.is_contiguous())
 
         # send message to self that is received into a separate buffer afterwards
         req = both_non_contiguous_data.comm.Isend(
@@ -185,14 +172,9 @@ class TestCommunication(TestCase):
 
         req.Wait()
         # check that after sending the data everything is equal
-        self.assertTrue(
-            (
-                both_non_contiguous_data._DNDarray__array
-                == both_non_contiguous_out._DNDarray__array
-            ).all()
-        )
+        self.assertTrue((both_non_contiguous_data.larray == both_non_contiguous_out.larray).all())
         if ht.get_device().device_type == "cpu" or ht.communication.CUDA_AWARE_MPI:
-            self.assertFalse(both_non_contiguous_out._DNDarray__array.is_contiguous())
+            self.assertFalse(both_non_contiguous_out.larray.is_contiguous())
 
     def test_default_comm(self):
         # default comm is world
@@ -220,17 +202,16 @@ class TestCommunication(TestCase):
         output = ht.zeros((ht.MPI_WORLD.size, 7))
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Allgather(data, output)
 
         # check result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         self.assertTrue(
             (
-                output._DNDarray__array
-                == torch.ones(ht.MPI_WORLD.size, 7, device=self.device.torch_device)
+                output.larray == torch.ones(ht.MPI_WORLD.size, 7, device=self.device.torch_device)
             ).all()
         )
 
@@ -239,16 +220,16 @@ class TestCommunication(TestCase):
         output = ht.random.randn(7, 2 * ht.MPI_WORLD.size, dtype=ht.float64)
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Allgather(data, output, recv_axis=1)
 
         # check result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         self.assertTrue(
             (
-                output._DNDarray__array
+                output.larray
                 == torch.ones(7, 2 * ht.MPI_WORLD.size, device=self.device.torch_device)
             ).all()
         )
@@ -258,16 +239,16 @@ class TestCommunication(TestCase):
         output = ht.zeros((5, 4 * ht.MPI_WORLD.size))
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Allgather(data, output)
 
         # check result
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         self.assertTrue(
             (
-                output._DNDarray__array
+                output.larray
                 == torch.ones(5, 4 * ht.MPI_WORLD.size, device=self.device.torch_device)
             ).all()
         )
@@ -277,16 +258,16 @@ class TestCommunication(TestCase):
         output = ht.zeros((7 * ht.MPI_WORLD.size, 5)).T
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         data.comm.Allgather(data, output, recv_axis=1)
 
         # check result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         self.assertTrue(
             (
-                output._DNDarray__array
+                output.larray
                 == torch.ones(5, 7 * ht.MPI_WORLD.size, device=self.device.torch_device)
             ).all()
         )
@@ -296,8 +277,8 @@ class TestCommunication(TestCase):
         output = ht.array([[0] * 10] * ht.MPI_WORLD.size)
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
 
         # perform the allgather operation
         data.comm.Allgather(data, output, recv_axis=0)
@@ -311,8 +292,8 @@ class TestCommunication(TestCase):
         output = ht.array([[0] * ht.MPI_WORLD.size] * 10)
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
 
         # perform the allgather operation
         data.comm.Allgather(data, output, recv_axis=1)
@@ -358,8 +339,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((output_count, 10))
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
 
         # perform the allgather operation
         counts = tuple(range(1, ht.MPI_WORLD.size + 1))
@@ -367,13 +348,10 @@ class TestCommunication(TestCase):
         data.comm.Allgatherv(data, (output, counts, displs))
 
         # check  result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         self.assertTrue(
-            (
-                output._DNDarray__array
-                == torch.ones(output_count, 10, device=self.device.torch_device)
-            ).all()
+            (output.larray == torch.ones(output_count, 10, device=self.device.torch_device)).all()
         )
 
         # non-contiguous data buffer, contiguous output buffer
@@ -382,8 +360,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((output_count, 10))
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
 
         # perform the allgather operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -391,13 +369,10 @@ class TestCommunication(TestCase):
         data.comm.Allgatherv(data, (output, counts, displs))
 
         # check  result
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         self.assertTrue(
-            (
-                output._DNDarray__array
-                == torch.ones(output_count, 10, device=self.device.torch_device)
-            ).all()
+            (output.larray == torch.ones(output_count, 10, device=self.device.torch_device)).all()
         )
 
         # contiguous data buffer, non-contiguous output buffer
@@ -406,8 +381,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((10, output_count)).T
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
 
         # perform the allgather operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -415,13 +390,10 @@ class TestCommunication(TestCase):
         data.comm.Allgatherv(data, (output, counts, displs))
 
         # check result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         self.assertTrue(
-            (
-                output._DNDarray__array
-                == torch.ones(output_count, 10, device=self.device.torch_device)
-            ).all()
+            (output.larray == torch.ones(output_count, 10, device=self.device.torch_device)).all()
         )
 
         # non-contiguous data buffer, non-contiguous output buffer
@@ -430,8 +402,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((10, output_count)).T
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
 
         # perform the allgather operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -439,13 +411,10 @@ class TestCommunication(TestCase):
         data.comm.Allgatherv(data, (output, counts, displs))
 
         # check result
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         self.assertTrue(
-            (
-                output._DNDarray__array
-                == torch.ones(output_count, 10, device=self.device.torch_device)
-            ).all()
+            (output.larray == torch.ones(output_count, 10, device=self.device.torch_device)).all()
         )
 
         # contiguous data buffer
@@ -465,8 +434,8 @@ class TestCommunication(TestCase):
         data.comm.Allgatherv((data, send_counts, send_displs), (output, recv_counts, recv_displs))
 
         # check result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         self.assertTrue((output[0] == first_line).all())
         self.assertTrue((output[output.lshape[0] - 1] == last_line).all())
 
@@ -476,22 +445,22 @@ class TestCommunication(TestCase):
         out = ht.zeros_like(data)
 
         # reduce across all nodes
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         data.comm.Allreduce(data, out, op=ht.MPI.SUM)
 
         # check the reduction result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
-        self.assertTrue((out._DNDarray__array == data.comm.size).all())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
+        self.assertTrue((out.larray == data.comm.size).all())
 
         # non-contiguous data
         data = ht.ones((10, 2), dtype=ht.int8).T
         out = ht.zeros_like(data)
 
         # reduce across all nodes
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         data.comm.Allreduce(data, out, op=ht.MPI.SUM)
 
         # check the reduction result
@@ -499,17 +468,17 @@ class TestCommunication(TestCase):
         # MPI enforces the same data type for send and receive buffer
         # the reduction implementation takes care of making the internal Torch storage
         # consistent
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
-        self.assertTrue((out._DNDarray__array == data.comm.size).all())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
+        self.assertTrue((out.larray == data.comm.size).all())
 
         # non-contiguous output
         data = ht.ones((10, 2), dtype=ht.int8)
         out = ht.zeros((2, 10), dtype=ht.int8).T
 
         # reduce across all nodes
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(out.larray.is_contiguous())
         data.comm.Allreduce(data, out, op=ht.MPI.SUM)
 
         # check the reduction result
@@ -517,9 +486,9 @@ class TestCommunication(TestCase):
         # MPI enforces the same data type for send and receive buffer
         # the reduction implementation takes care of making the internal Torch storage
         # consistent
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
-        self.assertTrue((out._DNDarray__array == data.comm.size).all())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
+        self.assertTrue((out.larray == data.comm.size).all())
 
     def test_alltoall(self):
         # contiguous data
@@ -527,72 +496,72 @@ class TestCommunication(TestCase):
         output = ht.zeros((ht.MPI_WORLD.size, 10), dtype=ht.int64)
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Alltoall(data, output)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         comparison = (
             torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
             .reshape(-1, 1)
             .expand(ht.MPI_WORLD.size, 10)
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         # contiguous data, different gather axis
         data = ht.array([[ht.MPI_WORLD.rank] * ht.MPI_WORLD.size] * 10)
         output = ht.zeros((10, ht.MPI_WORLD.size), dtype=ht.int64)
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Alltoall(data, output, send_axis=1)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         comparison = (
             torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
             .repeat(10)
             .reshape(10, ht.MPI_WORLD.size)
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         # non-contiguous data
         data = ht.ones((10, 2 * ht.MPI_WORLD.size), dtype=ht.int64).T
         output = ht.zeros((2 * ht.MPI_WORLD.size, 10), dtype=ht.int64)
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Alltoall(data, output)
 
         # check scatter result
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         comparison = torch.ones(
             (2 * ht.MPI_WORLD.size, 10), dtype=torch.int64, device=self.device.torch_device
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         # non-contiguous output, different gather axis
         data = ht.ones((10, 2 * ht.MPI_WORLD.size), dtype=ht.int64)
         output = ht.zeros((2 * ht.MPI_WORLD.size, 10), dtype=ht.int64).T
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         data.comm.Alltoall(data, output, send_axis=1)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         comparison = torch.ones(
             (10, 2 * ht.MPI_WORLD.size), dtype=torch.int64, device=self.device.torch_device
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         with self.assertRaises(TypeError):
             data = np.array([ht.MPI_WORLD.rank] * 3)
@@ -613,16 +582,16 @@ class TestCommunication(TestCase):
         recv_counts, recv_displs, _ = data.comm.counts_displs_shape(output.lshape, 0)
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         if ht.MPI_WORLD.size != 1:
             self.assertNotEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
         else:
             self.assertEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
 
         data.comm.Alltoallv((data, send_counts, send_displs), (output, recv_counts, recv_displs))
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         stack_count = output_shape[0] // ht.MPI_WORLD.size * 10
         comparison = (
             torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
@@ -630,7 +599,7 @@ class TestCommunication(TestCase):
             .expand(-1, stack_count)
             .reshape(-1, 10)
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         # non-contiguous data buffer
         data = ht.array([[ht.MPI_WORLD.rank] * (ht.MPI_WORLD.size + 1)] * 10).T
@@ -641,16 +610,16 @@ class TestCommunication(TestCase):
         recv_counts, recv_displs, _ = data.comm.counts_displs_shape(output.lshape, 0)
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         if ht.MPI_WORLD.size != 1:
             self.assertNotEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
         else:
             self.assertEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
 
         data.comm.Alltoallv((data, send_counts, send_displs), (output, recv_counts, recv_displs))
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         stack_count = output_shape[0] // ht.MPI_WORLD.size * 10
         comparison = (
             torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
@@ -658,7 +627,7 @@ class TestCommunication(TestCase):
             .expand(-1, stack_count)
             .reshape(-1, 10)
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         # contiguous data buffer
         data = ht.array([[ht.MPI_WORLD.rank] * 10] * (ht.MPI_WORLD.size + 1))
@@ -670,16 +639,16 @@ class TestCommunication(TestCase):
         recv_counts, recv_displs, _ = data.comm.counts_displs_shape(output.lshape, 0)
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         if ht.MPI_WORLD.size != 1:
             self.assertNotEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
         else:
             self.assertEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
 
         data.comm.Alltoallv((data, send_counts, send_displs), (output, recv_counts, recv_displs))
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         stack_count = output_shape[1] // ht.MPI_WORLD.size * 10
         comparison = (
             torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
@@ -687,7 +656,7 @@ class TestCommunication(TestCase):
             .expand(-1, stack_count)
             .reshape(-1, 10)
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         # non-contiguous data buffer
         data = ht.array([[ht.MPI_WORLD.rank] * (ht.MPI_WORLD.size + 1)] * 10).T
@@ -699,16 +668,16 @@ class TestCommunication(TestCase):
         recv_counts, recv_displs, _ = data.comm.counts_displs_shape(output.lshape, 0)
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         if ht.MPI_WORLD.size != 1:
             self.assertNotEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
         else:
             self.assertEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
 
         data.comm.Alltoallv((data, send_counts, send_displs), (output, recv_counts, recv_displs))
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         stack_count = output_shape[1] // ht.MPI_WORLD.size * 10
         comparison = (
             torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
@@ -716,7 +685,7 @@ class TestCommunication(TestCase):
             .expand(-1, stack_count)
             .reshape(-1, 10)
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
     def test_bcast(self):
         # contiguous data
@@ -725,14 +694,12 @@ class TestCommunication(TestCase):
             data = ht.zeros_like(data, dtype=ht.int64)
 
         # broadcast data to all nodes
-        self.assertTrue(data._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
         data.comm.Bcast(data, root=0)
 
         # assert output is equal
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(
-            (data._DNDarray__array == torch.arange(10, device=self.device.torch_device)).all()
-        )
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue((data.larray == torch.arange(10, device=self.device.torch_device)).all())
 
         # non-contiguous data
         data = ht.ones((2, 5), dtype=ht.float32).T
@@ -740,14 +707,14 @@ class TestCommunication(TestCase):
             data = ht.zeros((2, 5), dtype=ht.float32).T
 
         # broadcast data to all nodes
-        self.assertFalse(data._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
         data.comm.Bcast(data, root=0)
 
         # assert output is equal
-        self.assertFalse(data._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
         self.assertTrue(
             (
-                data._DNDarray__array
+                data.larray
                 == torch.ones((5, 2), dtype=torch.float32, device=self.device.torch_device)
             ).all()
         )
@@ -758,22 +725,22 @@ class TestCommunication(TestCase):
         out = ht.zeros_like(data)
 
         # reduce across all nodes
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         data.comm.Exscan(data, out)
 
         # check the reduction result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
-        self.assertTrue((out._DNDarray__array == data.comm.rank).all())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
+        self.assertTrue((out.larray == data.comm.rank).all())
 
         # non-contiguous data
         data = ht.ones((5, 3), dtype=ht.int64).T
         out = ht.zeros_like(data)
 
         # reduce across all nodes
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         data.comm.Exscan(data, out)
 
         # check the reduction result
@@ -781,17 +748,17 @@ class TestCommunication(TestCase):
         # MPI enforces the same data type for send and receive buffer
         # the reduction implementation takes care of making the internal Torch
         # storage consistent
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
-        self.assertTrue((out._DNDarray__array == data.comm.rank).all())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
+        self.assertTrue((out.larray == data.comm.rank).all())
 
         # non-contiguous output
         data = ht.ones((5, 3), dtype=ht.int64)
         out = ht.zeros((3, 5), dtype=ht.int64).T
 
         # reduce across all nodes
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(out.larray.is_contiguous())
         data.comm.Exscan(data, out)
 
         # check the reduction result
@@ -799,9 +766,9 @@ class TestCommunication(TestCase):
         # MPI enforces the same data type for send and receive buffer
         # the reduction implementation takes care of making the internal Torch storage
         # consistent
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
-        self.assertTrue((out._DNDarray__array == data.comm.rank).all())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
+        self.assertTrue((out.larray == data.comm.rank).all())
 
     def test_gather(self):
         # contiguous data
@@ -809,17 +776,17 @@ class TestCommunication(TestCase):
         output = ht.zeros((ht.MPI_WORLD.size, 5))
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Gather(data, output, root=0)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         if data.comm.rank == 0:
             self.assertTrue(
                 (
-                    output._DNDarray__array
+                    output.larray
                     == torch.ones(ht.MPI_WORLD.size, 5, device=self.device.torch_device)
                 ).all()
             )
@@ -829,17 +796,17 @@ class TestCommunication(TestCase):
         output = ht.zeros((5, 2 * ht.MPI_WORLD.size))
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Gather(data, output, root=0, axis=1)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         if data.comm.rank == 0:
             self.assertTrue(
                 (
-                    output._DNDarray__array
+                    output.larray
                     == torch.ones(5, 2 * ht.MPI_WORLD.size, device=self.device.torch_device)
                 ).all()
             )
@@ -849,17 +816,17 @@ class TestCommunication(TestCase):
         output = ht.zeros((5, 3 * ht.MPI_WORLD.size))
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Gather(data, output, root=0)
 
         # check scatter result
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         if data.comm.rank == 0:
             self.assertTrue(
                 (
-                    output._DNDarray__array
+                    output.larray
                     == torch.ones(5, 3 * ht.MPI_WORLD.size, device=self.device.torch_device)
                 ).all()
             )
@@ -869,17 +836,17 @@ class TestCommunication(TestCase):
         output = ht.zeros((3 * ht.MPI_WORLD.size, 5)).T
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         data.comm.Gather(data, output, root=0, axis=1)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         if data.comm.rank == 0:
             self.assertTrue(
                 (
-                    output._DNDarray__array
+                    output.larray
                     == torch.ones(5, 3 * ht.MPI_WORLD.size, device=self.device.torch_device)
                 ).all()
             )
@@ -891,8 +858,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((output_count, 10))
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
 
         # perform the scatter operation
         counts = tuple(range(1, ht.MPI_WORLD.size + 1))
@@ -900,13 +867,12 @@ class TestCommunication(TestCase):
         data.comm.Gatherv(data, (output, counts, displs), root=0)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         if data.comm.rank == 0:
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 10, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 10, device=self.device.torch_device)
                 ).all()
             )
 
@@ -916,8 +882,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((output_count, 10))
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
 
         # perform the scatter operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -925,13 +891,12 @@ class TestCommunication(TestCase):
         data.comm.Gatherv(data, (output, counts, displs), root=0)
 
         # check scatter result
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         if data.comm.rank == 0:
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 10, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 10, device=self.device.torch_device)
                 ).all()
             )
 
@@ -941,8 +906,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((10, output_count)).T
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
 
         # perform the scatter operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -950,13 +915,12 @@ class TestCommunication(TestCase):
         data.comm.Gatherv(data, (output, counts, displs), root=0)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         if data.comm.rank == 0:
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 10, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 10, device=self.device.torch_device)
                 ).all()
             )
 
@@ -966,8 +930,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((10, output_count)).T
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
 
         # perform the scatter operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -975,13 +939,12 @@ class TestCommunication(TestCase):
         data.comm.Gatherv(data, (output, counts, displs), root=0)
 
         # check scatter result
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         if data.comm.rank == 0:
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 10, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 10, device=self.device.torch_device)
                 ).all()
             )
 
@@ -992,17 +955,17 @@ class TestCommunication(TestCase):
             output = ht.zeros((ht.MPI_WORLD.size, 7))
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Iallgather(data, output)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
+                    output.larray
                     == torch.ones(ht.MPI_WORLD.size, 7, device=self.device.torch_device)
                 ).all()
             )
@@ -1012,16 +975,16 @@ class TestCommunication(TestCase):
             output = ht.random.randn(7, 2 * ht.MPI_WORLD.size, dtype=ht.float64)
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Iallgather(data, output, recv_axis=1)
             req.Wait()
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
+                    output.larray
                     == torch.ones(7, 2 * ht.MPI_WORLD.size, device=self.device.torch_device)
                 ).all()
             )
@@ -1031,17 +994,17 @@ class TestCommunication(TestCase):
             output = ht.zeros((5, 4 * ht.MPI_WORLD.size))
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Iallgather(data, output)
             req.Wait()
 
             # check scatter result
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
+                    output.larray
                     == torch.ones(5, 4 * ht.MPI_WORLD.size, device=self.device.torch_device)
                 ).all()
             )
@@ -1051,17 +1014,17 @@ class TestCommunication(TestCase):
             output = ht.zeros((7 * ht.MPI_WORLD.size, 5)).T
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             req = data.comm.Iallgather(data, output, recv_axis=1)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
+                    output.larray
                     == torch.ones(5, 7 * ht.MPI_WORLD.size, device=self.device.torch_device)
                 ).all()
             )
@@ -1078,8 +1041,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((output_count, 10))
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(1, ht.MPI_WORLD.size + 1))
@@ -1088,12 +1051,11 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 10, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 10, device=self.device.torch_device)
                 ).all()
             )
 
@@ -1103,8 +1065,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((output_count, 10))
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -1113,12 +1075,11 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 10, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 10, device=self.device.torch_device)
                 ).all()
             )
 
@@ -1128,8 +1089,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((10, output_count)).T
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -1138,12 +1099,11 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 10, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 10, device=self.device.torch_device)
                 ).all()
             )
 
@@ -1153,8 +1113,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((10, output_count)).T
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -1163,12 +1123,11 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 10, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 10, device=self.device.torch_device)
                 ).all()
             )
 
@@ -1183,23 +1142,23 @@ class TestCommunication(TestCase):
             out = ht.zeros_like(data)
 
             # reduce across all nodes
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             req = data.comm.Iallreduce(data, out, op=ht.MPI.SUM)
             req.Wait()
 
             # check the reduction result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
-            self.assertTrue((out._DNDarray__array == data.comm.size).all())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
+            self.assertTrue((out.larray == data.comm.size).all())
 
             # non-contiguous data
             data = ht.ones((10, 2), dtype=ht.int8).T
             out = ht.zeros_like(data)
 
             # reduce across all nodes
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             req = data.comm.Iallreduce(data, out, op=ht.MPI.SUM)
             req.Wait()
 
@@ -1208,17 +1167,17 @@ class TestCommunication(TestCase):
             # MPI enforces the same data type for send and receive buffer
             # the reduction implementation takes care of making the internal Torch
             # storage consistent
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
-            self.assertTrue((out._DNDarray__array == data.comm.size).all())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
+            self.assertTrue((out.larray == data.comm.size).all())
 
             # non-contiguous output
             data = ht.ones((10, 2), dtype=ht.int8)
             out = ht.zeros((2, 10), dtype=ht.int8).T
 
             # reduce across all nodes
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(out.larray.is_contiguous())
             req = data.comm.Iallreduce(data, out, op=ht.MPI.SUM)
             req.Wait()
 
@@ -1227,9 +1186,9 @@ class TestCommunication(TestCase):
             # MPI enforces the same data type for send and receive buffer
             # the reduction implementation takes care of making the internal Torch
             # storage consistent
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
-            self.assertTrue((out._DNDarray__array == data.comm.size).all())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
+            self.assertTrue((out.larray == data.comm.size).all())
 
         # MPI implementation may not support asynchronous operations
         except NotImplementedError:
@@ -1242,76 +1201,76 @@ class TestCommunication(TestCase):
             output = ht.zeros((ht.MPI_WORLD.size, 10), dtype=ht.int64)
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Ialltoall(data, output)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             comparison = (
                 torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
                 .reshape(-1, 1)
                 .expand(ht.MPI_WORLD.size, 10)
             )
-            self.assertTrue((output._DNDarray__array == comparison).all())
+            self.assertTrue((output.larray == comparison).all())
 
             # contiguous data, different gather axis
             data = ht.array([[ht.MPI_WORLD.rank] * ht.MPI_WORLD.size] * 10)
             output = ht.zeros((10, ht.MPI_WORLD.size), dtype=ht.int64)
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Ialltoall(data, output, send_axis=1)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             comparison = (
                 torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
                 .repeat(10)
                 .reshape(10, ht.MPI_WORLD.size)
             )
-            self.assertTrue((output._DNDarray__array == comparison).all())
+            self.assertTrue((output.larray == comparison).all())
 
             # non-contiguous data
             data = ht.ones((10, 2 * ht.MPI_WORLD.size), dtype=ht.int64).T
             output = ht.zeros((2 * ht.MPI_WORLD.size, 10), dtype=ht.int64)
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Ialltoall(data, output)
             req.Wait()
 
             # check scatter result
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             comparison = torch.ones(
                 (2 * ht.MPI_WORLD.size, 10), dtype=torch.int64, device=self.device.torch_device
             )
-            self.assertTrue((output._DNDarray__array == comparison).all())
+            self.assertTrue((output.larray == comparison).all())
 
             # non-contiguous output, different gather axis
             data = ht.ones((10, 2 * ht.MPI_WORLD.size), dtype=ht.int64)
             output = ht.zeros((2 * ht.MPI_WORLD.size, 10), dtype=ht.int64).T
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             req = data.comm.Ialltoall(data, output, send_axis=1)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             comparison = torch.ones(
                 (10, 2 * ht.MPI_WORLD.size), dtype=torch.int64, device=self.device.torch_device
             )
-            self.assertTrue((output._DNDarray__array == comparison).all())
+            self.assertTrue((output.larray == comparison).all())
 
         # MPI implementation may not support asynchronous operations
         except NotImplementedError:
@@ -1328,8 +1287,8 @@ class TestCommunication(TestCase):
             recv_counts, recv_displs, _ = data.comm.counts_displs_shape(output.lshape, 0)
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             if ht.MPI_WORLD.size != 1:
                 self.assertNotEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
             else:
@@ -1340,8 +1299,8 @@ class TestCommunication(TestCase):
             )
             req.Wait()
 
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             stack_count = output_shape[0] // ht.MPI_WORLD.size * 10
             comparison = (
                 torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
@@ -1349,7 +1308,7 @@ class TestCommunication(TestCase):
                 .expand(-1, stack_count)
                 .reshape(-1, 10)
             )
-            self.assertTrue((output._DNDarray__array == comparison).all())
+            self.assertTrue((output.larray == comparison).all())
 
             # non-contiguous data buffer
             data = ht.array([[ht.MPI_WORLD.rank] * (ht.MPI_WORLD.size + 1)] * 10).T
@@ -1360,8 +1319,8 @@ class TestCommunication(TestCase):
             recv_counts, recv_displs, _ = data.comm.counts_displs_shape(output.lshape, 0)
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             if ht.MPI_WORLD.size != 1:
                 self.assertNotEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
             else:
@@ -1372,8 +1331,8 @@ class TestCommunication(TestCase):
             )
             req.Wait()
 
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             stack_count = output_shape[0] // ht.MPI_WORLD.size * 10
             comparison = (
                 torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
@@ -1381,7 +1340,7 @@ class TestCommunication(TestCase):
                 .expand(-1, stack_count)
                 .reshape(-1, 10)
             )
-            self.assertTrue((output._DNDarray__array == comparison).all())
+            self.assertTrue((output.larray == comparison).all())
 
             # contiguous data buffer
             data = ht.array([[ht.MPI_WORLD.rank] * 10] * (ht.MPI_WORLD.size + 1))
@@ -1393,8 +1352,8 @@ class TestCommunication(TestCase):
             recv_counts, recv_displs, _ = data.comm.counts_displs_shape(output.lshape, 0)
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             if ht.MPI_WORLD.size != 1:
                 self.assertNotEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
             else:
@@ -1405,8 +1364,8 @@ class TestCommunication(TestCase):
             )
             req.Wait()
 
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             stack_count = output_shape[1] // ht.MPI_WORLD.size * 10
             comparison = (
                 torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
@@ -1414,7 +1373,7 @@ class TestCommunication(TestCase):
                 .expand(-1, stack_count)
                 .reshape(-1, 10)
             )
-            self.assertTrue((output._DNDarray__array == comparison).all())
+            self.assertTrue((output.larray == comparison).all())
 
             # non-contiguous data buffer
             data = ht.array([[ht.MPI_WORLD.rank] * (ht.MPI_WORLD.size + 1)] * 10).T
@@ -1426,8 +1385,8 @@ class TestCommunication(TestCase):
             recv_counts, recv_displs, _ = data.comm.counts_displs_shape(output.lshape, 0)
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             if ht.MPI_WORLD.size != 1:
                 self.assertNotEqual(data.shape[0] % ht.MPI_WORLD.size, 0)
             else:
@@ -1438,8 +1397,8 @@ class TestCommunication(TestCase):
             )
             req.Wait()
 
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             stack_count = output_shape[1] // ht.MPI_WORLD.size * 10
             comparison = (
                 torch.arange(ht.MPI_WORLD.size, device=self.device.torch_device)
@@ -1447,7 +1406,7 @@ class TestCommunication(TestCase):
                 .expand(-1, stack_count)
                 .reshape(-1, 10)
             )
-            self.assertTrue((output._DNDarray__array == comparison).all())
+            self.assertTrue((output.larray == comparison).all())
 
         # MPI implementation may not support asynchronous operations
         except NotImplementedError:
@@ -1461,14 +1420,14 @@ class TestCommunication(TestCase):
                 data = ht.zeros_like(data, dtype=ht.int64)
 
             # broadcast data to all nodes
-            self.assertTrue(data._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
             req = data.comm.Ibcast(data, root=0)
             req.Wait()
 
             # assert output is equal
-            self.assertTrue(data._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
             self.assertTrue(
-                (data._DNDarray__array == torch.arange(10, device=self.device.torch_device)).all()
+                (data.larray == torch.arange(10, device=self.device.torch_device)).all()
             )
 
             # non-contiguous data
@@ -1477,15 +1436,15 @@ class TestCommunication(TestCase):
                 data = ht.zeros((2, 5), dtype=ht.float32).T
 
             # broadcast data to all nodes
-            self.assertFalse(data._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
             req = data.comm.Ibcast(data, root=0)
             req.Wait()
 
             # assert output is equal
-            self.assertFalse(data._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
             self.assertTrue(
                 (
-                    data._DNDarray__array
+                    data.larray
                     == torch.ones((5, 2), dtype=torch.float32, device=self.device.torch_device)
                 ).all()
             )
@@ -1501,23 +1460,23 @@ class TestCommunication(TestCase):
             out = ht.zeros_like(data)
 
             # reduce across all nodes
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             req = data.comm.Iexscan(data, out)
             req.Wait()
 
             # check the reduction result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
-            self.assertTrue((out._DNDarray__array == data.comm.rank).all())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
+            self.assertTrue((out.larray == data.comm.rank).all())
 
             # non-contiguous data
             data = ht.ones((5, 3), dtype=ht.int64).T
             out = ht.zeros_like(data)
 
             # reduce across all nodes
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             req = data.comm.Iexscan(data, out)
             req.Wait()
 
@@ -1526,17 +1485,17 @@ class TestCommunication(TestCase):
             # MPI enforces the same data type for send and receive buffer
             # the reduction implementation takes care of making the internal Torch
             # storage consistent
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
-            self.assertTrue((out._DNDarray__array == data.comm.rank).all())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
+            self.assertTrue((out.larray == data.comm.rank).all())
 
             # non-contiguous output
             data = ht.ones((5, 3), dtype=ht.int64)
             out = ht.zeros((3, 5), dtype=ht.int64).T
 
             # reduce across all nodes
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(out.larray.is_contiguous())
             req = data.comm.Iexscan(data, out)
             req.Wait()
 
@@ -1545,9 +1504,9 @@ class TestCommunication(TestCase):
             # MPI enforces the same data type for send and receive buffer
             # the reduction implementation takes care of making the internal Torch
             # storage consistent
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
-            self.assertTrue((out._DNDarray__array == data.comm.rank).all())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
+            self.assertTrue((out.larray == data.comm.rank).all())
 
         # MPI implementation may not support asynchronous operations
         except NotImplementedError:
@@ -1560,18 +1519,18 @@ class TestCommunication(TestCase):
             output = ht.random.randn(ht.MPI_WORLD.size, 5, dtype=ht.float64)
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Igather(data, output, root=0)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             if data.comm.rank == 0:
                 self.assertTrue(
                     (
-                        output._DNDarray__array
+                        output.larray
                         == torch.ones(
                             (ht.MPI_WORLD.size, 5),
                             dtype=torch.float32,
@@ -1585,18 +1544,18 @@ class TestCommunication(TestCase):
             output = ht.random.randn(5, 2 * ht.MPI_WORLD.size, dtype=ht.float64)
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Igather(data, output, root=0, axis=1)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             if data.comm.rank == 0:
                 self.assertTrue(
                     (
-                        output._DNDarray__array
+                        output.larray
                         == torch.ones(
                             (5, 2 * ht.MPI_WORLD.size),
                             dtype=torch.float32,
@@ -1610,18 +1569,18 @@ class TestCommunication(TestCase):
             output = ht.random.randn(5, 3 * ht.MPI_WORLD.size, dtype=ht.float64)
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Igather(data, output, root=0)
             req.Wait()
 
             # check scatter result
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             if data.comm.rank == 0:
                 self.assertTrue(
                     (
-                        output._DNDarray__array
+                        output.larray
                         == torch.ones(
                             (5, 3 * ht.MPI_WORLD.size),
                             dtype=torch.float32,
@@ -1635,18 +1594,18 @@ class TestCommunication(TestCase):
             output = ht.random.randn(3 * ht.MPI_WORLD.size, 5, dtype=ht.float64).T
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             req = data.comm.Igather(data, output, root=0, axis=1)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             if data.comm.rank == 0:
                 self.assertTrue(
                     (
-                        output._DNDarray__array
+                        output.larray
                         == torch.ones(
                             (5, 3 * ht.MPI_WORLD.size),
                             dtype=torch.float32,
@@ -1667,8 +1626,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((output_count, 10))
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(1, ht.MPI_WORLD.size + 1))
@@ -1677,12 +1636,12 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             if data.comm.rank == 0:
                 self.assertTrue(
                     (
-                        output._DNDarray__array
+                        output.larray
                         == torch.ones(output_count, 10, device=self.device.torch_device)
                     ).all()
                 )
@@ -1693,8 +1652,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((output_count, 10))
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -1703,12 +1662,12 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             if data.comm.rank == 0:
                 self.assertTrue(
                     (
-                        output._DNDarray__array
+                        output.larray
                         == torch.ones(output_count, 10, device=self.device.torch_device)
                     ).all()
                 )
@@ -1719,8 +1678,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((10, output_count)).T
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -1729,12 +1688,12 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             if data.comm.rank == 0:
                 self.assertTrue(
                     (
-                        output._DNDarray__array
+                        output.larray
                         == torch.ones(output_count, 10, device=self.device.torch_device)
                     ).all()
                 )
@@ -1745,8 +1704,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((10, output_count)).T
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -1755,12 +1714,12 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             if data.comm.rank == 0:
                 self.assertTrue(
                     (
-                        output._DNDarray__array
+                        output.larray
                         == torch.ones(output_count, 10, device=self.device.torch_device)
                     ).all()
                 )
@@ -1776,24 +1735,24 @@ class TestCommunication(TestCase):
             out = ht.zeros_like(data)
 
             # reduce across all nodes
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             req = data.comm.Ireduce(data, out, op=ht.MPI.SUM, root=0)
             req.Wait()
 
             # check the reduction result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             if data.comm.rank == 0:
-                self.assertTrue((out._DNDarray__array == data.comm.size).all())
+                self.assertTrue((out.larray == data.comm.size).all())
 
             # non-contiguous data
             data = ht.ones((10, 2), dtype=ht.int32).T
             out = ht.zeros_like(data)
 
             # reduce across all nodes
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             req = data.comm.Ireduce(data, out, op=ht.MPI.SUM, root=0)
             req.Wait()
 
@@ -1802,18 +1761,18 @@ class TestCommunication(TestCase):
             # MPI enforces the same data type for send and receive buffer
             # the reduction implementation takes care of making the internal Torch
             # storage consistent
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             if data.comm.rank == 0:
-                self.assertTrue((out._DNDarray__array == data.comm.size).all())
+                self.assertTrue((out.larray == data.comm.size).all())
 
             # non-contiguous output
             data = ht.ones((10, 2), dtype=ht.int32)
             out = ht.zeros((2, 10), dtype=ht.int32).T
 
             # reduce across all nodes
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(out.larray.is_contiguous())
             req = data.comm.Ireduce(data, out, op=ht.MPI.SUM, root=0)
             req.Wait()
 
@@ -1822,10 +1781,10 @@ class TestCommunication(TestCase):
             # MPI enforces the same data type for send and receive buffer
             # the reduction implementation takes care of making the internal Torch
             # storage consistent
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             if data.comm.rank == 0:
-                self.assertTrue((out._DNDarray__array == data.comm.size).all())
+                self.assertTrue((out.larray == data.comm.size).all())
 
         # MPI implementation may not support asynchronous operations
         except NotImplementedError:
@@ -1838,23 +1797,23 @@ class TestCommunication(TestCase):
             out = ht.zeros_like(data)
 
             # reduce across all nodes
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             req = data.comm.Iscan(data, out)
             req.Wait()
 
             # check the reduction result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
-            self.assertTrue((out._DNDarray__array == data.comm.rank + 1).all())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
+            self.assertTrue((out.larray == data.comm.rank + 1).all())
 
             # non-contiguous data
             data = ht.ones((5, 3), dtype=ht.float64).T
             out = ht.zeros_like(data)
 
             # reduce across all nodes
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
             req = data.comm.Iscan(data, out)
             req.Wait()
 
@@ -1863,17 +1822,17 @@ class TestCommunication(TestCase):
             # MPI enforces the same data type for send and receive buffer
             # the reduction implementation takes care of making the internal Torch
             # storage consistent
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
-            self.assertTrue((out._DNDarray__array == data.comm.rank + 1).all())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
+            self.assertTrue((out.larray == data.comm.rank + 1).all())
 
             # non-contiguous output
             data = ht.ones((5, 3), dtype=ht.float64)
             out = ht.zeros((3, 5), dtype=ht.float64).T
 
             # reduce across all nodes
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(out._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(out.larray.is_contiguous())
             req = data.comm.Iscan(data, out)
             req.Wait()
 
@@ -1882,9 +1841,9 @@ class TestCommunication(TestCase):
             # MPI enforces the same data type for send and receive buffer
             # the reduction implementation takes care of making the internal Torch
             # storage consistent
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(out._DNDarray__array.is_contiguous())
-            self.assertTrue((out._DNDarray__array == data.comm.rank + 1).all())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(out.larray.is_contiguous())
+            self.assertTrue((out.larray == data.comm.rank + 1).all())
 
         # MPI implementation may not support asynchronous operations
         except NotImplementedError:
@@ -1900,16 +1859,16 @@ class TestCommunication(TestCase):
             output = ht.zeros((1, 5))
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Iscatter(data, output, root=0)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
-                (output._DNDarray__array == torch.ones(1, 5, device=self.device.torch_device)).all()
+                (output.larray == torch.ones(1, 5, device=self.device.torch_device)).all()
             )
 
             # contiguous data, different scatter axis
@@ -1920,40 +1879,40 @@ class TestCommunication(TestCase):
             output = ht.zeros((5, 1))
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Iscatter(data, output, root=0, axis=1)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
-                (output._DNDarray__array == torch.ones(5, 1, device=self.device.torch_device)).all()
+                (output.larray == torch.ones(5, 1, device=self.device.torch_device)).all()
             )
 
             # non-contiguous data
             if ht.MPI_WORLD.rank == 0:
                 data = ht.ones((5, ht.MPI_WORLD.size * 2)).T
-                self.assertFalse(data._DNDarray__array.is_contiguous())
+                self.assertFalse(data.larray.is_contiguous())
             else:
                 data = ht.zeros((1,))
-                self.assertTrue(data._DNDarray__array.is_contiguous())
+                self.assertTrue(data.larray.is_contiguous())
             output = ht.zeros((2, 5))
 
             # ensure prior invariants
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             req = data.comm.Iscatter(data, output, root=0)
             req.Wait()
 
             # check scatter result
             if ht.MPI_WORLD.rank == 0:
-                self.assertFalse(data._DNDarray__array.is_contiguous())
+                self.assertFalse(data.larray.is_contiguous())
             else:
-                self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+                self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
-                (output._DNDarray__array == torch.ones(2, 5, device=self.device.torch_device)).all()
+                (output.larray == torch.ones(2, 5, device=self.device.torch_device)).all()
             )
 
             # non-contiguous destination, different split axis
@@ -1964,16 +1923,16 @@ class TestCommunication(TestCase):
             output = ht.zeros((2, 5)).T
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             req = data.comm.Iscatter(data, output, root=0, axis=1)
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             self.assertTrue(
-                (output._DNDarray__array == torch.ones(5, 2, device=self.device.torch_device)).all()
+                (output.larray == torch.ones(5, 2, device=self.device.torch_device)).all()
             )
 
         # MPI implementation may not support asynchronous operations
@@ -1989,8 +1948,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((output_count, 12))
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -1999,12 +1958,11 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 12, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 12, device=self.device.torch_device)
                 ).all()
             )
 
@@ -2015,8 +1973,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((output_count, 12))
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -2025,12 +1983,11 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertTrue(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertTrue(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 12, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 12, device=self.device.torch_device)
                 ).all()
             )
 
@@ -2041,8 +1998,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((12, output_count)).T
 
             # ensure prior invariants
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -2051,12 +2008,11 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 12, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 12, device=self.device.torch_device)
                 ).all()
             )
 
@@ -2067,8 +2023,8 @@ class TestCommunication(TestCase):
             output = ht.zeros((12, output_count)).T
 
             # ensure prior invariants
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
 
             # perform the scatter operation
             counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -2077,12 +2033,11 @@ class TestCommunication(TestCase):
             req.Wait()
 
             # check scatter result
-            self.assertFalse(data._DNDarray__array.is_contiguous())
-            self.assertFalse(output._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
+            self.assertFalse(output.larray.is_contiguous())
             self.assertTrue(
                 (
-                    output._DNDarray__array
-                    == torch.ones(output_count, 12, device=self.device.torch_device)
+                    output.larray == torch.ones(output_count, 12, device=self.device.torch_device)
                 ).all()
             )
 
@@ -2095,7 +2050,7 @@ class TestCommunication(TestCase):
         data = ht.ones((size, size), dtype=ht.int32)
         data.comm.Allreduce(ht.MPI.IN_PLACE, data, op=ht.MPI.SUM)
 
-        self.assertTrue((data._DNDarray__array == size).all())
+        self.assertTrue((data.larray == size).all())
         # MPI Inplace is not allowed for AllToAll
 
     def test_reduce(self):
@@ -2104,23 +2059,23 @@ class TestCommunication(TestCase):
         out = ht.zeros_like(data)
 
         # reduce across all nodes
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         data.comm.Reduce(data, out, op=ht.MPI.SUM, root=0)
 
         # check the reduction result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         if data.comm.rank == 0:
-            self.assertTrue((out._DNDarray__array == data.comm.size).all())
+            self.assertTrue((out.larray == data.comm.size).all())
 
         # non-contiguous data
         data = ht.ones((10, 2), dtype=ht.int32).T
         out = ht.zeros_like(data)
 
         # reduce across all nodes
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         data.comm.Reduce(data, out, op=ht.MPI.SUM, root=0)
 
         # check the reduction result
@@ -2128,18 +2083,18 @@ class TestCommunication(TestCase):
         # MPI enforces the same data type for send and receive buffer
         # the reduction implementation takes care of making the internal Torch
         # storage consistent
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         if data.comm.rank == 0:
-            self.assertTrue((out._DNDarray__array == data.comm.size).all())
+            self.assertTrue((out.larray == data.comm.size).all())
 
         # non-contiguous output
         data = ht.ones((10, 2), dtype=ht.int32)
         out = ht.zeros((2, 10), dtype=ht.int32).T
 
         # reduce across all nodes
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(out.larray.is_contiguous())
         data.comm.Reduce(data, out, op=ht.MPI.SUM, root=0)
 
         # check the reduction result
@@ -2147,10 +2102,10 @@ class TestCommunication(TestCase):
         # MPI enforces the same data type for send and receive buffer
         # the reduction implementation takes care of making the internal Torch storage
         # consistent
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         if data.comm.rank == 0:
-            self.assertTrue((out._DNDarray__array == data.comm.size).all())
+            self.assertTrue((out.larray == data.comm.size).all())
 
     def test_scan(self):
         # contiguous data
@@ -2158,22 +2113,22 @@ class TestCommunication(TestCase):
         out = ht.zeros_like(data)
 
         # reduce across all nodes
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         data.comm.Scan(data, out)
 
         # check the reduction result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
-        self.assertTrue((out._DNDarray__array == data.comm.rank + 1).all())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
+        self.assertTrue((out.larray == data.comm.rank + 1).all())
 
         # non-contiguous data
         data = ht.ones((5, 3), dtype=ht.float64).T
         out = ht.zeros_like(data)
 
         # reduce across all nodes
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
         data.comm.Scan(data, out)
 
         # check the reduction result
@@ -2181,17 +2136,17 @@ class TestCommunication(TestCase):
         # MPI enforces the same data type for send and receive buffer
         # the reduction implementation takes care of making the internal Torch storage
         # consistent
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
-        self.assertTrue((out._DNDarray__array == data.comm.rank + 1).all())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
+        self.assertTrue((out.larray == data.comm.rank + 1).all())
 
         # non-contiguous output
         data = ht.ones((5, 3), dtype=ht.float64)
         out = ht.zeros((3, 5), dtype=ht.float64).T
 
         # reduce across all nodes
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(out._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(out.larray.is_contiguous())
         data.comm.Scan(data, out)
 
         # check the reduction result
@@ -2199,9 +2154,9 @@ class TestCommunication(TestCase):
         # MPI enforces the same data type for send and receive buffer
         # the reduction implementation takes care of making the internal Torch storage
         # consistent
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(out._DNDarray__array.is_contiguous())
-        self.assertTrue((out._DNDarray__array == data.comm.rank + 1).all())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(out.larray.is_contiguous())
+        self.assertTrue((out.larray == data.comm.rank + 1).all())
 
     def test_scatter(self):
         # contiguous data
@@ -2212,16 +2167,14 @@ class TestCommunication(TestCase):
         output = ht.zeros((1, 5))
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Scatter(data, output, root=0)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
-        self.assertTrue(
-            (output._DNDarray__array == torch.ones(1, 5, device=self.device.torch_device)).all()
-        )
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
+        self.assertTrue((output.larray == torch.ones(1, 5, device=self.device.torch_device)).all())
 
         # contiguous data, different scatter axis
         if ht.MPI_WORLD.rank == 0:
@@ -2231,39 +2184,35 @@ class TestCommunication(TestCase):
         output = ht.zeros((5, 1))
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Scatter(data, output, root=0, axis=1)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
-        self.assertTrue(
-            (output._DNDarray__array == torch.ones(5, 1, device=self.device.torch_device)).all()
-        )
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
+        self.assertTrue((output.larray == torch.ones(5, 1, device=self.device.torch_device)).all())
 
         # non-contiguous data
         if ht.MPI_WORLD.rank == 0:
             data = ht.ones((5, ht.MPI_WORLD.size * 2)).T
-            self.assertFalse(data._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
         else:
             data = ht.zeros((1,))
-            self.assertTrue(data._DNDarray__array.is_contiguous())
+            self.assertTrue(data.larray.is_contiguous())
         output = ht.zeros((2, 5))
 
         # ensure prior invariants
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         data.comm.Scatter(data, output, root=0)
 
         # check scatter result
         if ht.MPI_WORLD.rank == 0:
-            self.assertFalse(data._DNDarray__array.is_contiguous())
+            self.assertFalse(data.larray.is_contiguous())
         else:
-            self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
-        self.assertTrue(
-            (output._DNDarray__array == torch.ones(2, 5, device=self.device.torch_device)).all()
-        )
+            self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
+        self.assertTrue((output.larray == torch.ones(2, 5, device=self.device.torch_device)).all())
 
         # non-contiguous destination, different split axis
         if ht.MPI_WORLD.rank == 0:
@@ -2273,16 +2222,14 @@ class TestCommunication(TestCase):
         output = ht.zeros((2, 5)).T
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         data.comm.Scatter(data, output, root=0, axis=1)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
-        self.assertTrue(
-            (output._DNDarray__array == torch.ones(5, 2, device=self.device.torch_device)).all()
-        )
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
+        self.assertTrue((output.larray == torch.ones(5, 2, device=self.device.torch_device)).all())
 
     def test_scatter_like_axes(self):
         # input and output are not split
@@ -2296,7 +2243,7 @@ class TestCommunication(TestCase):
             .reshape(-1, 1)
             .repeat(1, ht.MPI_WORLD.size)
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         # minor axis send buffer, main axis receive buffer
         data.comm.Alltoall(data, output, send_axis=1)
@@ -2305,7 +2252,7 @@ class TestCommunication(TestCase):
             .reshape(1, -1)
             .repeat(ht.MPI_WORLD.size, 1)
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         # main axis send buffer, minor axis receive buffer
         data = ht.array([[ht.MPI_WORLD.rank] * (2 * ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
@@ -2316,7 +2263,7 @@ class TestCommunication(TestCase):
             .reshape(1, -1)
             .repeat(2 * ht.MPI_WORLD.size, 1)
         )
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
         # minor axis send buffer, minor axis receive buffer
         data = ht.array([range(ht.MPI_WORLD.size)] * ht.MPI_WORLD.size)
@@ -2328,7 +2275,7 @@ class TestCommunication(TestCase):
             .repeat(1, ht.MPI_WORLD.size)
         )
 
-        self.assertTrue((output._DNDarray__array == comparison).all())
+        self.assertTrue((output.larray == comparison).all())
 
     def test_scatterv(self):
         # contiguous data buffer, contiguous output buffer
@@ -2338,8 +2285,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((output_count, 12))
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
 
         # perform the scatter operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -2347,13 +2294,10 @@ class TestCommunication(TestCase):
         data.comm.Scatterv((data, counts, displs), output, root=0)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         self.assertTrue(
-            (
-                output._DNDarray__array
-                == torch.ones(output_count, 12, device=self.device.torch_device)
-            ).all()
+            (output.larray == torch.ones(output_count, 12, device=self.device.torch_device)).all()
         )
 
         # non-contiguous data buffer, contiguous output buffer
@@ -2363,8 +2307,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((output_count, 12))
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
 
         # perform the scatter operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -2372,13 +2316,10 @@ class TestCommunication(TestCase):
         data.comm.Scatterv((data, counts, displs), output, root=0)
 
         # check scatter result
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertTrue(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertTrue(output.larray.is_contiguous())
         self.assertTrue(
-            (
-                output._DNDarray__array
-                == torch.ones(output_count, 12, device=self.device.torch_device)
-            ).all()
+            (output.larray == torch.ones(output_count, 12, device=self.device.torch_device)).all()
         )
 
         # contiguous data buffer, non-contiguous output buffer
@@ -2388,8 +2329,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((12, output_count)).T
 
         # ensure prior invariants
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
 
         # perform the scatter operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -2397,13 +2338,10 @@ class TestCommunication(TestCase):
         data.comm.Scatterv((data, counts, displs), output, root=0)
 
         # check scatter result
-        self.assertTrue(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertTrue(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         self.assertTrue(
-            (
-                output._DNDarray__array
-                == torch.ones(output_count, 12, device=self.device.torch_device)
-            ).all()
+            (output.larray == torch.ones(output_count, 12, device=self.device.torch_device)).all()
         )
 
         # non-contiguous data buffer, non-contiguous output buffer
@@ -2413,8 +2351,8 @@ class TestCommunication(TestCase):
         output = ht.zeros((12, output_count)).T
 
         # ensure prior invariants
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
 
         # perform the scatter operation
         counts = tuple(range(2, 2 * (ht.MPI_WORLD.size + 1), 2))
@@ -2422,13 +2360,10 @@ class TestCommunication(TestCase):
         data.comm.Scatterv((data, counts, displs), output, root=0)
 
         # check scatter result
-        self.assertFalse(data._DNDarray__array.is_contiguous())
-        self.assertFalse(output._DNDarray__array.is_contiguous())
+        self.assertFalse(data.larray.is_contiguous())
+        self.assertFalse(output.larray.is_contiguous())
         self.assertTrue(
-            (
-                output._DNDarray__array
-                == torch.ones(output_count, 12, device=self.device.torch_device)
-            ).all()
+            (output.larray == torch.ones(output_count, 12, device=self.device.torch_device)).all()
         )
 
     def test_allgathervSorting(self):
@@ -2458,17 +2393,17 @@ class TestCommunication(TestCase):
         test1.comm.Allgatherv(
             test1, (gathered1, gathered1_counts, gathered1_displs), recv_axis=test1.split
         )
-        self.assertTrue(torch.equal(gathered1, result._DNDarray__array))
+        self.assertTrue(torch.equal(gathered1, result.larray))
 
         test2.comm.Allgatherv(
             test2, (gathered2, gathered2_counts, gathered2_displs), recv_axis=test2.split
         )
-        self.assertTrue(torch.equal(gathered2, result._DNDarray__array))
+        self.assertTrue(torch.equal(gathered2, result.larray))
 
         test3.comm.Allgatherv(
             test3, (gathered3, gathered3_counts, gathered3_displs), recv_axis=test3.split
         )
-        self.assertTrue(torch.equal(gathered3, result._DNDarray__array))
+        self.assertTrue(torch.equal(gathered3, result.larray))
 
     def test_alltoallSorting(self):
         test1 = self.sorted3Dtensor.copy()
@@ -2479,12 +2414,9 @@ class TestCommunication(TestCase):
             comparison1.lshape, dtype=test1.dtype.torch_type(), device=self.device.torch_device
         )
         test1.comm.Alltoallv(
-            test1._DNDarray__array,
-            redistributed1,
-            send_axis=comparison1.split,
-            recv_axis=test1.split,
+            test1.larray, redistributed1, send_axis=comparison1.split, recv_axis=test1.split
         )
-        self.assertTrue(torch.equal(redistributed1, comparison1._DNDarray__array))
+        self.assertTrue(torch.equal(redistributed1, comparison1.larray))
 
         test2 = self.sorted3Dtensor.copy()
         test2.resplit_(axis=1)
@@ -2498,12 +2430,12 @@ class TestCommunication(TestCase):
             comparison2.lshape, dtype=test2.dtype.torch_type(), device=self.device.torch_device
         )
         test2.comm.Alltoallv(
-            (test2._DNDarray__array, send_counts, send_displs),
+            (test2.larray, send_counts, send_displs),
             (redistributed2, recv_counts, recv_displs),
             send_axis=comparison2.split,
             recv_axis=test2.split,
         )
-        self.assertTrue(torch.equal(redistributed2, comparison2._DNDarray__array))
+        self.assertTrue(torch.equal(redistributed2, comparison2.larray))
 
         test3 = self.sorted3Dtensor.copy()
         test3.resplit_(axis=0)
@@ -2513,12 +2445,9 @@ class TestCommunication(TestCase):
             comparison3.lshape, dtype=test3.dtype.torch_type(), device=self.device.torch_device
         )
         test3.comm.Alltoallv(
-            test3._DNDarray__array,
-            redistributed3,
-            send_axis=comparison3.split,
-            recv_axis=test3.split,
+            test3.larray, redistributed3, send_axis=comparison3.split, recv_axis=test3.split
         )
-        self.assertTrue(torch.equal(redistributed3, comparison3._DNDarray__array))
+        self.assertTrue(torch.equal(redistributed3, comparison3.larray))
 
         test4 = self.sorted3Dtensor.copy()
         test4.resplit_(axis=2)
@@ -2528,14 +2457,11 @@ class TestCommunication(TestCase):
             comparison4.lshape, dtype=test4.dtype.torch_type(), device=self.device.torch_device
         )
         test4.comm.Alltoallv(
-            test4._DNDarray__array,
-            redistributed4,
-            send_axis=comparison4.split,
-            recv_axis=test4.split,
+            test4.larray, redistributed4, send_axis=comparison4.split, recv_axis=test4.split
         )
-        self.assertTrue(torch.equal(redistributed4, comparison4._DNDarray__array))
+        self.assertTrue(torch.equal(redistributed4, comparison4.larray))
 
         with self.assertRaises(NotImplementedError):
-            test4.comm.Alltoallv(test4._DNDarray__array, redistributed4, send_axis=2, recv_axis=2)
+            test4.comm.Alltoallv(test4.larray, redistributed4, send_axis=2, recv_axis=2)
         with self.assertRaises(NotImplementedError):
-            test4.comm.Alltoallv(test4._DNDarray__array, redistributed4, send_axis=None)
+            test4.comm.Alltoallv(test4.larray, redistributed4, send_axis=None)

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -170,6 +170,30 @@ class TestDNDarray(TestCase):
                 self.assertTrue(data.halo_next is None)
                 self.assertEqual(data_with_halos.shape, (12, 0))
 
+    def test_larray(self):
+        x = ht.arange(6 * 7 * 8).reshape((6, 7, 8))
+
+        self.assertTrue((x._DNDarray__array == x.larray).all())
+        self.assertIsInstance(x.larray, torch.Tensor)
+        self.assertEqual(x.larray.shape, x.lshape)
+
+        x.larray = torch.arange(42)
+
+        self.assertTrue((x._DNDarray__array == x.larray).all())
+        self.assertTrue(x.gshape, (42,))
+        self.assertIsInstance(x.larray, torch.Tensor)
+        self.assertEqual(x.larray.shape, x.lshape)
+
+        # Exceptions
+        with self.assertRaises(TypeError):
+            x.larray = ht.array([1, 2, 3])
+        with self.assertRaises(TypeError):
+            x.larray = np.array([1, 2, 3])
+        with self.assertRaises(TypeError):
+            x.larray = [1, 2, 3]
+        with self.assertRaises(TypeError):
+            x.larray = "[1, 2, 3]"
+
     def test_astype(self):
         data = ht.float32([[1, 2, 3], [4, 5, 6]])
 

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -171,6 +171,7 @@ class TestDNDarray(TestCase):
                 self.assertEqual(data_with_halos.shape, (12, 0))
 
     def test_larray(self):
+        # undistributed case
         x = ht.arange(6 * 7 * 8).reshape((6, 7, 8))
 
         self.assertTrue((x.larray == x.larray).all())
@@ -183,6 +184,31 @@ class TestDNDarray(TestCase):
         self.assertTrue(x.gshape, (42,))
         self.assertIsInstance(x.larray, torch.Tensor)
         self.assertEqual(x.larray.shape, x.lshape)
+
+        # Exceptions
+        with self.assertRaises(TypeError):
+            x.larray = ht.array([1, 2, 3])
+        with self.assertRaises(TypeError):
+            x.larray = np.array([1, 2, 3])
+        with self.assertRaises(TypeError):
+            x.larray = [1, 2, 3]
+        with self.assertRaises(TypeError):
+            x.larray = "[1, 2, 3]"
+
+        # distributed case
+        x = ht.arange(6 * 7 * 8, split=0).reshape((6, 7, 8))
+
+        self.assertTrue((x.larray == x.larray).all())
+        self.assertIsInstance(x.larray, torch.Tensor)
+        self.assertEqual(x.larray.shape, x.lshape)
+
+        x.larray = torch.arange(42)
+
+        self.assertTrue((x.larray == x.larray).all())
+        self.assertTrue(x.gshape, (42,))
+        self.assertIsInstance(x.larray, torch.Tensor)
+        self.assertEqual(x.larray.shape, x.lshape)
+        self.assertEqual(x.split, 0)
 
         # Exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -129,7 +129,7 @@ class TestDNDarray(TestCase):
             # exception on non balanced tensor
             with self.assertRaises(RuntimeError):
                 if data.comm.rank == 1:
-                    data._DNDarray__array = torch.empty(0)
+                    data.larray = torch.empty(0)
                 data.get_halo(1)
 
             # test no data on process
@@ -173,13 +173,13 @@ class TestDNDarray(TestCase):
     def test_larray(self):
         x = ht.arange(6 * 7 * 8).reshape((6, 7, 8))
 
-        self.assertTrue((x._DNDarray__array == x.larray).all())
+        self.assertTrue((x.larray == x.larray).all())
         self.assertIsInstance(x.larray, torch.Tensor)
         self.assertEqual(x.larray.shape, x.lshape)
 
         x.larray = torch.arange(42)
 
-        self.assertTrue((x._DNDarray__array == x.larray).all())
+        self.assertTrue((x.larray == x.larray).all())
         self.assertTrue(x.gshape, (42,))
         self.assertIsInstance(x.larray, torch.Tensor)
         self.assertEqual(x.larray.shape, x.lshape)
@@ -204,14 +204,14 @@ class TestDNDarray(TestCase):
         as_uint8 = data.astype(ht.uint8)
         self.assertIsInstance(as_uint8, ht.DNDarray)
         self.assertEqual(as_uint8.dtype, ht.uint8)
-        self.assertEqual(as_uint8._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(as_uint8.larray.dtype, torch.uint8)
         self.assertIsNot(as_uint8, data)
 
         # check the copy case for uint8
         as_float64 = data.astype(ht.float64, copy=False)
         self.assertIsInstance(as_float64, ht.DNDarray)
         self.assertEqual(as_float64.dtype, ht.float64)
-        self.assertEqual(as_float64._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(as_float64.larray.dtype, torch.float64)
         self.assertIs(as_float64, data)
 
     def test_balance_and_lshape_map(self):
@@ -491,19 +491,19 @@ class TestDNDarray(TestCase):
         # single set
         a = ht.zeros((13, 5), split=0)
         a.lloc[0, 0] = 1
-        self.assertEqual(a._DNDarray__array[0, 0], 1)
+        self.assertEqual(a.larray[0, 0], 1)
         self.assertEqual(a.lloc[0, 0].dtype, torch.float32)
 
         # multiple set
         a = ht.zeros((13, 5), split=0)
         a.lloc[1:3, 1] = 1
-        self.assertTrue(all(a._DNDarray__array[1:3, 1] == 1))
+        self.assertTrue(all(a.larray[1:3, 1] == 1))
         self.assertEqual(a.lloc[1:3, 1].dtype, torch.float32)
 
         # multiple set with specific indexing
         a = ht.zeros((13, 5), split=0)
         a.lloc[3:7:2, 2:5:2] = 1
-        self.assertTrue(torch.all(a._DNDarray__array[3:7:2, 2:5:2] == 1))
+        self.assertTrue(torch.all(a.larray[3:7:2, 2:5:2] == 1))
         self.assertEqual(a.lloc[3:7:2, 2:5:2].dtype, torch.float32)
 
     def test_lshift(self):
@@ -531,7 +531,7 @@ class TestDNDarray(TestCase):
         b = ht.array(a)
         self.assertIsInstance(b.numpy(), np.ndarray)
         self.assertEqual(b.numpy().shape, a.shape)
-        self.assertEqual(b.numpy().tolist(), b._DNDarray__array.cpu().numpy().tolist())
+        self.assertEqual(b.numpy().tolist(), b.larray.cpu().numpy().tolist())
 
         a = ht.ones((10, 8), dtype=ht.float32)
         b = np.ones((2, 2)).astype("float32")
@@ -682,11 +682,11 @@ class TestDNDarray(TestCase):
         local_shape = (1, N + 1, 2 * N)
         local_tensor = self.reference_tensor[ht.MPI_WORLD.rank, :, :]
         self.assertEqual(a_tensor.lshape, local_shape)
-        self.assertTrue((a_tensor._DNDarray__array == local_tensor._DNDarray__array).all())
+        self.assertTrue((a_tensor.larray == local_tensor.larray).all())
 
         # unsplit
         a_tensor.resplit_(axis=None)
-        self.assertTrue((a_tensor._DNDarray__array == self.reference_tensor._DNDarray__array).all())
+        self.assertTrue((a_tensor.larray == self.reference_tensor.larray).all())
 
         # split along axis = 1
         a_tensor.resplit_(axis=1)
@@ -700,11 +700,11 @@ class TestDNDarray(TestCase):
             ]
 
         self.assertEqual(a_tensor.lshape, local_shape)
-        self.assertTrue((a_tensor._DNDarray__array == local_tensor._DNDarray__array).all())
+        self.assertTrue((a_tensor.larray == local_tensor.larray).all())
 
         # unsplit
         a_tensor.resplit_(axis=None)
-        self.assertTrue((a_tensor._DNDarray__array == self.reference_tensor._DNDarray__array).all())
+        self.assertTrue((a_tensor.larray == self.reference_tensor.larray).all())
 
         # split along axis = 2
         a_tensor.resplit_(axis=2)
@@ -714,7 +714,7 @@ class TestDNDarray(TestCase):
         ]
 
         self.assertEqual(a_tensor.lshape, local_shape)
-        self.assertTrue((a_tensor._DNDarray__array == local_tensor._DNDarray__array).all())
+        self.assertTrue((a_tensor.larray == local_tensor.larray).all())
 
         expected = torch.ones(
             (ht.MPI_WORLD.size, 100), dtype=torch.int64, device=self.device.torch_device
@@ -722,11 +722,11 @@ class TestDNDarray(TestCase):
         data = ht.array(expected, split=1)
         data.resplit_(None)
 
-        self.assertTrue(torch.equal(data._DNDarray__array, expected))
+        self.assertTrue(torch.equal(data.larray, expected))
         self.assertFalse(data.is_distributed())
         self.assertIsNone(data.split)
         self.assertEqual(data.dtype, ht.int64)
-        self.assertEqual(data._DNDarray__array.dtype, expected.dtype)
+        self.assertEqual(data.larray.dtype, expected.dtype)
 
         expected = torch.zeros(
             (100, ht.MPI_WORLD.size), dtype=torch.uint8, device=self.device.torch_device
@@ -734,11 +734,11 @@ class TestDNDarray(TestCase):
         data = ht.array(expected, split=0)
         data.resplit_(None)
 
-        self.assertTrue(torch.equal(data._DNDarray__array, expected))
+        self.assertTrue(torch.equal(data.larray, expected))
         self.assertFalse(data.is_distributed())
         self.assertIsNone(data.split)
         self.assertEqual(data.dtype, ht.uint8)
-        self.assertEqual(data._DNDarray__array.dtype, expected.dtype)
+        self.assertEqual(data.larray.dtype, expected.dtype)
 
         # "in place"
         length = torch.tensor([i + 20 for i in range(2)], device=self.device.torch_device)
@@ -994,7 +994,7 @@ class TestDNDarray(TestCase):
         a[1, 0:4] = ht.arange(4)
         for c, i in enumerate(range(4)):
             b = a[1, c]
-            if b._DNDarray__array.numel() > 0:
+            if b.larray.numel() > 0:
                 self.assertEqual(b.item(), i)
 
         # setting with torch tensor

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -52,7 +52,7 @@ class TestExponential(TestCase):
         self.assertEqual(actual.split, 0)
         actual = actual.resplit_(None)
         self.assertEqual(actual.lshape, expected.shape)
-        self.assertTrue(torch.equal(expected, actual._DNDarray__array))
+        self.assertTrue(torch.equal(expected, actual.larray))
         self.assertEqual(actual.dtype, ht.float32)
 
     def test_expm1(self):
@@ -387,9 +387,9 @@ class TestExponential(TestCase):
         # check whether the output buffer still has the correct shape
         self.assertIsInstance(float32_sqrt, ht.DNDarray)
         self.assertEqual(float32_sqrt.dtype, ht.float32)
-        self.assertEqual(float32_sqrt._DNDarray__array.shape, output_shape)
+        self.assertEqual(float32_sqrt.larray.shape, output_shape)
         for row in range(output_shape[0]):
-            self.assertTrue((float32_sqrt._DNDarray__array[row] == comparison).all())
+            self.assertTrue((float32_sqrt.larray[row] == comparison).all())
 
         # exception
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -12,7 +12,7 @@ class TestFactories(TestCase):
         self.assertEqual(one_arg_arange_int.shape, (10,))
         self.assertLessEqual(one_arg_arange_int.lshape[0], 10)
         self.assertEqual(one_arg_arange_int.dtype, ht.int32)
-        self.assertEqual(one_arg_arange_int._DNDarray__array.dtype, torch.int32)
+        self.assertEqual(one_arg_arange_int.larray.dtype, torch.int32)
         self.assertEqual(one_arg_arange_int.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(one_arg_arange_int.sum(), 45)
@@ -23,7 +23,7 @@ class TestFactories(TestCase):
         self.assertEqual(one_arg_arange_float.shape, (10,))
         self.assertLessEqual(one_arg_arange_float.lshape[0], 10)
         self.assertEqual(one_arg_arange_float.dtype, ht.float32)
-        self.assertEqual(one_arg_arange_float._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(one_arg_arange_float.larray.dtype, torch.float32)
         self.assertEqual(one_arg_arange_float.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(one_arg_arange_float.sum(), 45.0)
@@ -34,7 +34,7 @@ class TestFactories(TestCase):
         self.assertEqual(two_arg_arange_int.shape, (10,))
         self.assertLessEqual(two_arg_arange_int.lshape[0], 10)
         self.assertEqual(two_arg_arange_int.dtype, ht.int32)
-        self.assertEqual(two_arg_arange_int._DNDarray__array.dtype, torch.int32)
+        self.assertEqual(two_arg_arange_int.larray.dtype, torch.int32)
         self.assertEqual(two_arg_arange_int.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(two_arg_arange_int.sum(), 45)
@@ -45,7 +45,7 @@ class TestFactories(TestCase):
         self.assertEqual(two_arg_arange_float.shape, (10,))
         self.assertLessEqual(two_arg_arange_float.lshape[0], 10)
         self.assertEqual(two_arg_arange_float.dtype, ht.float32)
-        self.assertEqual(two_arg_arange_float._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(two_arg_arange_float.larray.dtype, torch.float32)
         self.assertEqual(two_arg_arange_float.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(two_arg_arange_float.sum(), 45.0)
@@ -56,7 +56,7 @@ class TestFactories(TestCase):
         self.assertEqual(three_arg_arange_int.shape, (5,))
         self.assertLessEqual(three_arg_arange_int.lshape[0], 5)
         self.assertEqual(three_arg_arange_int.dtype, ht.int32)
-        self.assertEqual(three_arg_arange_int._DNDarray__array.dtype, torch.int32)
+        self.assertEqual(three_arg_arange_int.larray.dtype, torch.int32)
         self.assertEqual(three_arg_arange_int.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(three_arg_arange_int.sum(), 20)
@@ -67,7 +67,7 @@ class TestFactories(TestCase):
         self.assertEqual(three_arg_arange_float.shape, (5,))
         self.assertLessEqual(three_arg_arange_float.lshape[0], 5)
         self.assertEqual(three_arg_arange_float.dtype, ht.float32)
-        self.assertEqual(three_arg_arange_float._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(three_arg_arange_float.larray.dtype, torch.float32)
         self.assertEqual(three_arg_arange_float.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(three_arg_arange_float.sum(), 20.0)
@@ -78,7 +78,7 @@ class TestFactories(TestCase):
         self.assertEqual(three_arg_arange_dtype_float32.shape, (5,))
         self.assertLessEqual(three_arg_arange_dtype_float32.lshape[0], 5)
         self.assertEqual(three_arg_arange_dtype_float32.dtype, ht.float32)
-        self.assertEqual(three_arg_arange_dtype_float32._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(three_arg_arange_dtype_float32.larray.dtype, torch.float32)
         self.assertEqual(three_arg_arange_dtype_float32.split, 0)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(three_arg_arange_dtype_float32.sum(axis=0, keepdim=True), 20.0)
@@ -89,7 +89,7 @@ class TestFactories(TestCase):
         self.assertEqual(three_arg_arange_dtype_short.shape, (5,))
         self.assertLessEqual(three_arg_arange_dtype_short.lshape[0], 5)
         self.assertEqual(three_arg_arange_dtype_short.dtype, ht.int16)
-        self.assertEqual(three_arg_arange_dtype_short._DNDarray__array.dtype, torch.int16)
+        self.assertEqual(three_arg_arange_dtype_short.larray.dtype, torch.int16)
         self.assertEqual(three_arg_arange_dtype_short.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(three_arg_arange_dtype_short.sum(axis=0, keepdim=True), 20)
@@ -100,7 +100,7 @@ class TestFactories(TestCase):
         self.assertEqual(three_arg_arange_dtype_float64.shape, (5,))
         self.assertLessEqual(three_arg_arange_dtype_float64.lshape[0], 5)
         self.assertEqual(three_arg_arange_dtype_float64.dtype, ht.float64)
-        self.assertEqual(three_arg_arange_dtype_float64._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(three_arg_arange_dtype_float64.larray.dtype, torch.float64)
         self.assertEqual(three_arg_arange_dtype_float64.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(three_arg_arange_dtype_float64.sum(axis=0, keepdim=True), 20.0)
@@ -123,9 +123,7 @@ class TestFactories(TestCase):
         self.assertEqual(a.gshape, (2, 3))
         self.assertEqual(a.split, None)
         self.assertTrue(
-            (
-                a._DNDarray__array == torch.tensor(unsplit_data, device=self.device.torch_device)
-            ).all()
+            (a.larray == torch.tensor(unsplit_data, device=self.device.torch_device)).all()
         )
 
         # basic array function, unsplit data, different datatype
@@ -133,13 +131,13 @@ class TestFactories(TestCase):
         b = ht.array(tuple_data, dtype=ht.int8)
         self.assertIsInstance(b, ht.DNDarray)
         self.assertEqual(b.dtype, ht.int8)
-        self.assertEqual(b._DNDarray__array.dtype, torch.int8)
+        self.assertEqual(b.larray.dtype, torch.int8)
         self.assertEqual(b.lshape, (2, 2))
         self.assertEqual(b.gshape, (2, 2))
         self.assertEqual(b.split, None)
         self.assertTrue(
             (
-                b._DNDarray__array
+                b.larray
                 == torch.tensor(tuple_data, dtype=torch.int8, device=self.device.torch_device)
             ).all()
         )
@@ -152,8 +150,8 @@ class TestFactories(TestCase):
         self.assertEqual(c.lshape, (6,))
         self.assertEqual(c.gshape, (6,))
         self.assertEqual(c.split, None)
-        self.assertIs(c._DNDarray__array, torch_tensor)
-        self.assertTrue((c._DNDarray__array == torch_tensor).all())
+        self.assertIs(c.larray, torch_tensor)
+        self.assertTrue((c.larray == torch_tensor).all())
 
         # basic array function, unsplit data, additional dimensions
         vector_data = [4.0, 5.0, 6.0]
@@ -165,7 +163,7 @@ class TestFactories(TestCase):
         self.assertEqual(d.split, None)
         self.assertTrue(
             (
-                d._DNDarray__array
+                d.larray
                 == torch.tensor(vector_data, device=self.device.torch_device).reshape(-1, 1, 1)
             ).all()
         )
@@ -180,7 +178,7 @@ class TestFactories(TestCase):
         self.assertEqual(d.split, None)
         self.assertTrue(
             (
-                d._DNDarray__array
+                d.larray
                 == torch.tensor(vector_data, device=self.device.torch_device).reshape(1, 1, -1)
             ).all()
         )
@@ -196,8 +194,7 @@ class TestFactories(TestCase):
         self.assertEqual(tensor_2d.split, 0)
         self.assertTrue(
             (
-                tensor_2d._DNDarray__array
-                == torch.tensor([1.0, 2.0, 3.0], device=self.device.torch_device)
+                tensor_2d.larray == torch.tensor([1.0, 2.0, 3.0], device=self.device.torch_device)
             ).all()
         )
 
@@ -410,14 +407,14 @@ class TestFactories(TestCase):
         self.assertEqual(eye.shape, (shape, shape))
         self.assertEqual(eye.split, 1)
 
-        offset_x, offset_y = get_offset(eye._DNDarray__array)
+        offset_x, offset_y = get_offset(eye.larray)
         self.assertGreaterEqual(offset_x, 0)
         self.assertGreaterEqual(offset_y, 0)
-        x, y = eye._DNDarray__array.shape
+        x, y = eye.larray.shape
         for i in range(x):
             for j in range(y):
                 expected = 1 if i - offset_x is j - offset_y else 0
-                self.assertEqual(eye._DNDarray__array[i][j], expected)
+                self.assertEqual(eye.larray[i][j], expected)
 
         shape = (10, 20)
         eye = ht.eye(shape, dtype=ht.float32)
@@ -426,14 +423,14 @@ class TestFactories(TestCase):
         self.assertEqual(eye.shape, shape)
         self.assertEqual(eye.split, None)
 
-        offset_x, offset_y = get_offset(eye._DNDarray__array)
+        offset_x, offset_y = get_offset(eye.larray)
         self.assertGreaterEqual(offset_x, 0)
         self.assertGreaterEqual(offset_y, 0)
-        x, y = eye._DNDarray__array.shape
+        x, y = eye.larray.shape
         for i in range(x):
             for j in range(y):
                 expected = 1.0 if i - offset_x is j - offset_y else 0.0
-                self.assertEqual(eye._DNDarray__array[i][j], expected)
+                self.assertEqual(eye.larray[i][j], expected)
 
         shape = (10,)
         eye = ht.eye(shape, dtype=ht.int32, split=0)
@@ -442,14 +439,14 @@ class TestFactories(TestCase):
         self.assertEqual(eye.shape, shape * 2)
         self.assertEqual(eye.split, 0)
 
-        offset_x, offset_y = get_offset(eye._DNDarray__array)
+        offset_x, offset_y = get_offset(eye.larray)
         self.assertGreaterEqual(offset_x, 0)
         self.assertGreaterEqual(offset_y, 0)
-        x, y = eye._DNDarray__array.shape
+        x, y = eye.larray.shape
         for i in range(x):
             for j in range(y):
                 expected = 1 if i - offset_x is j - offset_y else 0
-                self.assertEqual(eye._DNDarray__array[i][j], expected)
+                self.assertEqual(eye.larray[i][j], expected)
 
         shape = (11, 30)
         eye = ht.eye(shape, split=1, dtype=ht.float32)
@@ -465,7 +462,7 @@ class TestFactories(TestCase):
         self.assertEqual(data.shape, (10, 2))
         self.assertEqual(data.lshape, (10, 2))
         self.assertEqual(data.dtype, ht.float32)
-        self.assertEqual(data._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(data.larray.dtype, torch.float32)
         self.assertEqual(data.split, None)
         self.assertTrue(ht.allclose(data, ht.float32(4.0)))
 
@@ -475,7 +472,7 @@ class TestFactories(TestCase):
         self.assertEqual(data.shape, (10, 2))
         self.assertEqual(data.lshape, (10, 2))
         self.assertEqual(data.dtype, ht.int32)
-        self.assertEqual(data._DNDarray__array.dtype, torch.int32)
+        self.assertEqual(data.larray.dtype, torch.int32)
         self.assertEqual(data.split, None)
         self.assertTrue(ht.allclose(data, ht.int32(4)))
 
@@ -486,7 +483,7 @@ class TestFactories(TestCase):
         self.assertLessEqual(data.lshape[0], 10)
         self.assertEqual(data.lshape[1], 2)
         self.assertEqual(data.dtype, ht.float32)
-        self.assertEqual(data._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(data.larray.dtype, torch.float32)
         self.assertEqual(data.split, 0)
         self.assertTrue(ht.allclose(data, ht.float32(4.0)))
 
@@ -551,7 +548,7 @@ class TestFactories(TestCase):
         self.assertEqual(ascending.shape, (50,))
         self.assertLessEqual(ascending.lshape[0], 50)
         self.assertEqual(ascending.dtype, ht.float32)
-        self.assertEqual(ascending._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(ascending.larray.dtype, torch.float32)
         self.assertEqual(ascending.split, None)
 
         # simple inverse linear space
@@ -560,7 +557,7 @@ class TestFactories(TestCase):
         self.assertEqual(descending.shape, (100,))
         self.assertLessEqual(descending.lshape[0], 100)
         self.assertEqual(descending.dtype, ht.float32)
-        self.assertEqual(descending._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(descending.larray.dtype, torch.float32)
         self.assertEqual(descending.split, None)
 
         # split linear space
@@ -569,7 +566,7 @@ class TestFactories(TestCase):
         self.assertEqual(split.shape, (70,))
         self.assertLessEqual(split.lshape[0], 70)
         self.assertEqual(split.dtype, ht.float32)
-        self.assertEqual(split._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(split.larray.dtype, torch.float32)
         self.assertEqual(split.split, 0)
 
         # with casted type
@@ -578,7 +575,7 @@ class TestFactories(TestCase):
         self.assertEqual(casted.shape, (70,))
         self.assertLessEqual(casted.lshape[0], 70)
         self.assertEqual(casted.dtype, ht.uint8)
-        self.assertEqual(casted._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(casted.larray.dtype, torch.uint8)
         self.assertEqual(casted.split, 0)
 
         # retstep test
@@ -590,7 +587,7 @@ class TestFactories(TestCase):
         self.assertEqual(result[0].shape, (70,))
         self.assertLessEqual(result[0].lshape[0], 70)
         self.assertEqual(result[0].dtype, ht.uint8)
-        self.assertEqual(result[0]._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(result[0].larray.dtype, torch.uint8)
         self.assertEqual(result[0].split, 0)
 
         self.assertIsInstance(result[1], float)
@@ -611,7 +608,7 @@ class TestFactories(TestCase):
         self.assertEqual(ascending.shape, (50,))
         self.assertLessEqual(ascending.lshape[0], 50)
         self.assertEqual(ascending.dtype, ht.float32)
-        self.assertEqual(ascending._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(ascending.larray.dtype, torch.float32)
         self.assertEqual(ascending.split, None)
 
         # simple inverse log space
@@ -620,7 +617,7 @@ class TestFactories(TestCase):
         self.assertEqual(descending.shape, (100,))
         self.assertLessEqual(descending.lshape[0], 100)
         self.assertEqual(descending.dtype, ht.float32)
-        self.assertEqual(descending._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(descending.larray.dtype, torch.float32)
         self.assertEqual(descending.split, None)
 
         # split log space
@@ -629,7 +626,7 @@ class TestFactories(TestCase):
         self.assertEqual(split.shape, (70,))
         self.assertLessEqual(split.lshape[0], 70)
         self.assertEqual(split.dtype, ht.float32)
-        self.assertEqual(split._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(split.larray.dtype, torch.float32)
         self.assertEqual(split.split, 0)
 
         # with casted type
@@ -638,7 +635,7 @@ class TestFactories(TestCase):
         self.assertEqual(casted.shape, (70,))
         self.assertLessEqual(casted.lshape[0], 70)
         self.assertEqual(casted.dtype, ht.uint8)
-        self.assertEqual(casted._DNDarray__array.dtype, torch.uint8)
+        self.assertEqual(casted.larray.dtype, torch.uint8)
         self.assertEqual(casted.split, 0)
 
         # base test
@@ -647,7 +644,7 @@ class TestFactories(TestCase):
         self.assertEqual(base.shape, (70,))
         self.assertLessEqual(base.lshape[0], 70)
         self.assertEqual(base.dtype, ht.float32)
-        self.assertEqual(base._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(base.larray.dtype, torch.float32)
         self.assertEqual(base.split, None)
 
         # exceptions
@@ -666,7 +663,7 @@ class TestFactories(TestCase):
         self.assertEqual(simple_ones_float.lshape, (3,))
         self.assertEqual(simple_ones_float.split, None)
         self.assertEqual(simple_ones_float.dtype, ht.float32)
-        self.assertEqual((simple_ones_float._DNDarray__array == 1).all().item(), 1)
+        self.assertEqual((simple_ones_float.larray == 1).all().item(), 1)
 
         # different data type
         simple_ones_uint = ht.ones(5, dtype=ht.bool)
@@ -675,7 +672,7 @@ class TestFactories(TestCase):
         self.assertEqual(simple_ones_uint.lshape, (5,))
         self.assertEqual(simple_ones_uint.split, None)
         self.assertEqual(simple_ones_uint.dtype, ht.bool)
-        self.assertEqual((simple_ones_uint._DNDarray__array == 1).all().item(), 1)
+        self.assertEqual((simple_ones_uint.larray == 1).all().item(), 1)
 
         # multi-dimensional
         elaborate_ones_int = ht.ones((2, 3), dtype=ht.int32)
@@ -684,7 +681,7 @@ class TestFactories(TestCase):
         self.assertEqual(elaborate_ones_int.lshape, (2, 3))
         self.assertEqual(elaborate_ones_int.split, None)
         self.assertEqual(elaborate_ones_int.dtype, ht.int32)
-        self.assertEqual((elaborate_ones_int._DNDarray__array == 1).all().item(), 1)
+        self.assertEqual((elaborate_ones_int.larray == 1).all().item(), 1)
 
         # split axis
         elaborate_ones_split = ht.ones((6, 4), dtype=ht.int32, split=0)
@@ -694,7 +691,7 @@ class TestFactories(TestCase):
         self.assertEqual(elaborate_ones_split.lshape[1], 4)
         self.assertEqual(elaborate_ones_split.split, 0)
         self.assertEqual(elaborate_ones_split.dtype, ht.int32)
-        self.assertEqual((elaborate_ones_split._DNDarray__array == 1).all().item(), 1)
+        self.assertEqual((elaborate_ones_split.larray == 1).all().item(), 1)
 
         # exceptions
         with self.assertRaises(TypeError):
@@ -712,7 +709,7 @@ class TestFactories(TestCase):
         self.assertEqual(like_int.lshape, (1,))
         self.assertEqual(like_int.split, None)
         self.assertEqual(like_int.dtype, ht.int32)
-        self.assertEqual((like_int._DNDarray__array == 1).all().item(), 1)
+        self.assertEqual((like_int.larray == 1).all().item(), 1)
 
         # sequence
         like_str = ht.ones_like("abc")
@@ -721,7 +718,7 @@ class TestFactories(TestCase):
         self.assertEqual(like_str.lshape, (3,))
         self.assertEqual(like_str.split, None)
         self.assertEqual(like_str.dtype, ht.float32)
-        self.assertEqual((like_str._DNDarray__array == 1).all().item(), 1)
+        self.assertEqual((like_str.larray == 1).all().item(), 1)
 
         # elaborate tensor
         zeros = ht.zeros((2, 3), dtype=ht.uint8)
@@ -731,7 +728,7 @@ class TestFactories(TestCase):
         self.assertEqual(like_zeros.lshape, (2, 3))
         self.assertEqual(like_zeros.split, None)
         self.assertEqual(like_zeros.dtype, ht.uint8)
-        self.assertEqual((like_zeros._DNDarray__array == 1).all().item(), 1)
+        self.assertEqual((like_zeros.larray == 1).all().item(), 1)
 
         # elaborate tensor with split
         zeros_split = ht.zeros((2, 3), dtype=ht.uint8, split=0)
@@ -742,7 +739,7 @@ class TestFactories(TestCase):
         self.assertEqual(like_zeros_split.lshape[1], 3)
         self.assertEqual(like_zeros_split.split, 0)
         self.assertEqual(like_zeros_split.dtype, ht.uint8)
-        self.assertEqual((like_zeros_split._DNDarray__array == 1).all().item(), 1)
+        self.assertEqual((like_zeros_split.larray == 1).all().item(), 1)
 
         # exceptions
         with self.assertRaises(TypeError):
@@ -758,7 +755,7 @@ class TestFactories(TestCase):
         self.assertEqual(simple_zeros_float.lshape, (3,))
         self.assertEqual(simple_zeros_float.split, None)
         self.assertEqual(simple_zeros_float.dtype, ht.float32)
-        self.assertEqual((simple_zeros_float._DNDarray__array == 0).all().item(), 1)
+        self.assertEqual((simple_zeros_float.larray == 0).all().item(), 1)
 
         # different data type
         simple_zeros_uint = ht.zeros(5, dtype=ht.bool)
@@ -767,7 +764,7 @@ class TestFactories(TestCase):
         self.assertEqual(simple_zeros_uint.lshape, (5,))
         self.assertEqual(simple_zeros_uint.split, None)
         self.assertEqual(simple_zeros_uint.dtype, ht.bool)
-        self.assertEqual((simple_zeros_uint._DNDarray__array == 0).all().item(), 1)
+        self.assertEqual((simple_zeros_uint.larray == 0).all().item(), 1)
 
         # multi-dimensional
         elaborate_zeros_int = ht.zeros((2, 3), dtype=ht.int32)
@@ -776,7 +773,7 @@ class TestFactories(TestCase):
         self.assertEqual(elaborate_zeros_int.lshape, (2, 3))
         self.assertEqual(elaborate_zeros_int.split, None)
         self.assertEqual(elaborate_zeros_int.dtype, ht.int32)
-        self.assertEqual((elaborate_zeros_int._DNDarray__array == 0).all().item(), 1)
+        self.assertEqual((elaborate_zeros_int.larray == 0).all().item(), 1)
 
         # split axis
         elaborate_zeros_split = ht.zeros((6, 4), dtype=ht.int32, split=0)
@@ -786,7 +783,7 @@ class TestFactories(TestCase):
         self.assertEqual(elaborate_zeros_split.lshape[1], 4)
         self.assertEqual(elaborate_zeros_split.split, 0)
         self.assertEqual(elaborate_zeros_split.dtype, ht.int32)
-        self.assertEqual((elaborate_zeros_split._DNDarray__array == 0).all().item(), 1)
+        self.assertEqual((elaborate_zeros_split.larray == 0).all().item(), 1)
 
         # exceptions
         with self.assertRaises(TypeError):
@@ -804,7 +801,7 @@ class TestFactories(TestCase):
         self.assertEqual(like_int.lshape, (1,))
         self.assertEqual(like_int.split, None)
         self.assertEqual(like_int.dtype, ht.int32)
-        self.assertEqual((like_int._DNDarray__array == 0).all().item(), 1)
+        self.assertEqual((like_int.larray == 0).all().item(), 1)
 
         # sequence
         like_str = ht.zeros_like("abc")
@@ -813,7 +810,7 @@ class TestFactories(TestCase):
         self.assertEqual(like_str.lshape, (3,))
         self.assertEqual(like_str.split, None)
         self.assertEqual(like_str.dtype, ht.float32)
-        self.assertEqual((like_str._DNDarray__array == 0).all().item(), 1)
+        self.assertEqual((like_str.larray == 0).all().item(), 1)
 
         # elaborate tensor
         ones = ht.ones((2, 3), dtype=ht.uint8)
@@ -823,7 +820,7 @@ class TestFactories(TestCase):
         self.assertEqual(like_ones.lshape, (2, 3))
         self.assertEqual(like_ones.split, None)
         self.assertEqual(like_ones.dtype, ht.uint8)
-        self.assertEqual((like_ones._DNDarray__array == 0).all().item(), 1)
+        self.assertEqual((like_ones.larray == 0).all().item(), 1)
 
         # elaborate tensor with split
         ones_split = ht.ones((2, 3), dtype=ht.uint8, split=0)
@@ -834,7 +831,7 @@ class TestFactories(TestCase):
         self.assertEqual(like_ones_split.lshape[1], 3)
         self.assertEqual(like_ones_split.split, 0)
         self.assertEqual(like_ones_split.dtype, ht.uint8)
-        self.assertEqual((like_ones_split._DNDarray__array == 0).all().item(), 1)
+        self.assertEqual((like_ones_split.larray == 0).all().item(), 1)
 
         # exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -56,12 +56,12 @@ class TestIO(TestCase):
             self.assertIsInstance(iris, ht.DNDarray)
             # shape invariant
             self.assertEqual(iris.shape, self.IRIS.shape)
-            self.assertEqual(iris._DNDarray__array.shape, self.IRIS.shape)
+            self.assertEqual(iris.larray.shape, self.IRIS.shape)
             # data type
             self.assertEqual(iris.dtype, ht.float32)
-            self.assertEqual(iris._DNDarray__array.dtype, torch.float32)
+            self.assertEqual(iris.larray.dtype, torch.float32)
             # content
-            self.assertTrue((self.IRIS == iris._DNDarray__array).all())
+            self.assertTrue((self.IRIS == iris.larray).all())
         else:
             with self.assertRaises(ValueError):
                 _ = ht.load(self.HDF5_PATH, dataset=self.HDF5_DATASET)
@@ -72,12 +72,12 @@ class TestIO(TestCase):
             self.assertIsInstance(iris, ht.DNDarray)
             # shape invariant
             self.assertEqual(iris.shape, self.IRIS.shape)
-            self.assertEqual(iris._DNDarray__array.shape, self.IRIS.shape)
+            self.assertEqual(iris.larray.shape, self.IRIS.shape)
             # data type
             self.assertEqual(iris.dtype, ht.float32)
-            self.assertEqual(iris._DNDarray__array.dtype, torch.float32)
+            self.assertEqual(iris.larray.dtype, torch.float32)
             # content
-            self.assertTrue((self.IRIS == iris._DNDarray__array).all())
+            self.assertTrue((self.IRIS == iris.larray).all())
         else:
             with self.assertRaises(ValueError):
                 _ = ht.load(self.NETCDF_PATH, variable=self.NETCDF_VARIABLE)
@@ -95,8 +95,8 @@ class TestIO(TestCase):
         a = ht.load_csv(self.CSV_PATH, sep=";")
         self.assertEqual(len(a), csv_file_length)
         self.assertEqual(a.shape, (csv_file_length, csv_file_cols))
-        self.assertTrue(torch.equal(a._DNDarray__array[0], first_value))
-        self.assertTrue(torch.equal(a._DNDarray__array[9], tenth_value))
+        self.assertTrue(torch.equal(a.larray[0], first_value))
+        self.assertTrue(torch.equal(a.larray[9], tenth_value))
 
         a = ht.load_csv(self.CSV_PATH, sep=";", split=0)
         rank = a.comm.Get_rank()
@@ -108,7 +108,7 @@ class TestIO(TestCase):
         self.assertEqual(a.lshape, expected_lshape)
 
         if rank == 0:
-            self.assertTrue(torch.equal(a._DNDarray__array[0], first_value))
+            self.assertTrue(torch.equal(a.larray[0], first_value))
 
         a = ht.load_csv(self.CSV_PATH, sep=";", header_lines=9, dtype=ht.float32, split=0)
         expected_gshape = (csv_file_length - 9, csv_file_cols)
@@ -119,7 +119,7 @@ class TestIO(TestCase):
         self.assertEqual(a.lshape, expected_lshape)
         self.assertEqual(a.dtype, ht.float32)
         if rank == 0:
-            self.assertTrue(torch.equal(a._DNDarray__array[0], tenth_value))
+            self.assertTrue(torch.equal(a.larray[0], tenth_value))
 
         a = ht.load_csv(self.CSV_PATH, sep=";", split=1)
         self.assertEqual(a.shape, (csv_file_length, csv_file_cols))
@@ -175,7 +175,7 @@ class TestIO(TestCase):
                         dtype=torch.int32,
                         device=self.device.torch_device,
                     )
-                self.assertTrue((local_range._DNDarray__array == comparison).all())
+                self.assertTrue((local_range.larray == comparison).all())
 
             # split range
             split_range = ht.arange(100, split=0)
@@ -187,7 +187,7 @@ class TestIO(TestCase):
                         dtype=torch.int32,
                         device=self.device.torch_device,
                     )
-                self.assertTrue((local_range._DNDarray__array == comparison).all())
+                self.assertTrue((local_range.larray == comparison).all())
 
         if ht.io.supports_netcdf():
             # local range
@@ -200,7 +200,7 @@ class TestIO(TestCase):
                         dtype=torch.int32,
                         device=self.device.torch_device,
                     )
-                self.assertTrue((local_range._DNDarray__array == comparison).all())
+                self.assertTrue((local_range.larray == comparison).all())
 
             # split range
             split_range = ht.arange(100, split=0)
@@ -212,7 +212,7 @@ class TestIO(TestCase):
                         dtype=torch.int32,
                         device=self.device.torch_device,
                     )
-                self.assertTrue((local_range._DNDarray__array == comparison).all())
+                self.assertTrue((local_range.larray == comparison).all())
 
     def test_save_exception(self):
         data = ht.arange(1)
@@ -249,8 +249,8 @@ class TestIO(TestCase):
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.float32)
-        self.assertEqual(iris._DNDarray__array.dtype, torch.float32)
-        self.assertTrue((self.IRIS == iris._DNDarray__array).all())
+        self.assertEqual(iris.larray.dtype, torch.float32)
+        self.assertTrue((self.IRIS == iris.larray).all())
 
         # positive split axis
         iris = ht.load_hdf5(self.HDF5_PATH, self.HDF5_DATASET, split=0)
@@ -275,7 +275,7 @@ class TestIO(TestCase):
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.int8)
-        self.assertEqual(iris._DNDarray__array.dtype, torch.int8)
+        self.assertEqual(iris.larray.dtype, torch.int8)
 
     def test_load_hdf5_exception(self):
         # HDF5 support is optional
@@ -309,7 +309,7 @@ class TestIO(TestCase):
                 comparison = torch.tensor(
                     handle[self.HDF5_DATASET], dtype=torch.int32, device=self.device.torch_device
                 )
-            self.assertTrue((local_data._DNDarray__array == comparison).all())
+            self.assertTrue((local_data.larray == comparison).all())
 
         # distributed data range
         split_data = ht.arange(100, split=0)
@@ -319,7 +319,7 @@ class TestIO(TestCase):
                 comparison = torch.tensor(
                     handle[self.HDF5_DATASET], dtype=torch.int32, device=self.device.torch_device
                 )
-            self.assertTrue((local_data._DNDarray__array == comparison).all())
+            self.assertTrue((local_data.larray == comparison).all())
 
     def test_save_hdf5_exception(self):
         # HDF5 support is optional
@@ -346,8 +346,8 @@ class TestIO(TestCase):
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.float32)
-        self.assertEqual(iris._DNDarray__array.dtype, torch.float32)
-        self.assertTrue((self.IRIS == iris._DNDarray__array).all())
+        self.assertEqual(iris.larray.dtype, torch.float32)
+        self.assertTrue((self.IRIS == iris.larray).all())
 
         # positive split axis
         iris = ht.load_netcdf(self.NETCDF_PATH, self.NETCDF_VARIABLE, split=0)
@@ -372,7 +372,7 @@ class TestIO(TestCase):
         self.assertIsInstance(iris, ht.DNDarray)
         self.assertEqual(iris.shape, self.IRIS.shape)
         self.assertEqual(iris.dtype, ht.int8)
-        self.assertEqual(iris._DNDarray__array.dtype, torch.int8)
+        self.assertEqual(iris.larray.dtype, torch.int8)
 
     def test_load_netcdf_exception(self):
         # netcdf support is optional
@@ -408,7 +408,7 @@ class TestIO(TestCase):
                     dtype=torch.int32,
                     device=self.device.torch_device,
                 )
-            self.assertTrue((local_data._DNDarray__array == comparison).all())
+            self.assertTrue((local_data.larray == comparison).all())
 
         # distributed data range
         split_data = ht.arange(100, split=0)
@@ -420,7 +420,7 @@ class TestIO(TestCase):
                     dtype=torch.int32,
                     device=self.device.torch_device,
                 )
-            self.assertTrue((local_data._DNDarray__array == comparison).all())
+            self.assertTrue((local_data.larray == comparison).all())
 
     def test_save_netcdf_exception(self):
         # netcdf support is optional

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -16,13 +16,13 @@ class TestLogical(TestCase):
         self.assertEqual(x.shape, (1,))
         self.assertEqual(x.lshape, (1,))
         self.assertEqual(x.dtype, ht.bool)
-        self.assertEqual(x._DNDarray__array.dtype, torch.bool)
+        self.assertEqual(x.larray.dtype, torch.bool)
         self.assertEqual(x.split, None)
-        self.assertEqual(x._DNDarray__array, 1)
+        self.assertEqual(x.larray, 1)
 
         out_noaxis = ht.zeros((1,))
         ht.all(ones_noaxis, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 1)
+        self.assertEqual(out_noaxis.larray, 1)
 
         # check all over all float elements of split 1d tensor
         ones_noaxis_split = ht.ones(array_len, split=0)
@@ -32,13 +32,13 @@ class TestLogical(TestCase):
         self.assertEqual(floats_is_one.shape, (1,))
         self.assertEqual(floats_is_one.lshape, (1,))
         self.assertEqual(floats_is_one.dtype, ht.bool)
-        self.assertEqual(floats_is_one._DNDarray__array.dtype, torch.bool)
+        self.assertEqual(floats_is_one.larray.dtype, torch.bool)
         self.assertEqual(floats_is_one.split, None)
-        self.assertEqual(floats_is_one._DNDarray__array, 1)
+        self.assertEqual(floats_is_one.larray, 1)
 
         out_noaxis = ht.zeros((1,))
         ht.all(ones_noaxis_split, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 1)
+        self.assertEqual(out_noaxis.larray, 1)
 
         # check all over all integer elements of 1d tensor locally
         ones_noaxis_int = ht.ones(array_len).astype(ht.int)
@@ -48,13 +48,13 @@ class TestLogical(TestCase):
         self.assertEqual(int_is_one.shape, (1,))
         self.assertEqual(int_is_one.lshape, (1,))
         self.assertEqual(int_is_one.dtype, ht.bool)
-        self.assertEqual(int_is_one._DNDarray__array.dtype, torch.bool)
+        self.assertEqual(int_is_one.larray.dtype, torch.bool)
         self.assertEqual(int_is_one.split, None)
-        self.assertEqual(int_is_one._DNDarray__array, 1)
+        self.assertEqual(int_is_one.larray, 1)
 
         out_noaxis = ht.zeros((1,))
         ht.all(ones_noaxis_int, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 1)
+        self.assertEqual(out_noaxis.larray, 1)
 
         # check all over all integer elements of split 1d tensor
         ones_noaxis_split_int = ht.ones(array_len, split=0).astype(ht.int)
@@ -64,13 +64,13 @@ class TestLogical(TestCase):
         self.assertEqual(split_int_is_one.shape, (1,))
         self.assertEqual(split_int_is_one.lshape, (1,))
         self.assertEqual(split_int_is_one.dtype, ht.bool)
-        self.assertEqual(split_int_is_one._DNDarray__array.dtype, torch.bool)
+        self.assertEqual(split_int_is_one.larray.dtype, torch.bool)
         self.assertEqual(split_int_is_one.split, None)
-        self.assertEqual(split_int_is_one._DNDarray__array, 1)
+        self.assertEqual(split_int_is_one.larray, 1)
 
         out_noaxis = ht.zeros((1,))
         ht.all(ones_noaxis_split_int, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 1)
+        self.assertEqual(out_noaxis.larray, 1)
 
         # check all over all float elements of 3d tensor locally
         ones_noaxis_volume = ht.ones((3, 3, 3))
@@ -80,13 +80,13 @@ class TestLogical(TestCase):
         self.assertEqual(volume_is_one.shape, (1,))
         self.assertEqual(volume_is_one.lshape, (1,))
         self.assertEqual(volume_is_one.dtype, ht.bool)
-        self.assertEqual(volume_is_one._DNDarray__array.dtype, torch.bool)
+        self.assertEqual(volume_is_one.larray.dtype, torch.bool)
         self.assertEqual(volume_is_one.split, None)
-        self.assertEqual(volume_is_one._DNDarray__array, 1)
+        self.assertEqual(volume_is_one.larray, 1)
 
         out_noaxis = ht.zeros((1,))
         ht.all(ones_noaxis_volume, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 1)
+        self.assertEqual(out_noaxis.larray, 1)
 
         # check sequence is not all one
         sequence = ht.arange(array_len)
@@ -96,13 +96,13 @@ class TestLogical(TestCase):
         self.assertEqual(sequence_is_one.shape, (1,))
         self.assertEqual(sequence_is_one.lshape, (1,))
         self.assertEqual(sequence_is_one.dtype, ht.bool)
-        self.assertEqual(sequence_is_one._DNDarray__array.dtype, torch.bool)
+        self.assertEqual(sequence_is_one.larray.dtype, torch.bool)
         self.assertEqual(sequence_is_one.split, None)
-        self.assertEqual(sequence_is_one._DNDarray__array, 0)
+        self.assertEqual(sequence_is_one.larray, 0)
 
         out_noaxis = ht.zeros((1,))
         ht.all(sequence, out=out_noaxis)
-        self.assertEqual(out_noaxis._DNDarray__array, 0)
+        self.assertEqual(out_noaxis.larray, 0)
 
         # check all over all float elements of split 3d tensor
         ones_noaxis_split_axis = ht.ones((3, 3, 3), split=0)
@@ -111,7 +111,7 @@ class TestLogical(TestCase):
         self.assertIsInstance(float_volume_is_one, ht.DNDarray)
         self.assertEqual(float_volume_is_one.shape, (3, 3))
         self.assertEqual(float_volume_is_one.all(axis=1).dtype, ht.bool)
-        self.assertEqual(float_volume_is_one._DNDarray__array.dtype, torch.bool)
+        self.assertEqual(float_volume_is_one.larray.dtype, torch.bool)
         self.assertEqual(float_volume_is_one.split, None)
 
         out_noaxis = ht.zeros((3, 3))
@@ -124,7 +124,7 @@ class TestLogical(TestCase):
         self.assertIsInstance(float_volume_is_one, ht.DNDarray)
         self.assertEqual(float_volume_is_one.shape, (3,))
         self.assertEqual(float_volume_is_one.all(axis=0).dtype, ht.bool)
-        self.assertEqual(float_volume_is_one._DNDarray__array.dtype, torch.bool)
+        self.assertEqual(float_volume_is_one.larray.dtype, torch.bool)
         self.assertEqual(float_volume_is_one.split, None)
 
         # check all over all float elements of split 5d tensor with negative axis
@@ -134,7 +134,7 @@ class TestLogical(TestCase):
         self.assertIsInstance(float_5d_is_one, ht.DNDarray)
         self.assertEqual(float_5d_is_one.shape, (1, 2, 3, 5))
         self.assertEqual(float_5d_is_one.dtype, ht.bool)
-        self.assertEqual(float_5d_is_one._DNDarray__array.dtype, torch.bool)
+        self.assertEqual(float_5d_is_one.larray.dtype, torch.bool)
         self.assertEqual(float_5d_is_one.split, 1)
 
         out_noaxis = ht.zeros((1, 2, 3, 5))

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -371,13 +371,13 @@ class TestManipulations(TestCase):
         data = torch.arange(size * 2, device=self.device.torch_device)
         a = ht.array(data)
         res = ht.diag(a)
-        self.assertTrue(torch.equal(res._DNDarray__array, torch.diag(data)))
+        self.assertTrue(torch.equal(res.larray, torch.diag(data)))
 
         res = ht.diag(a, offset=size)
-        self.assertTrue(torch.equal(res._DNDarray__array, torch.diag(data, diagonal=size)))
+        self.assertTrue(torch.equal(res.larray, torch.diag(data, diagonal=size)))
 
         res = ht.diag(a, offset=-size)
-        self.assertTrue(torch.equal(res._DNDarray__array, torch.diag(data, diagonal=-size)))
+        self.assertTrue(torch.equal(res.larray, torch.diag(data, diagonal=-size)))
 
         a = ht.array(data, split=0)
         res = ht.diag(a)
@@ -386,7 +386,7 @@ class TestManipulations(TestCase):
         self.assertEqual(res.lshape[res.split], 2)
         exp = torch.diag(data)
         for i in range(rank * 2, (rank + 1) * 2):
-            self.assertTrue(torch.equal(res[i, i]._DNDarray__array, exp[i, i]))
+            self.assertTrue(torch.equal(res[i, i].larray, exp[i, i]))
 
         res = ht.diag(a, offset=size)
         self.assertEqual(res.split, a.split)
@@ -394,7 +394,7 @@ class TestManipulations(TestCase):
         self.assertEqual(res.lshape[res.split], 3)
         exp = torch.diag(data, diagonal=size)
         for i in range(rank * 3, min((rank + 1) * 3, a.shape[0])):
-            self.assertTrue(torch.equal(res[i, i + size]._DNDarray__array, exp[i, i + size]))
+            self.assertTrue(torch.equal(res[i, i + size].larray, exp[i, i + size]))
 
         res = ht.diag(a, offset=-size)
         self.assertEqual(res.split, a.split)
@@ -402,7 +402,7 @@ class TestManipulations(TestCase):
         self.assertEqual(res.lshape[res.split], 3)
         exp = torch.diag(data, diagonal=-size)
         for i in range(max(size, rank * 3), (rank + 1) * 3):
-            self.assertTrue(torch.equal(res[i, i - size]._DNDarray__array, exp[i, i - size]))
+            self.assertTrue(torch.equal(res[i, i - size].larray, exp[i, i - size]))
 
         self.assertTrue(ht.equal(ht.diag(ht.diag(a)), a))
 
@@ -433,7 +433,7 @@ class TestManipulations(TestCase):
         res = ht.diag(a)
         self.assertTrue(
             torch.equal(
-                res[rank, rank]._DNDarray__array,
+                res[rank, rank].larray,
                 torch.tensor(1, dtype=torch.int32, device=self.device.torch_device),
             )
         )
@@ -462,14 +462,14 @@ class TestManipulations(TestCase):
         a = ht.array(data)
         res = ht.diagonal(a)
         self.assertTrue(
-            torch.equal(res._DNDarray__array, torch.arange(size, device=self.device.torch_device))
+            torch.equal(res.larray, torch.arange(size, device=self.device.torch_device))
         )
         self.assertEqual(res.split, None)
 
         a = ht.array(data, split=0)
         res = ht.diagonal(a)
         self.assertTrue(
-            torch.equal(res._DNDarray__array, torch.tensor([rank], device=self.device.torch_device))
+            torch.equal(res.larray, torch.tensor([rank], device=self.device.torch_device))
         )
         self.assertEqual(res.split, 0)
 
@@ -479,7 +479,7 @@ class TestManipulations(TestCase):
 
         res = ht.diagonal(a)
         self.assertTrue(
-            torch.equal(res._DNDarray__array, torch.tensor([rank], device=self.device.torch_device))
+            torch.equal(res.larray, torch.tensor([rank], device=self.device.torch_device))
         )
         self.assertEqual(res.split, 0)
 
@@ -495,49 +495,39 @@ class TestManipulations(TestCase):
         a = ht.array(data)
         res = ht.diagonal(a, offset=0)
         self.assertTrue(
-            torch.equal(
-                res._DNDarray__array, torch.arange(size + 1, device=self.device.torch_device)
-            )
+            torch.equal(res.larray, torch.arange(size + 1, device=self.device.torch_device))
         )
         res = ht.diagonal(a, offset=1)
         self.assertTrue(
-            torch.equal(
-                res._DNDarray__array, torch.arange(1, size + 1, device=self.device.torch_device)
-            )
+            torch.equal(res.larray, torch.arange(1, size + 1, device=self.device.torch_device))
         )
         res = ht.diagonal(a, offset=-1)
         self.assertTrue(
-            torch.equal(
-                res._DNDarray__array, torch.arange(0, size, device=self.device.torch_device)
-            )
+            torch.equal(res.larray, torch.arange(0, size, device=self.device.torch_device))
         )
 
         a = ht.array(data, split=0)
         res = ht.diagonal(a, offset=1)
         res.balance_()
         self.assertTrue(
-            torch.equal(
-                res._DNDarray__array, torch.tensor([rank + 1], device=self.device.torch_device)
-            )
+            torch.equal(res.larray, torch.tensor([rank + 1], device=self.device.torch_device))
         )
         res = ht.diagonal(a, offset=-1)
         res.balance_()
         self.assertTrue(
-            torch.equal(res._DNDarray__array, torch.tensor([rank], device=self.device.torch_device))
+            torch.equal(res.larray, torch.tensor([rank], device=self.device.torch_device))
         )
 
         a = ht.array(data, split=1)
         res = ht.diagonal(a, offset=1)
         res.balance_()
         self.assertTrue(
-            torch.equal(
-                res._DNDarray__array, torch.tensor([rank + 1], device=self.device.torch_device)
-            )
+            torch.equal(res.larray, torch.tensor([rank + 1], device=self.device.torch_device))
         )
         res = ht.diagonal(a, offset=-1)
         res.balance_()
         self.assertTrue(
-            torch.equal(res._DNDarray__array, torch.tensor([rank], device=self.device.torch_device))
+            torch.equal(res.larray, torch.tensor([rank], device=self.device.torch_device))
         )
 
         data = (
@@ -549,15 +539,12 @@ class TestManipulations(TestCase):
         res = ht.diagonal(a, offset=10)
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
-                torch.arange(10, 10 + size * 2, device=self.device.torch_device),
+                res.larray, torch.arange(10, 10 + size * 2, device=self.device.torch_device)
             )
         )
         res = ht.diagonal(a, offset=-10)
         self.assertTrue(
-            torch.equal(
-                res._DNDarray__array, torch.arange(0, size * 2, device=self.device.torch_device)
-            )
+            torch.equal(res.larray, torch.arange(0, size * 2, device=self.device.torch_device))
         )
 
         a = ht.array(data, split=0)
@@ -565,7 +552,7 @@ class TestManipulations(TestCase):
         res.balance_()
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.tensor([10 + rank * 2, 11 + rank * 2], device=self.device.torch_device),
             )
         )
@@ -573,8 +560,7 @@ class TestManipulations(TestCase):
         res.balance_()
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
-                torch.tensor([rank * 2, 1 + rank * 2], device=self.device.torch_device),
+                res.larray, torch.tensor([rank * 2, 1 + rank * 2], device=self.device.torch_device)
             )
         )
 
@@ -583,7 +569,7 @@ class TestManipulations(TestCase):
         res.balance_()
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.tensor([10 + rank * 2, 11 + rank * 2], device=self.device.torch_device),
             )
         )
@@ -591,8 +577,7 @@ class TestManipulations(TestCase):
         res.balance_()
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
-                torch.tensor([rank * 2, 1 + rank * 2], device=self.device.torch_device),
+                res.larray, torch.tensor([rank * 2, 1 + rank * 2], device=self.device.torch_device)
             )
         )
 
@@ -605,7 +590,7 @@ class TestManipulations(TestCase):
         res = ht.diagonal(a)
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.arange(size + 1, device=self.device.torch_device)
                 .repeat(size + 1)
                 .reshape(size + 1, size + 1)
@@ -615,7 +600,7 @@ class TestManipulations(TestCase):
         res = ht.diagonal(a, offset=1)
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.arange(size + 1, device=self.device.torch_device)
                 .repeat(size)
                 .reshape(size, size + 1)
@@ -625,7 +610,7 @@ class TestManipulations(TestCase):
         res = ht.diagonal(a, offset=-1)
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.arange(size + 1, device=self.device.torch_device)
                 .repeat(size)
                 .reshape(size, size + 1)
@@ -636,7 +621,7 @@ class TestManipulations(TestCase):
         res = ht.diagonal(a, dim1=1, dim2=2)
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.arange(size + 1, device=self.device.torch_device)
                 .repeat(size + 1)
                 .reshape(size + 1, size + 1),
@@ -645,7 +630,7 @@ class TestManipulations(TestCase):
         res = ht.diagonal(a, offset=1, dim1=1, dim2=2)
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.arange(1, size + 1, device=self.device.torch_device)
                 .repeat(size + 1)
                 .reshape(size + 1, size),
@@ -654,7 +639,7 @@ class TestManipulations(TestCase):
         res = ht.diagonal(a, offset=-1, dim1=1, dim2=2)
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.arange(size, device=self.device.torch_device)
                 .repeat(size + 1)
                 .reshape(size + 1, size),
@@ -664,7 +649,7 @@ class TestManipulations(TestCase):
         res = ht.diagonal(a, dim1=0, dim2=2)
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.arange(size + 1, device=self.device.torch_device)
                 .repeat(size + 1)
                 .reshape(size + 1, size + 1),
@@ -676,7 +661,7 @@ class TestManipulations(TestCase):
         res.balance_()
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.arange(size + 1, device=self.device.torch_device).reshape(size + 1, 1),
             )
         )
@@ -686,7 +671,7 @@ class TestManipulations(TestCase):
         res.balance_()
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.arange(size + 1, device=self.device.torch_device).reshape(size + 1, 1),
             )
         )
@@ -696,7 +681,7 @@ class TestManipulations(TestCase):
         res.balance_()
         self.assertTrue(
             torch.equal(
-                res._DNDarray__array,
+                res.larray,
                 torch.empty((size + 1, 0), dtype=torch.int64, device=self.device.torch_device),
             )
         )
@@ -1549,21 +1534,21 @@ class TestManipulations(TestCase):
         data = ht.array(tensor, split=None)
         result, result_indices = ht.sort(data, axis=0, descending=True)
         expected, exp_indices = torch.sort(tensor, dim=0, descending=True)
-        self.assertTrue(torch.equal(result._DNDarray__array, expected))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices.int()))
+        self.assertTrue(torch.equal(result.larray, expected))
+        self.assertTrue(torch.equal(result_indices.larray, exp_indices.int()))
 
         result, result_indices = ht.sort(data, axis=1, descending=True)
         expected, exp_indices = torch.sort(tensor, dim=1, descending=True)
-        self.assertTrue(torch.equal(result._DNDarray__array, expected))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices.int()))
+        self.assertTrue(torch.equal(result.larray, expected))
+        self.assertTrue(torch.equal(result_indices.larray, exp_indices.int()))
 
         data = ht.array(tensor, split=0)
 
         exp_axis_zero = torch.arange(size, device=self.device.torch_device).reshape(1, size)
         exp_indices = torch.tensor([[rank] * size], device=self.device.torch_device)
         result, result_indices = ht.sort(data, descending=True, axis=0)
-        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices.int()))
+        self.assertTrue(torch.equal(result.larray, exp_axis_zero))
+        self.assertTrue(torch.equal(result_indices.larray, exp_indices.int()))
 
         exp_axis_one, exp_indices = (
             torch.arange(size, device=self.device.torch_device)
@@ -1571,8 +1556,8 @@ class TestManipulations(TestCase):
             .sort(dim=1, descending=True)
         )
         result, result_indices = ht.sort(data, descending=True, axis=1)
-        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_indices.int()))
+        self.assertTrue(torch.equal(result.larray, exp_axis_one))
+        self.assertTrue(torch.equal(result_indices.larray, exp_indices.int()))
 
         result1 = ht.sort(data, axis=1, descending=True)
         result2 = ht.sort(data, descending=True)
@@ -1588,10 +1573,10 @@ class TestManipulations(TestCase):
             size, dtype=torch.int64, device=self.device.torch_device
         ).reshape(size, 1)
         result, result_indices = ht.sort(data, axis=0, descending=True)
-        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_zero))
+        self.assertTrue(torch.equal(result.larray, exp_axis_zero))
         # comparison value is only true on CPU
-        if result_indices._DNDarray__array.is_cuda is False:
-            self.assertTrue(torch.equal(result_indices._DNDarray__array, indices_axis_zero.int()))
+        if result_indices.larray.is_cuda is False:
+            self.assertTrue(torch.equal(result_indices.larray, indices_axis_zero.int()))
 
         exp_axis_one = (
             torch.tensor(size - rank - 1, device=self.device.torch_device)
@@ -1599,8 +1584,8 @@ class TestManipulations(TestCase):
             .reshape(size, 1)
         )
         result, result_indices = ht.sort(data, descending=True, axis=1)
-        self.assertTrue(torch.equal(result._DNDarray__array, exp_axis_one))
-        self.assertTrue(torch.equal(result_indices._DNDarray__array, exp_axis_one.int()))
+        self.assertTrue(torch.equal(result.larray, exp_axis_one))
+        self.assertTrue(torch.equal(result_indices.larray, exp_axis_one.int()))
 
         tensor = torch.tensor(
             [
@@ -1626,8 +1611,8 @@ class TestManipulations(TestCase):
                 [[0, 2, 2], [3, 0, 0]], dtype=torch.int32, device=self.device.torch_device
             )
         result, result_indices = ht.sort(data, axis=0)
-        first = result[0]._DNDarray__array
-        first_indices = result_indices[0]._DNDarray__array
+        first = result[0].larray
+        first_indices = result_indices[0].larray
         if rank == 0:
             self.assertTrue(torch.equal(first, exp_axis_zero))
             self.assertTrue(torch.equal(first_indices, indices_axis_zero))
@@ -1638,8 +1623,8 @@ class TestManipulations(TestCase):
             [[0, 1, 1]], dtype=torch.int32, device=self.device.torch_device
         )
         result, result_indices = ht.sort(data, axis=1)
-        first = result[0]._DNDarray__array[:1]
-        first_indices = result_indices[0]._DNDarray__array[:1]
+        first = result[0].larray[:1]
+        first_indices = result_indices[0].larray[:1]
         if rank == 0:
             self.assertTrue(torch.equal(first, exp_axis_one))
             self.assertTrue(torch.equal(first_indices, indices_axis_one))
@@ -1650,8 +1635,8 @@ class TestManipulations(TestCase):
             [[0], [1]], dtype=torch.int32, device=self.device.torch_device
         )
         result, result_indices = ht.sort(data, axis=2)
-        first = result[0]._DNDarray__array[:, :1]
-        first_indices = result_indices[0]._DNDarray__array[:, :1]
+        first = result[0].larray[:, :1]
+        first_indices = result_indices[0].larray[:, :1]
         if rank == 0:
             self.assertTrue(torch.equal(first, exp_axis_two))
             self.assertTrue(torch.equal(first_indices, indices_axis_two))
@@ -1674,11 +1659,7 @@ class TestManipulations(TestCase):
         for i, c in enumerate(counts):
             for idx in range(c - 1):
                 if rank == i:
-                    self.assertTrue(
-                        torch.lt(
-                            result._DNDarray__array[idx], result._DNDarray__array[idx + 1]
-                        ).all()
-                    )
+                    self.assertTrue(torch.lt(result.larray[idx], result.larray[idx + 1]).all())
 
     def test_resplit(self):
         if ht.MPI_WORLD.size > 1:
@@ -1746,15 +1727,11 @@ class TestManipulations(TestCase):
             local_shape = (1, N + 1, 2 * N)
             local_tensor = reference_tensor[ht.MPI_WORLD.rank, :, :]
             self.assertEqual(resplit_tensor.lshape, local_shape)
-            self.assertTrue(
-                (resplit_tensor._DNDarray__array == local_tensor._DNDarray__array).all()
-            )
+            self.assertTrue((resplit_tensor.larray == local_tensor.larray).all())
 
             # unsplit
             unsplit_tensor = ht.resplit(resplit_tensor, axis=None)
-            self.assertTrue(
-                (unsplit_tensor._DNDarray__array == reference_tensor._DNDarray__array).all()
-            )
+            self.assertTrue((unsplit_tensor.larray == reference_tensor.larray).all())
 
             # split along axis = 1
             resplit_tensor = ht.resplit(unsplit_tensor, axis=1)
@@ -1766,15 +1743,11 @@ class TestManipulations(TestCase):
                 local_tensor = reference_tensor[:, ht.MPI_WORLD.rank + 1 : ht.MPI_WORLD.rank + 2, :]
 
             self.assertEqual(resplit_tensor.lshape, local_shape)
-            self.assertTrue(
-                (resplit_tensor._DNDarray__array == local_tensor._DNDarray__array).all()
-            )
+            self.assertTrue((resplit_tensor.larray == local_tensor.larray).all())
 
             # unsplit
             unsplit_tensor = ht.resplit(resplit_tensor, axis=None)
-            self.assertTrue(
-                (unsplit_tensor._DNDarray__array == reference_tensor._DNDarray__array).all()
-            )
+            self.assertTrue((unsplit_tensor.larray == reference_tensor.larray).all())
 
             # split along axis = 2
             resplit_tensor = ht.resplit(unsplit_tensor, axis=2)
@@ -1782,9 +1755,7 @@ class TestManipulations(TestCase):
             local_tensor = reference_tensor[:, :, 2 * ht.MPI_WORLD.rank : 2 * ht.MPI_WORLD.rank + 2]
 
             self.assertEqual(resplit_tensor.lshape, local_shape)
-            self.assertTrue(
-                (resplit_tensor._DNDarray__array == local_tensor._DNDarray__array).all()
-            )
+            self.assertTrue((resplit_tensor.larray == local_tensor.larray).all())
 
             # order tests for resplit
             for dims in range(3, 5):
@@ -1811,48 +1782,48 @@ class TestManipulations(TestCase):
         result = ht.squeeze(data)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.float32)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(result.larray.dtype, torch.float32)
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == data._DNDarray__array.squeeze()).all())
+        self.assertTrue((result.larray == data.larray.squeeze()).all())
 
         # 4D local tensor, major axis
         result = ht.squeeze(data, axis=0)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.float32)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(result.larray.dtype, torch.float32)
         self.assertEqual(result.shape, (4, 5, 1))
         self.assertEqual(result.lshape, (4, 5, 1))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == data._DNDarray__array.squeeze(0)).all())
+        self.assertTrue((result.larray == data.larray.squeeze(0)).all())
 
         # 4D local tensor, minor axis
         result = ht.squeeze(data, axis=-1)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.float32)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(result.larray.dtype, torch.float32)
         self.assertEqual(result.shape, (1, 4, 5))
         self.assertEqual(result.lshape, (1, 4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == data._DNDarray__array.squeeze(-1)).all())
+        self.assertTrue((result.larray == data.larray.squeeze(-1)).all())
 
         # 4D local tensor, tuple axis
         result = data.squeeze(axis=(0, -1))
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.float32)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(result.larray.dtype, torch.float32)
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == data._DNDarray__array.squeeze()).all())
+        self.assertTrue((result.larray == data.larray.squeeze()).all())
 
         # 4D split tensor, along the axis
         data = ht.array(ht.random.randn(1, 4, 5, 1), split=1)
         result = ht.squeeze(data, axis=-1)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.float32)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(result.larray.dtype, torch.float32)
         self.assertEqual(result.shape, (1, 4, 5))
         self.assertEqual(result.split, 1)
 
@@ -1861,7 +1832,7 @@ class TestManipulations(TestCase):
         result = ht.squeeze(data, axis=1)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.float32)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(result.larray.dtype, torch.float32)
         self.assertEqual(result.shape, (3, 5, 6))
         self.assertEqual(result.split, None)
 
@@ -1870,7 +1841,7 @@ class TestManipulations(TestCase):
         result = ht.squeeze(data, axis=-1)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.float32)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(result.larray.dtype, torch.float32)
         self.assertEqual(result.shape, (3, 6, 5))
         self.assertEqual(result.split, None)
 
@@ -1881,7 +1852,7 @@ class TestManipulations(TestCase):
         result = ht.squeeze(data, axis=0)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.float32)
-        self.assertEqual(result._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(result.larray.dtype, torch.float32)
         self.assertEqual(result.shape, (size * 2, size))
         self.assertEqual(result.lshape, (2, size))
         self.assertEqual(result.split, 0)
@@ -2005,18 +1976,18 @@ class TestManipulations(TestCase):
         exp_zero_indcs = ht.array(
             [[size - 1, size - 2] for i in range(size)], dtype=ht.int64, split=0
         )
-        self.assertTrue((res._DNDarray__array == exp_zero._DNDarray__array).all())
-        self.assertTrue((indcs._DNDarray__array == exp_zero._DNDarray__array).all())
-        self.assertTrue(indcs._DNDarray__array.dtype == exp_zero_indcs._DNDarray__array.dtype)
+        self.assertTrue((res.larray == exp_zero.larray).all())
+        self.assertTrue((indcs.larray == exp_zero.larray).all())
+        self.assertTrue(indcs.larray.dtype == exp_zero_indcs.larray.dtype)
 
         res, indcs = ht.topk(split_one, 2, sorted=True)
         exp_one = ht.array([[size - 1, size - 2] for i in range(size)], dtype=ht.int32, split=1)
         exp_one_indcs = ht.array(
             [[size - 1, size - 2] for i in range(size)], dtype=ht.int64, split=1
         )
-        self.assertTrue((res._DNDarray__array == exp_one._DNDarray__array).all())
-        self.assertTrue((indcs._DNDarray__array == exp_one_indcs._DNDarray__array).all())
-        self.assertTrue(indcs._DNDarray__array.dtype == exp_one_indcs._DNDarray__array.dtype)
+        self.assertTrue((res.larray == exp_one.larray).all())
+        self.assertTrue((indcs.larray == exp_one_indcs.larray).all())
+        self.assertTrue(indcs.larray.dtype == exp_one_indcs.larray.dtype)
 
         torch_array = torch.arange(size, dtype=torch.float64).expand(size, size)
         split_zero = ht.array(torch_array, split=0)
@@ -2027,38 +1998,38 @@ class TestManipulations(TestCase):
         exp_zero_indcs = ht.array(
             [[size - 1, size - 2] for i in range(size)], dtype=ht.int64, split=0
         )
-        self.assertTrue((res._DNDarray__array == exp_zero._DNDarray__array).all())
-        self.assertTrue((indcs._DNDarray__array == exp_zero_indcs._DNDarray__array).all())
-        self.assertTrue(indcs._DNDarray__array.dtype == exp_zero_indcs._DNDarray__array.dtype)
+        self.assertTrue((res.larray == exp_zero.larray).all())
+        self.assertTrue((indcs.larray == exp_zero_indcs.larray).all())
+        self.assertTrue(indcs.larray.dtype == exp_zero_indcs.larray.dtype)
 
         res, indcs = ht.topk(split_one, 2, sorted=True)
         exp_one = ht.array([[size - 1, size - 2] for i in range(size)], dtype=ht.float64, split=1)
         exp_one_indcs = ht.array(
             [[size - 1, size - 2] for i in range(size)], dtype=ht.int64, split=1
         )
-        self.assertTrue((res._DNDarray__array == exp_one._DNDarray__array).all())
-        self.assertTrue((indcs._DNDarray__array == exp_one_indcs._DNDarray__array).all())
-        self.assertTrue(indcs._DNDarray__array.dtype == exp_one_indcs._DNDarray__array.dtype)
+        self.assertTrue((res.larray == exp_one.larray).all())
+        self.assertTrue((indcs.larray == exp_one_indcs.larray).all())
+        self.assertTrue(indcs.larray.dtype == exp_one_indcs.larray.dtype)
 
         res, indcs = ht.topk(split_zero, 2, sorted=True, largest=False)
         exp_zero = ht.array([[0, 1] for i in range(size)], dtype=ht.int32, split=0)
         exp_zero_indcs = ht.array([[0, 1] for i in range(size)], dtype=ht.int64, split=0)
-        self.assertTrue((res._DNDarray__array == exp_zero._DNDarray__array).all())
-        self.assertTrue((indcs._DNDarray__array == exp_zero._DNDarray__array).all())
-        self.assertTrue(indcs._DNDarray__array.dtype == exp_zero_indcs._DNDarray__array.dtype)
+        self.assertTrue((res.larray == exp_zero.larray).all())
+        self.assertTrue((indcs.larray == exp_zero.larray).all())
+        self.assertTrue(indcs.larray.dtype == exp_zero_indcs.larray.dtype)
 
         exp_zero = ht.array([[0, 1] for i in range(size)], dtype=ht.int32, split=0)
         exp_zero_indcs = ht.array([[0, 1] for i in range(size)], dtype=ht.int64, split=0)
         out = (ht.empty_like(exp_zero), ht.empty_like(exp_zero_indcs))
         res, indcs = ht.topk(split_zero, 2, sorted=True, largest=False, out=out)
 
-        self.assertTrue((res._DNDarray__array == exp_zero._DNDarray__array).all())
-        self.assertTrue((indcs._DNDarray__array == exp_zero._DNDarray__array).all())
-        self.assertTrue(indcs._DNDarray__array.dtype == exp_zero_indcs._DNDarray__array.dtype)
+        self.assertTrue((res.larray == exp_zero.larray).all())
+        self.assertTrue((indcs.larray == exp_zero.larray).all())
+        self.assertTrue(indcs.larray.dtype == exp_zero_indcs.larray.dtype)
 
-        self.assertTrue((out[0]._DNDarray__array == exp_zero._DNDarray__array).all())
-        self.assertTrue((out[1]._DNDarray__array == exp_zero._DNDarray__array).all())
-        self.assertTrue(out[1]._DNDarray__array.dtype == exp_zero_indcs._DNDarray__array.dtype)
+        self.assertTrue((out[0].larray == exp_zero.larray).all())
+        self.assertTrue((out[1].larray == exp_zero.larray).all())
+        self.assertTrue(out[1].larray.dtype == exp_zero_indcs.larray.dtype)
 
     def test_unique(self):
         size = ht.MPI_WORLD.size
@@ -2070,30 +2041,30 @@ class TestManipulations(TestCase):
 
         exp_axis_none = ht.array([rank], dtype=ht.int32)
         res = split_zero.unique(sorted=True)
-        self.assertTrue((res._DNDarray__array == exp_axis_none._DNDarray__array).all())
+        self.assertTrue((res.larray == exp_axis_none.larray).all())
 
         exp_axis_zero = ht.arange(size, dtype=ht.int32).expand_dims(0)
         res = ht.unique(split_zero, sorted=True, axis=0)
-        self.assertTrue((res._DNDarray__array == exp_axis_zero._DNDarray__array).all())
+        self.assertTrue((res.larray == exp_axis_zero.larray).all())
 
         exp_axis_one = ht.array([rank], dtype=ht.int32).expand_dims(0)
         split_zero_transposed = ht.array(torch_array.transpose(0, 1), split=0)
         res = ht.unique(split_zero_transposed, sorted=False, axis=1)
-        self.assertTrue((res._DNDarray__array == exp_axis_one._DNDarray__array).all())
+        self.assertTrue((res.larray == exp_axis_one.larray).all())
 
         split_one = ht.array(torch_array, dtype=ht.int32, split=1)
 
         exp_axis_none = ht.arange(size, dtype=ht.int32)
         res = ht.unique(split_one, sorted=True)
-        self.assertTrue((res._DNDarray__array == exp_axis_none._DNDarray__array).all())
+        self.assertTrue((res.larray == exp_axis_none.larray).all())
 
         exp_axis_zero = ht.array([rank], dtype=ht.int32).expand_dims(0)
         res = ht.unique(split_one, sorted=False, axis=0)
-        self.assertTrue((res._DNDarray__array == exp_axis_zero._DNDarray__array).all())
+        self.assertTrue((res.larray == exp_axis_zero.larray).all())
 
         exp_axis_one = ht.array([rank] * size, dtype=ht.int32).expand_dims(1)
         res = ht.unique(split_one, sorted=True, axis=1)
-        self.assertTrue((res._DNDarray__array == exp_axis_one._DNDarray__array).all())
+        self.assertTrue((res.larray == exp_axis_one.larray).all())
 
         torch_array = torch.tensor(
             [[1, 2], [2, 3], [1, 2], [2, 3], [1, 2]],
@@ -2128,7 +2099,7 @@ class TestManipulations(TestCase):
         self.assertEqual(inv.split, None)
         self.assertEqual(inv.dtype, data_split_none.dtype)
         self.assertEqual(inv.device, data_split_none.device)
-        self.assertTrue(torch.equal(inv._DNDarray__array, exp_inv.int()))
+        self.assertTrue(torch.equal(inv.larray, exp_inv.int()))
 
         data_split_zero = ht.array(torch_array, split=0)
         res, inv = ht.unique(data_split_zero, return_inverse=True, sorted=True)

--- a/heat/core/tests/test_memory.py
+++ b/heat/core/tests/test_memory.py
@@ -11,7 +11,7 @@ class TestMemory(TestCase):
 
         # test identity inequality and value equality
         self.assertIsNot(tensor, copied)
-        self.assertIsNot(tensor._DNDarray__array, copied._DNDarray__array)
+        self.assertIsNot(tensor.larray, copied.larray)
         self.assertTrue((tensor == copied)._DNDarray__array.all())
 
         # test exceptions

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -27,19 +27,19 @@ class TestRandom(TestCase):
 
         # torch results to compare to
         a_cmp = torch.randperm(a.shape[0], device=self.device.torch_device)
-        b_cmp = b_arr._DNDarray__array[torch.randperm(b.shape[0], device=self.device.torch_device)]
-        c_cmp = c_arr._DNDarray__array[torch.randperm(c.shape[0], device=self.device.torch_device)]
-        c0_cmp = c_arr._DNDarray__array[torch.randperm(c.shape[0], device=self.device.torch_device)]
-        c1_cmp = c_arr._DNDarray__array[torch.randperm(c.shape[0], device=self.device.torch_device)]
+        b_cmp = b_arr.larray[torch.randperm(b.shape[0], device=self.device.torch_device)]
+        c_cmp = c_arr.larray[torch.randperm(c.shape[0], device=self.device.torch_device)]
+        c0_cmp = c_arr.larray[torch.randperm(c.shape[0], device=self.device.torch_device)]
+        c1_cmp = c_arr.larray[torch.randperm(c.shape[0], device=self.device.torch_device)]
 
         # compare
         self.assertEqual(a.dtype, ht.int64)
-        self.assertTrue((a._DNDarray__array == a_cmp).all())
+        self.assertTrue((a.larray == a_cmp).all())
         self.assertEqual(b.dtype, ht.float32)
-        self.assertTrue((ht.resplit(b)._DNDarray__array == b_cmp).all())
-        self.assertTrue((c._DNDarray__array == c_cmp).all())
-        self.assertTrue((ht.resplit(c0)._DNDarray__array == c0_cmp).all())
-        self.assertTrue((ht.resplit(c1)._DNDarray__array == c1_cmp).all())
+        self.assertTrue((ht.resplit(b).larray == b_cmp).all())
+        self.assertTrue((c.larray == c_cmp).all())
+        self.assertTrue((ht.resplit(c0).larray == c0_cmp).all())
+        self.assertTrue((ht.resplit(c1).larray == c1_cmp).all())
 
         with self.assertRaises(TypeError):
             ht.random.permutation("abc")
@@ -52,7 +52,7 @@ class TestRandom(TestCase):
         ht.random.seed(seed)
         a = ht.random.rand(2, 5, 7, 3, split=0)
         self.assertEqual(a.dtype, ht.float32)
-        self.assertEqual(a._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(a.larray.dtype, torch.float32)
         b = ht.random.rand(2, 5, 7, 3, split=0)
         self.assertFalse(ht.equal(a, b))
         ht.random.seed(seed)
@@ -99,7 +99,7 @@ class TestRandom(TestCase):
         ht.random.seed(seed)
         b = ht.random.rand(100, split=None)
         a = a.numpy().flatten()
-        b = b._DNDarray__array.cpu().numpy()
+        b = b.larray.cpu().numpy()
         self.assertTrue(np.array_equal(a, b))
 
         # On different shape and split the same random values are used
@@ -153,12 +153,12 @@ class TestRandom(TestCase):
         shape = (13, 43, 13, 23)
         a = ht.random.rand(*shape, dtype=ht.float32, split=0)
         self.assertEqual(a.dtype, ht.float32)
-        self.assertEqual(a._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(a.larray.dtype, torch.float32)
 
         ht.random.seed(9876)
         b = ht.random.rand(np.prod(shape), dtype=ht.float32)
         a = a.numpy().flatten()
-        b = b._DNDarray__array.cpu().numpy()
+        b = b.larray.cpu().numpy()
         self.assertTrue(np.array_equal(a, b))
         self.assertEqual(a.dtype, np.float32)
 
@@ -254,7 +254,7 @@ class TestRandom(TestCase):
         b = ht.random.randint(50, 1000, size=(13, 45), dtype=ht.int32, split=0)
 
         self.assertEqual(a.dtype, ht.int32)
-        self.assertEqual(a._DNDarray__array.dtype, torch.int32)
+        self.assertEqual(a.larray.dtype, torch.int32)
         self.assertEqual(b.dtype, ht.int32)
         a = a.numpy()
         b = b.numpy()
@@ -337,7 +337,7 @@ class TestRandom(TestCase):
         ht.random.seed(54321)
         a = ht.random.randn(30, 30, 30, dtype=ht.float32, split=2)
         self.assertEqual(a.dtype, ht.float32)
-        self.assertEqual(a._DNDarray__array[0, 0, 0].dtype, torch.float32)
+        self.assertEqual(a.larray[0, 0, 0].dtype, torch.float32)
         a = a.numpy()
         self.assertEqual(a.dtype, np.float32)
         mean = np.mean(a)
@@ -373,13 +373,13 @@ class TestRandom(TestCase):
         d_cmp = torch.randperm(5, dtype=torch.float64, device=self.device.torch_device)
 
         self.assertEqual(a.dtype, ht.int32)
-        self.assertTrue((a._DNDarray__array == a_cmp).all())
+        self.assertTrue((a.larray == a_cmp).all())
         self.assertEqual(b.dtype, ht.float32)
-        self.assertTrue((ht.resplit(b)._DNDarray__array == b_cmp).all())
+        self.assertTrue((ht.resplit(b).larray == b_cmp).all())
         self.assertEqual(c.dtype, ht.int64)
-        self.assertTrue((ht.resplit(c)._DNDarray__array == c_cmp).all())
+        self.assertTrue((ht.resplit(c).larray == c_cmp).all())
         self.assertEqual(d.dtype, ht.float64)
-        self.assertTrue((d._DNDarray__array == d_cmp).all())
+        self.assertTrue((d.larray == d_cmp).all())
 
         with self.assertRaises(TypeError):
             ht.random.randperm("abc")

--- a/heat/core/tests/test_rounding.py
+++ b/heat/core/tests/test_rounding.py
@@ -56,7 +56,7 @@ class TestRounding(TestCase):
         self.assertIsInstance(absolute_values, ht.DNDarray)
         self.assertEqual(absolute_values.sum(axis=0), 100)
         self.assertEqual(absolute_values.dtype, ht.float32)
-        self.assertEqual(absolute_values._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(absolute_values.larray.dtype, torch.float32)
         # for fabs
         self.assertEqual(int8_absolute_values_fabs.dtype, ht.float32)
         self.assertEqual(int16_absolute_values_fabs.dtype, ht.float32)
@@ -98,7 +98,7 @@ class TestRounding(TestCase):
         self.assertIsInstance(float32_floor, ht.DNDarray)
         self.assertEqual(float32_floor.dtype, ht.float32)
         self.assertEqual(float32_floor.dtype, ht.float32)
-        self.assertTrue((float32_floor._DNDarray__array == comparison.float()).all())
+        self.assertTrue((float32_floor.larray == comparison.float()).all())
 
         # exponential of float64
         float64_tensor = ht.arange(start, end, step, dtype=ht.float64)
@@ -106,7 +106,7 @@ class TestRounding(TestCase):
         self.assertIsInstance(float64_floor, ht.DNDarray)
         self.assertEqual(float64_floor.dtype, ht.float64)
         self.assertEqual(float64_floor.dtype, ht.float64)
-        self.assertTrue((float64_floor._DNDarray__array == comparison).all())
+        self.assertTrue((float64_floor.larray == comparison).all())
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -151,7 +151,7 @@ class TestRounding(TestCase):
         self.assertIsInstance(float32_floor, ht.DNDarray)
         self.assertEqual(float32_floor.dtype, ht.float32)
         self.assertEqual(float32_floor.dtype, ht.float32)
-        self.assertTrue((float32_floor._DNDarray__array == comparison.float()).all())
+        self.assertTrue((float32_floor.larray == comparison.float()).all())
 
         # exponential of float64
         float64_tensor = ht.arange(start, end, step, dtype=ht.float64)
@@ -159,7 +159,7 @@ class TestRounding(TestCase):
         self.assertIsInstance(float64_floor, ht.DNDarray)
         self.assertEqual(float64_floor.dtype, ht.float64)
         self.assertEqual(float64_floor.dtype, ht.float64)
-        self.assertTrue((float64_floor._DNDarray__array == comparison).all())
+        self.assertTrue((float64_floor.larray == comparison).all())
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -312,14 +312,14 @@ class TestRounding(TestCase):
         float32_floor = float32_tensor.trunc()
         self.assertIsInstance(float32_floor, ht.DNDarray)
         self.assertEqual(float32_floor.dtype, ht.float32)
-        self.assertTrue((float32_floor._DNDarray__array == comparison.float()).all())
+        self.assertTrue((float32_floor.larray == comparison.float()).all())
 
         # trunc of float64
         float64_tensor = ht.array(base_array, dtype=ht.float64)
         float64_floor = float64_tensor.trunc()
         self.assertIsInstance(float64_floor, ht.DNDarray)
         self.assertEqual(float64_floor.dtype, ht.float64)
-        self.assertTrue((float64_floor._DNDarray__array == comparison).all())
+        self.assertTrue((float64_floor.larray == comparison).all())
 
         # check exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -17,48 +17,44 @@ class TestStatistics(TestCase):
         result = ht.argmax(data, axis=0)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == data._DNDarray__array.argmax(0)).all())
+        self.assertTrue((result.larray == data.larray.argmax(0)).all())
 
         # 3D local tensor, minor axis
         result = ht.argmax(data, axis=-1, keepdim=True)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (3, 4, 1))
         self.assertEqual(result.lshape, (3, 4, 1))
         self.assertEqual(result.split, None)
-        self.assertTrue(
-            (result._DNDarray__array == data._DNDarray__array.argmax(-1, keepdim=True)).all()
-        )
+        self.assertTrue((result.larray == data.larray.argmax(-1, keepdim=True)).all())
 
         # 1D split tensor, no axis
         data = ht.arange(-10, 10, split=0)
         result = ht.argmax(data)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (1,))
         self.assertEqual(result.lshape, (1,))
         self.assertEqual(result.split, None)
-        self.assertTrue(
-            (result._DNDarray__array == torch.tensor([19], device=self.device.torch_device))
-        )
+        self.assertTrue((result.larray == torch.tensor([19], device=self.device.torch_device)))
 
         # 2D split tensor, along the axis
         data = ht.array(ht.random.randn(4, 5), is_split=0)
         result = ht.argmax(data, axis=1)
-        expected = torch.argmax(data._DNDarray__array, dim=1)
+        expected = torch.argmax(data.larray, dim=1)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (ht.MPI_WORLD.size * 4,))
         self.assertEqual(result.lshape, (4,))
         self.assertEqual(result.split, 0 if ht.MPI_WORLD.size > 1 else None)
-        self.assertTrue((result._DNDarray__array == expected).all())
+        self.assertTrue((result.larray == expected).all())
 
         # 2D split tensor, across the axis
         size = ht.MPI_WORLD.size * 2
@@ -68,13 +64,13 @@ class TestStatistics(TestCase):
         expected = torch.tensor(np.argmax(data.numpy(), axis=0))
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (size,))
         self.assertEqual(result.lshape, (size,))
         self.assertEqual(result.split, None)
         # skip test on gpu; argmax works different
         if not (torch.cuda.is_available() and result.device == ht.gpu):
-            self.assertTrue((result._DNDarray__array == expected).all())
+            self.assertTrue((result.larray == expected).all())
 
         # 2D split tensor, across the axis, output tensor
         size = ht.MPI_WORLD.size * 2
@@ -85,13 +81,13 @@ class TestStatistics(TestCase):
         expected = torch.tensor(np.argmax(data.numpy(), axis=0))
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(output.dtype, ht.int64)
-        self.assertEqual(output._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(output.larray.dtype, torch.int64)
         self.assertEqual(output.shape, (size,))
         self.assertEqual(output.lshape, (size,))
         self.assertEqual(output.split, None)
         # skip test on gpu; argmax works different
         if not (torch.cuda.is_available() and result.device == ht.gpu):
-            self.assertTrue((output._DNDarray__array == expected).all())
+            self.assertTrue((output.larray == expected).all())
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -111,45 +107,43 @@ class TestStatistics(TestCase):
         result = ht.argmin(data)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (1,))
         self.assertEqual(result.lshape, (1,))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == data._DNDarray__array.argmin()).all())
+        self.assertTrue((result.larray == data.larray.argmin()).all())
 
         # 3D local tensor, major axis
         result = ht.argmin(data, axis=0)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (4, 5))
         self.assertEqual(result.lshape, (4, 5))
         self.assertEqual(result.split, None)
-        self.assertTrue((result._DNDarray__array == data._DNDarray__array.argmin(0)).all())
+        self.assertTrue((result.larray == data.larray.argmin(0)).all())
 
         # 3D local tensor, minor axis
         result = ht.argmin(data, axis=-1, keepdim=True)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (3, 4, 1))
         self.assertEqual(result.lshape, (3, 4, 1))
         self.assertEqual(result.split, None)
-        self.assertTrue(
-            (result._DNDarray__array == data._DNDarray__array.argmin(-1, keepdim=True)).all()
-        )
+        self.assertTrue((result.larray == data.larray.argmin(-1, keepdim=True)).all())
 
         # 2D split tensor, along the axis
         data = ht.array(ht.random.randn(4, 5), is_split=0)
         result = ht.argmin(data, axis=1)
-        expected = torch.argmin(data._DNDarray__array, dim=1)
+        expected = torch.argmin(data.larray, dim=1)
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (ht.MPI_WORLD.size * 4,))
         self.assertEqual(result.lshape, (4,))
         self.assertEqual(result.split, 0 if ht.MPI_WORLD.size > 1 else None)
-        self.assertTrue((result._DNDarray__array == expected).all())
+        self.assertTrue((result.larray == expected).all())
 
         # 2D split tensor, across the axis
         size = ht.MPI_WORLD.size * 2
@@ -159,13 +153,13 @@ class TestStatistics(TestCase):
         expected = torch.tensor(np.argmin(data.numpy(), axis=0))
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(result.dtype, ht.int64)
-        self.assertEqual(result._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (size,))
         self.assertEqual(result.lshape, (size,))
         self.assertEqual(result.split, None)
         # skip test on gpu; argmin works different
         if not (torch.cuda.is_available() and result.device == ht.gpu):
-            self.assertTrue((result._DNDarray__array == expected).all())
+            self.assertTrue((result.larray == expected).all())
 
         # 2D split tensor, across the axis, output tensor
         size = ht.MPI_WORLD.size * 2
@@ -176,13 +170,13 @@ class TestStatistics(TestCase):
         expected = torch.tensor(np.argmin(data.numpy(), axis=0))
         self.assertIsInstance(result, ht.DNDarray)
         self.assertEqual(output.dtype, ht.int64)
-        self.assertEqual(output._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(output.larray.dtype, torch.int64)
         self.assertEqual(output.shape, (size,))
         self.assertEqual(output.lshape, (size,))
         self.assertEqual(output.split, None)
         # skip test on gpu; argmin works different
         if not (torch.cuda.is_available() and result.device == ht.gpu):
-            self.assertTrue((output._DNDarray__array == expected).all())
+            self.assertTrue((output.larray == expected).all())
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -208,7 +202,7 @@ class TestStatistics(TestCase):
         self.assertEqual(avg.lshape, ())
         self.assertEqual(avg.split, None)
         self.assertEqual(avg.dtype, ht.float32)
-        self.assertEqual(avg._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(avg.larray.dtype, torch.float32)
         self.assertEqual(avg.numpy(), np.average(comparison))
 
         # average along first axis
@@ -219,7 +213,7 @@ class TestStatistics(TestCase):
         self.assertEqual(avg_vertical.lshape, (3,))
         self.assertEqual(avg_vertical.split, None)
         self.assertEqual(avg_vertical.dtype, ht.float32)
-        self.assertEqual(avg_vertical._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(avg_vertical.larray.dtype, torch.float32)
         self.assertTrue((avg_vertical.numpy() == np.average(comparison, axis=0)).all())
 
         # average along second axis
@@ -230,7 +224,7 @@ class TestStatistics(TestCase):
         self.assertEqual(avg_horizontal.lshape, (4,))
         self.assertEqual(avg_horizontal.split, None)
         self.assertEqual(avg_horizontal.dtype, ht.float32)
-        self.assertEqual(avg_horizontal._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(avg_horizontal.larray.dtype, torch.float32)
         self.assertTrue((avg_horizontal.numpy() == np.average(comparison, axis=1)).all())
 
         # check weighted average over all float elements of split 3d tensor, across split axis
@@ -247,7 +241,7 @@ class TestStatistics(TestCase):
         self.assertEqual(avg_volume.shape, (3, 3))
         self.assertEqual(avg_volume.lshape, (3, 3))
         self.assertEqual(avg_volume.dtype, ht.float64)
-        self.assertEqual(avg_volume._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(avg_volume.larray.dtype, torch.float64)
         self.assertEqual(avg_volume.split, None)
         self.assertAlmostEqual(avg_volume.numpy().all(), np_avg_volume.all())
         avg_volume_with_cumwgt = ht.average(
@@ -269,7 +263,7 @@ class TestStatistics(TestCase):
         self.assertEqual(avg_volume.shape, (3, 3))
         self.assertEqual(avg_volume.lshape, (3, 3))
         self.assertEqual(avg_volume.dtype, ht.float64)
-        self.assertEqual(avg_volume._DNDarray__array.dtype, torch.float64)
+        self.assertEqual(avg_volume.larray.dtype, torch.float64)
         self.assertEqual(avg_volume.split, None)
         self.assertAlmostEqual(avg_volume.numpy().all(), np_avg_volume.all())
         avg_volume_with_cumwgt = ht.average(
@@ -288,7 +282,7 @@ class TestStatistics(TestCase):
         self.assertEqual(avg_volume.shape, (3,))
         self.assertEqual(avg_volume.lshape[0], random_volume.lshape[0])
         self.assertEqual(avg_volume.dtype, ht.float32)
-        self.assertEqual(avg_volume._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(avg_volume.larray.dtype, torch.float32)
         self.assertEqual(avg_volume.split, 0)
 
         # check weighted average over all float elements of split 5d tensor, along split axis
@@ -301,7 +295,7 @@ class TestStatistics(TestCase):
         self.assertEqual(avg_5d.gshape, (2, 3, 4, 5))
         self.assertLessEqual(avg_5d.lshape[1], 3)
         self.assertEqual(avg_5d.dtype, ht.float32)
-        self.assertEqual(avg_5d._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(avg_5d.larray.dtype, torch.float32)
         self.assertEqual(avg_5d.split, None)
 
         # check exceptions
@@ -550,7 +544,7 @@ class TestStatistics(TestCase):
         self.assertEqual(maximum.lshape, (1,))
         self.assertEqual(maximum.split, None)
         self.assertEqual(maximum.dtype, ht.int64)
-        self.assertEqual(maximum._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(maximum.larray.dtype, torch.int64)
         self.assertEqual(maximum, 12)
 
         # maximum along first axis
@@ -561,10 +555,8 @@ class TestStatistics(TestCase):
         self.assertEqual(maximum_vertical.lshape, (3,))
         self.assertEqual(maximum_vertical.split, None)
         self.assertEqual(maximum_vertical.dtype, ht.int64)
-        self.assertEqual(maximum_vertical._DNDarray__array.dtype, torch.int64)
-        self.assertTrue(
-            (maximum_vertical._DNDarray__array == comparison.max(dim=0, keepdim=True)[0]).all()
-        )
+        self.assertEqual(maximum_vertical.larray.dtype, torch.int64)
+        self.assertTrue((maximum_vertical.larray == comparison.max(dim=0, keepdim=True)[0]).all())
 
         # maximum along second axis
         maximum_horizontal = ht.max(ht_array, axis=1, keepdim=True)
@@ -574,10 +566,8 @@ class TestStatistics(TestCase):
         self.assertEqual(maximum_horizontal.lshape, (4, 1))
         self.assertEqual(maximum_horizontal.split, None)
         self.assertEqual(maximum_horizontal.dtype, ht.int64)
-        self.assertEqual(maximum_horizontal._DNDarray__array.dtype, torch.int64)
-        self.assertTrue(
-            (maximum_horizontal._DNDarray__array == comparison.max(dim=1, keepdim=True)[0]).all()
-        )
+        self.assertEqual(maximum_horizontal.larray.dtype, torch.int64)
+        self.assertTrue((maximum_horizontal.larray == comparison.max(dim=1, keepdim=True)[0]).all())
 
         # check max over all float elements of split 3d tensor, across split axis
         size = ht.MPI_WORLD.size
@@ -588,7 +578,7 @@ class TestStatistics(TestCase):
         self.assertEqual(maximum_volume.shape, (3, 3))
         self.assertEqual(maximum_volume.lshape, (3, 3))
         self.assertEqual(maximum_volume.dtype, ht.float32)
-        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(maximum_volume.larray.dtype, torch.float32)
         self.assertEqual(maximum_volume.split, None)
 
         # check max over all float elements of split 3d tensor, tuple axis
@@ -599,7 +589,7 @@ class TestStatistics(TestCase):
         self.assertIsInstance(maximum_volume, ht.DNDarray)
         self.assertEqual(maximum_volume.shape, (3 * size,))
         self.assertEqual(maximum_volume.dtype, ht.float32)
-        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(maximum_volume.larray.dtype, torch.float32)
         self.assertEqual(maximum_volume.split, 0)
         self.assertTrue((maximum_volume == alt_maximum_volume).all())
 
@@ -611,7 +601,7 @@ class TestStatistics(TestCase):
         self.assertEqual(maximum_5d.shape, (1 * size, 3, 4, 5))
         self.assertLessEqual(maximum_5d.lshape[1], 3)
         self.assertEqual(maximum_5d.dtype, ht.float32)
-        self.assertEqual(maximum_5d._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(maximum_5d.larray.dtype, torch.float32)
         self.assertEqual(maximum_5d.split, 0)
 
         # Calculating max with empty local vectors works
@@ -621,7 +611,7 @@ class TestStatistics(TestCase):
             expected = torch.tensor(
                 [size - 2], dtype=a.dtype.torch_type(), device=self.device.torch_device
             )
-            self.assertTrue(torch.equal(res._DNDarray__array, expected))
+            self.assertTrue(torch.equal(res.larray, expected))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -648,8 +638,8 @@ class TestStatistics(TestCase):
         self.assertEqual(maximum.lshape, (4, 3))
         self.assertEqual(maximum.split, None)
         self.assertEqual(maximum.dtype, ht.int64)
-        self.assertEqual(maximum._DNDarray__array.dtype, torch.int64)
-        self.assertTrue((maximum._DNDarray__array == torch.max(comparison1, comparison2)).all())
+        self.assertEqual(maximum.larray.dtype, torch.int64)
+        self.assertTrue((maximum.larray == torch.max(comparison1, comparison2)).all())
 
         # check maximum over float elements of split 3d tensors
         torch.manual_seed(1)
@@ -661,7 +651,7 @@ class TestStatistics(TestCase):
         self.assertIsInstance(maximum_volume, ht.DNDarray)
         self.assertEqual(maximum_volume.shape, (6, 3, 3))
         self.assertEqual(maximum_volume.dtype, ht.float32)
-        self.assertEqual(maximum_volume._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(maximum_volume.larray.dtype, torch.float32)
         self.assertEqual(maximum_volume.split, random_volume_1.split)
         self.assertTrue((maximum_volume.numpy() == np_maximum).all())
 
@@ -696,7 +686,7 @@ class TestStatistics(TestCase):
         self.assertIsInstance(output, ht.DNDarray)
         self.assertEqual(output.shape, (6, 3, 3))
         self.assertEqual(output.dtype, ht.float32)
-        self.assertEqual(output._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(output.larray.dtype, torch.float32)
 
         # check exceptions
         random_volume_3 = ht.array([])
@@ -815,7 +805,7 @@ class TestStatistics(TestCase):
         self.assertEqual(minimum.lshape, (1,))
         self.assertEqual(minimum.split, None)
         self.assertEqual(minimum.dtype, ht.int64)
-        self.assertEqual(minimum._DNDarray__array.dtype, torch.int64)
+        self.assertEqual(minimum.larray.dtype, torch.int64)
         self.assertEqual(minimum, 1)
 
         # maximum along first axis
@@ -827,10 +817,8 @@ class TestStatistics(TestCase):
         self.assertEqual(minimum_vertical.lshape, (3,))
         self.assertEqual(minimum_vertical.split, None)
         self.assertEqual(minimum_vertical.dtype, ht.int8)
-        self.assertEqual(minimum_vertical._DNDarray__array.dtype, torch.int8)
-        self.assertTrue(
-            (minimum_vertical._DNDarray__array == comparison.min(dim=0, keepdim=True)[0]).all()
-        )
+        self.assertEqual(minimum_vertical.larray.dtype, torch.int8)
+        self.assertTrue((minimum_vertical.larray == comparison.min(dim=0, keepdim=True)[0]).all())
 
         # maximum along second axis
         ht_array = ht.array(data, dtype=ht.int16)
@@ -841,10 +829,8 @@ class TestStatistics(TestCase):
         self.assertEqual(minimum_horizontal.lshape, (4, 1))
         self.assertEqual(minimum_horizontal.split, None)
         self.assertEqual(minimum_horizontal.dtype, ht.int16)
-        self.assertEqual(minimum_horizontal._DNDarray__array.dtype, torch.int16)
-        self.assertTrue(
-            (minimum_horizontal._DNDarray__array == comparison.min(dim=1, keepdim=True)[0]).all()
-        )
+        self.assertEqual(minimum_horizontal.larray.dtype, torch.int16)
+        self.assertTrue((minimum_horizontal.larray == comparison.min(dim=1, keepdim=True)[0]).all())
 
         # check max over all float elements of split 3d tensor, across split axis
         size = ht.MPI_WORLD.size
@@ -855,7 +841,7 @@ class TestStatistics(TestCase):
         self.assertEqual(minimum_volume.shape, (3, 3))
         self.assertEqual(minimum_volume.lshape, (3, 3))
         self.assertEqual(minimum_volume.dtype, ht.float32)
-        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(minimum_volume.larray.dtype, torch.float32)
         self.assertEqual(minimum_volume.split, None)
 
         # check min over all float elements of split 3d tensor, tuple axis
@@ -866,7 +852,7 @@ class TestStatistics(TestCase):
         self.assertIsInstance(minimum_volume, ht.DNDarray)
         self.assertEqual(minimum_volume.shape, (3 * size,))
         self.assertEqual(minimum_volume.dtype, ht.float32)
-        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(minimum_volume.larray.dtype, torch.float32)
         self.assertEqual(minimum_volume.split, 0)
         self.assertTrue((minimum_volume == alt_minimum_volume).all())
 
@@ -878,7 +864,7 @@ class TestStatistics(TestCase):
         self.assertEqual(minimum_5d.shape, (1 * size, 3, 4, 5))
         self.assertLessEqual(minimum_5d.lshape[1], 3)
         self.assertEqual(minimum_5d.dtype, ht.float32)
-        self.assertEqual(minimum_5d._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(minimum_5d.larray.dtype, torch.float32)
         self.assertEqual(minimum_5d.split, 0)
 
         # Calculating min with empty local vectors works
@@ -889,7 +875,7 @@ class TestStatistics(TestCase):
             expected = torch.tensor(
                 [0], dtype=a.dtype.torch_type(), device=self.device.torch_device
             )
-            self.assertTrue(torch.equal(res._DNDarray__array, expected))
+            self.assertTrue(torch.equal(res.larray, expected))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -916,8 +902,8 @@ class TestStatistics(TestCase):
         self.assertEqual(minimum.lshape, (4, 3))
         self.assertEqual(minimum.split, None)
         self.assertEqual(minimum.dtype, ht.int64)
-        self.assertEqual(minimum._DNDarray__array.dtype, torch.int64)
-        self.assertTrue((minimum._DNDarray__array == torch.min(comparison1, comparison2)).all())
+        self.assertEqual(minimum.larray.dtype, torch.int64)
+        self.assertTrue((minimum.larray == torch.min(comparison1, comparison2)).all())
 
         # check minimum over float elements of split 3d tensors
         torch.manual_seed(1)
@@ -929,7 +915,7 @@ class TestStatistics(TestCase):
         self.assertIsInstance(minimum_volume, ht.DNDarray)
         self.assertEqual(minimum_volume.shape, (6, 3, 3))
         self.assertEqual(minimum_volume.dtype, ht.float32)
-        self.assertEqual(minimum_volume._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(minimum_volume.larray.dtype, torch.float32)
         self.assertEqual(minimum_volume.split, random_volume_1.split)
         self.assertTrue((minimum_volume.numpy() == np_minimum).all())
 
@@ -964,7 +950,7 @@ class TestStatistics(TestCase):
         self.assertIsInstance(output, ht.DNDarray)
         self.assertEqual(output.shape, (6, 3, 3))
         self.assertEqual(output.dtype, ht.float32)
-        self.assertEqual(output._DNDarray__array.dtype, torch.float32)
+        self.assertEqual(output.larray.dtype, torch.float32)
 
         # check exceptions
         random_volume_3 = ht.array([])

--- a/heat/core/tests/test_suites/basic_test.py
+++ b/heat/core/tests/test_suites/basic_test.py
@@ -298,11 +298,11 @@ class TestCase(unittest.TestCase):
             ht_res = heat_func(ht_array, **heat_args)
 
             self.assertEqual(ht_array.device, ht_res.device)
-            self.assertEqual(ht_array._DNDarray__array.device, ht_res._DNDarray__array.device)
+            self.assertEqual(ht_array.larray.device, ht_res.larray.device)
             if distributed_result:
                 self.assert_array_equal(ht_res, np_res)
             else:
-                self.assertTrue(np.array_equal(ht_res._DNDarray__array.cpu().numpy(), np_res))
+                self.assertTrue(np.array_equal(ht_res.larray.cpu().numpy(), np_res))
 
     def assertTrue_memory_layout(self, tensor, order):
         """
@@ -312,7 +312,7 @@ class TestCase(unittest.TestCase):
         -----------
         order: str, 'C' for C-like (row-major), 'F' for Fortran-like (column-major) memory layout.
         """
-        stride = tensor._DNDarray__array.stride()
+        stride = tensor.larray.stride()
         row_major = all(np.diff(list(stride)) <= 0)
         column_major = all(np.diff(list(stride)) >= 0)
         if order == "C":

--- a/heat/core/tests/test_tiling.py
+++ b/heat/core/tests/test_tiling.py
@@ -265,32 +265,32 @@ class TestSquareDiagTiles(TestCase):
             lcl_key = m_eq_n_s0_t2.local_to_global(key=k, rank=m_eq_n_s0.comm.rank)
             st_sp = m_eq_n_s0_t2.get_start_stop(key=lcl_key)
             sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-            lcl_slice = m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+            lcl_slice = m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
             lcl_shape = m_eq_n_s0_t2.local_get(key=(slice(None), slice(None))).shape
             self.assertEqual(lcl_shape, m_eq_n_s0.lshape)
             self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
             # reset base
-            m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+            m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
 
             k = (1, 1)
             m_eq_n_s0_t2.local_set(key=k, value=1)
             lcl_key = m_eq_n_s0_t2.local_to_global(key=k, rank=m_eq_n_s0.comm.rank)
             st_sp = m_eq_n_s0_t2.get_start_stop(key=lcl_key)
             sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-            lcl_slice = m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+            lcl_slice = m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
             self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
             # reset base
-            m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+            m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
 
             k = 1
             m_eq_n_s0_t2.local_set(key=k, value=1)
             lcl_key = m_eq_n_s0_t2.local_to_global(key=k, rank=m_eq_n_s0.comm.rank)
             st_sp = m_eq_n_s0_t2.get_start_stop(key=lcl_key)
             sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-            lcl_slice = m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+            lcl_slice = m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
             self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
             # reset base
-            m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+            m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
 
             # --------------------- local ----------- s1 ----------------
             m_eq_n_s1 = ht.zeros((25, 25), split=1)
@@ -300,32 +300,32 @@ class TestSquareDiagTiles(TestCase):
             lcl_key = m_eq_n_s1_t2.local_to_global(key=k, rank=m_eq_n_s1.comm.rank)
             st_sp = m_eq_n_s1_t2.get_start_stop(key=lcl_key)
             sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-            lcl_slice = m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+            lcl_slice = m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
             lcl_shape = m_eq_n_s1_t2.local_get(key=(slice(None), slice(None))).shape
             self.assertEqual(lcl_shape, m_eq_n_s1.lshape)
             self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
             # reset base
-            m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+            m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
             if ht.MPI_WORLD.size > 2:
                 k = (5, 1)
                 m_eq_n_s1_t2.local_set(key=k, value=1)
                 lcl_key = m_eq_n_s1_t2.local_to_global(key=k, rank=m_eq_n_s1.comm.rank)
                 st_sp = m_eq_n_s1_t2.get_start_stop(key=lcl_key)
                 sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-                lcl_slice = m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+                lcl_slice = m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
                 self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
                 # reset base
-                m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+                m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
 
             k = 2
             m_eq_n_s1_t2.local_set(key=k, value=1)
             lcl_key = m_eq_n_s1_t2.local_to_global(key=k, rank=m_eq_n_s1.comm.rank)
             st_sp = m_eq_n_s1_t2.get_start_stop(key=lcl_key)
             sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-            lcl_slice = m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+            lcl_slice = m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
             self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
             # reset base
-            m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+            m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
 
             # --------------------- global ---------- s0 ----------------
             m_eq_n_s0 = ht.zeros((25, 25), split=0)
@@ -335,30 +335,30 @@ class TestSquareDiagTiles(TestCase):
             if m_eq_n_s0_t2[k] is not None:
                 st_sp = m_eq_n_s0_t2.get_start_stop(key=k)
                 sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-                lcl_slice = m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+                lcl_slice = m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
                 self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
                 # reset base
-                m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+                m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
             if ht.MPI_WORLD.size > 2:
                 k = (5, 5)
                 m_eq_n_s0_t2[k] = 1
                 if m_eq_n_s0_t2[k] is not None:
                     st_sp = m_eq_n_s0_t2.get_start_stop(key=k)
                     sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-                    lcl_slice = m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+                    lcl_slice = m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
                     self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
                     # reset base
-                    m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+                    m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
 
                 k = (slice(0, 2), slice(1, 5))
                 m_eq_n_s0_t2[k] = 1
                 if m_eq_n_s0_t2[k] is not None:
                     st_sp = m_eq_n_s0_t2.get_start_stop(key=k)
                     sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-                    lcl_slice = m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+                    lcl_slice = m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
                     self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
                     # reset base
-                    m_eq_n_s0._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+                    m_eq_n_s0.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
 
             # --------------------- global ---------- s1 ----------------
             m_eq_n_s1 = ht.zeros((25, 25), split=1)
@@ -368,10 +368,10 @@ class TestSquareDiagTiles(TestCase):
             if m_eq_n_s1_t2[k] is not None:
                 st_sp = m_eq_n_s1_t2.get_start_stop(key=k)
                 sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-                lcl_slice = m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+                lcl_slice = m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
                 self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
                 # reset base
-                m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+                m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
 
             # k = (slice(0, 3), slice(0, 2))
             if ht.MPI_WORLD.size > 2:
@@ -380,20 +380,20 @@ class TestSquareDiagTiles(TestCase):
                 if m_eq_n_s1_t2[k] is not None:
                     st_sp = m_eq_n_s1_t2.get_start_stop(key=k)
                     sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-                    lcl_slice = m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+                    lcl_slice = m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
                     self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
                     # reset base
-                    m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+                    m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
 
             k = (slice(0, 3), 3)
             m_eq_n_s1_t2[k] = 1
             if m_eq_n_s1_t2[k] is not None:
                 st_sp = m_eq_n_s1_t2.get_start_stop(key=k)
                 sz = st_sp[1] - st_sp[0], st_sp[3] - st_sp[2]
-                lcl_slice = m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
+                lcl_slice = m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]]
                 self.assertTrue(torch.all(lcl_slice - torch.ones(sz, device=torch_dev) == 0))
                 # reset base
-                m_eq_n_s1._DNDarray__array[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
+                m_eq_n_s1.larray[st_sp[0] : st_sp[1], st_sp[2] : st_sp[3]] = 0
             with self.assertRaises(ValueError):
                 m_eq_n_s1_t2[1, :]
             with self.assertRaises(TypeError):

--- a/heat/core/tests/test_trigonometrics.py
+++ b/heat/core/tests/test_trigonometrics.py
@@ -18,21 +18,21 @@ class TestTrigonometrics(TestCase):
         float32_arccos = ht.acos(float32_tensor)
         self.assertIsInstance(float32_arccos, ht.DNDarray)
         self.assertEqual(float32_arccos.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arccos._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_arccos.larray.double(), comparison))
 
         # arccos of float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_arccos = ht.arccos(float64_tensor)
         self.assertIsInstance(float64_arccos, ht.DNDarray)
         self.assertEqual(float64_arccos.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_arccos._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_arccos.larray.double(), comparison))
 
         # arccos of value out of domain
         nan_tensor = ht.array([1.2])
         nan_arccos = ht.arccos(nan_tensor)
         self.assertIsInstance(float64_arccos, ht.DNDarray)
         self.assertEqual(nan_arccos.dtype, ht.float32)
-        self.assertTrue(math.isnan(nan_arccos._DNDarray__array.item()))
+        self.assertTrue(math.isnan(nan_arccos.larray.item()))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -52,21 +52,21 @@ class TestTrigonometrics(TestCase):
         float32_arcsin = ht.asin(float32_tensor)
         self.assertIsInstance(float32_arcsin, ht.DNDarray)
         self.assertEqual(float32_arcsin.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arcsin._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_arcsin.larray.double(), comparison))
 
         # arcsin of float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_arcsin = ht.arcsin(float64_tensor)
         self.assertIsInstance(float64_arcsin, ht.DNDarray)
         self.assertEqual(float64_arcsin.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_arcsin._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_arcsin.larray.double(), comparison))
 
         # arcsin of value out of domain
         nan_tensor = ht.array([1.2])
         nan_arcsin = ht.arcsin(nan_tensor)
         self.assertIsInstance(float64_arcsin, ht.DNDarray)
         self.assertEqual(nan_arcsin.dtype, ht.float32)
-        self.assertTrue(math.isnan(nan_arcsin._DNDarray__array.item()))
+        self.assertTrue(math.isnan(nan_arcsin.larray.item()))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -86,28 +86,28 @@ class TestTrigonometrics(TestCase):
         float32_arctan = ht.arctan(float32_tensor)
         self.assertIsInstance(float32_arctan, ht.DNDarray)
         self.assertEqual(float32_arctan.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arctan._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_arctan.larray.double(), comparison))
 
         # arctan of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_arctan = ht.arctan(float64_tensor)
         self.assertIsInstance(float64_arctan, ht.DNDarray)
         self.assertEqual(float64_arctan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_arctan._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_arctan.larray.double(), comparison))
 
         # arctan of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_arctan = ht.arctan(int32_tensor)
         self.assertIsInstance(int32_arctan, ht.DNDarray)
         self.assertEqual(int32_arctan.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arctan._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_arctan.larray.double(), comparison))
 
         # arctan of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_arctan = ht.atan(int64_tensor)
         self.assertIsInstance(int64_arctan, ht.DNDarray)
         self.assertEqual(int64_arctan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_arctan._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int64_arctan.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -124,7 +124,7 @@ class TestTrigonometrics(TestCase):
 
         self.assertIsInstance(float32_arctan2, ht.DNDarray)
         self.assertEqual(float32_arctan2.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_arctan2._DNDarray__array, float32_comparison))
+        self.assertTrue(torch.allclose(float32_arctan2.larray, float32_comparison))
 
         float64_y = torch.randn(30, dtype=torch.float64, device=self.device.torch_device)
         float64_x = torch.randn(30, dtype=torch.float64, device=self.device.torch_device)
@@ -134,7 +134,7 @@ class TestTrigonometrics(TestCase):
 
         self.assertIsInstance(float64_arctan2, ht.DNDarray)
         self.assertEqual(float64_arctan2.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_arctan2._DNDarray__array, float64_comparison))
+        self.assertTrue(torch.allclose(float64_arctan2.larray, float64_comparison))
 
         # Rare Special Case with integers
         int32_x = ht.array([-1, +1, +1, -1])
@@ -171,14 +171,14 @@ class TestTrigonometrics(TestCase):
         float32_degrees = ht.degrees(float32_tensor)
         self.assertIsInstance(float32_degrees, ht.DNDarray)
         self.assertEqual(float32_degrees.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_degrees._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_degrees.larray.double(), comparison))
 
         # degrees with float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_degrees = ht.degrees(float64_tensor)
         self.assertIsInstance(float64_degrees, ht.DNDarray)
         self.assertEqual(float64_degrees.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_degrees._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_degrees.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -200,14 +200,14 @@ class TestTrigonometrics(TestCase):
         float32_deg2rad = ht.deg2rad(float32_tensor)
         self.assertIsInstance(float32_deg2rad, ht.DNDarray)
         self.assertEqual(float32_deg2rad.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_deg2rad._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_deg2rad.larray.double(), comparison))
 
         # deg2rad with float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_deg2rad = ht.deg2rad(float64_tensor)
         self.assertIsInstance(float64_deg2rad, ht.DNDarray)
         self.assertEqual(float64_deg2rad.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_deg2rad._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_deg2rad.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -227,28 +227,28 @@ class TestTrigonometrics(TestCase):
         float32_cos = ht.cos(float32_tensor)
         self.assertIsInstance(float32_cos, ht.DNDarray)
         self.assertEqual(float32_cos.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_cos._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_cos.larray.double(), comparison))
 
         # cosine of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_cos = ht.cos(float64_tensor)
         self.assertIsInstance(float64_cos, ht.DNDarray)
         self.assertEqual(float64_cos.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_cos._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_cos.larray.double(), comparison))
 
         # cosine of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_cos = ht.cos(int32_tensor)
         self.assertIsInstance(int32_cos, ht.DNDarray)
         self.assertEqual(int32_cos.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_cos._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_cos.larray.double(), comparison))
 
         # cosine of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_cos = int64_tensor.cos()
         self.assertIsInstance(int64_cos, ht.DNDarray)
         self.assertEqual(int64_cos.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_cos._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int64_cos.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -268,28 +268,28 @@ class TestTrigonometrics(TestCase):
         float32_cosh = float32_tensor.cosh()
         self.assertIsInstance(float32_cosh, ht.DNDarray)
         self.assertEqual(float32_cosh.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_cosh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_cosh.larray.double(), comparison))
 
         # hyperbolic cosine of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_cosh = ht.cosh(float64_tensor)
         self.assertIsInstance(float64_cosh, ht.DNDarray)
         self.assertEqual(float64_cosh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_cosh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_cosh.larray.double(), comparison))
 
         # hyperbolic cosine of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_cosh = ht.cosh(int32_tensor)
         self.assertIsInstance(int32_cosh, ht.DNDarray)
         self.assertEqual(int32_cosh.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_cosh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_cosh.larray.double(), comparison))
 
         # hyperbolic cosine of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_cosh = ht.cosh(int64_tensor)
         self.assertIsInstance(int64_cosh, ht.DNDarray)
         self.assertEqual(int64_cosh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_cosh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int64_cosh.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -311,14 +311,14 @@ class TestTrigonometrics(TestCase):
         float32_rad2deg = ht.rad2deg(float32_tensor)
         self.assertIsInstance(float32_rad2deg, ht.DNDarray)
         self.assertEqual(float32_rad2deg.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_rad2deg._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_rad2deg.larray.double(), comparison))
 
         # rad2deg with float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_rad2deg = ht.rad2deg(float64_tensor)
         self.assertIsInstance(float64_rad2deg, ht.DNDarray)
         self.assertEqual(float64_rad2deg.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_rad2deg._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_rad2deg.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -340,14 +340,14 @@ class TestTrigonometrics(TestCase):
         float32_radians = ht.radians(float32_tensor)
         self.assertIsInstance(float32_radians, ht.DNDarray)
         self.assertEqual(float32_radians.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_radians._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_radians.larray.double(), comparison))
 
         # radians with float64
         float64_tensor = ht.array(elements, dtype=ht.float64)
         float64_radians = ht.radians(float64_tensor)
         self.assertIsInstance(float64_radians, ht.DNDarray)
         self.assertEqual(float64_radians.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_radians._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_radians.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -367,28 +367,28 @@ class TestTrigonometrics(TestCase):
         float32_sin = float32_tensor.sin()
         self.assertIsInstance(float32_sin, ht.DNDarray)
         self.assertEqual(float32_sin.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_sin._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_sin.larray.double(), comparison))
 
         # sine of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_sin = ht.sin(float64_tensor)
         self.assertIsInstance(float64_sin, ht.DNDarray)
         self.assertEqual(float64_sin.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_sin._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_sin.larray.double(), comparison))
 
         # sine of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_sin = ht.sin(int32_tensor)
         self.assertIsInstance(int32_sin, ht.DNDarray)
         self.assertEqual(int32_sin.dtype, ht.float32)
-        self.assertTrue(torch.allclose(int32_sin._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int32_sin.larray.double(), comparison))
 
         # sine of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_sin = ht.sin(int64_tensor)
         self.assertIsInstance(int64_sin, ht.DNDarray)
         self.assertEqual(int64_sin.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_sin._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int64_sin.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -408,28 +408,28 @@ class TestTrigonometrics(TestCase):
         float32_sinh = float32_tensor.sinh()
         self.assertIsInstance(float32_sinh, ht.DNDarray)
         self.assertEqual(float32_sinh.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_sinh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_sinh.larray.double(), comparison))
 
         # hyperbolic sine of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_sinh = ht.sinh(float64_tensor)
         self.assertIsInstance(float64_sinh, ht.DNDarray)
         self.assertEqual(float64_sinh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_sinh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_sinh.larray.double(), comparison))
 
         # hyperbolic sine of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_sinh = ht.sinh(int32_tensor)
         self.assertIsInstance(int32_sinh, ht.DNDarray)
         self.assertEqual(int32_sinh.dtype, ht.float32)
-        self.assertTrue(torch.allclose(int32_sinh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int32_sinh.larray.double(), comparison))
 
         # hyperbolic sine of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_sinh = ht.sinh(int64_tensor)
         self.assertIsInstance(int64_sinh, ht.DNDarray)
         self.assertEqual(int64_sinh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_sinh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int64_sinh.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -449,28 +449,28 @@ class TestTrigonometrics(TestCase):
         float32_tan = float32_tensor.tan()
         self.assertIsInstance(float32_tan, ht.DNDarray)
         self.assertEqual(float32_tan.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_tan._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_tan.larray.double(), comparison))
 
         # tangent of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_tan = ht.tan(float64_tensor)
         self.assertIsInstance(float64_tan, ht.DNDarray)
         self.assertEqual(float64_tan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_tan._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_tan.larray.double(), comparison))
 
         # tangent of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_tan = ht.tan(int32_tensor)
         self.assertIsInstance(int32_tan, ht.DNDarray)
         self.assertEqual(int32_tan.dtype, ht.float32)
-        self.assertTrue(torch.allclose(int32_tan._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int32_tan.larray.double(), comparison))
 
         # tangent of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_tan = ht.tan(int64_tensor)
         self.assertIsInstance(int64_tan, ht.DNDarray)
         self.assertEqual(int64_tan.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_tan._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int64_tan.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):
@@ -490,28 +490,28 @@ class TestTrigonometrics(TestCase):
         float32_tanh = float32_tensor.tanh()
         self.assertIsInstance(float32_tanh, ht.DNDarray)
         self.assertEqual(float32_tanh.dtype, ht.float32)
-        self.assertTrue(torch.allclose(float32_tanh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float32_tanh.larray.double(), comparison))
 
         # hyperbolic tangent of float64
         float64_tensor = ht.arange(elements, dtype=ht.float64)
         float64_tanh = ht.tanh(float64_tensor)
         self.assertIsInstance(float64_tanh, ht.DNDarray)
         self.assertEqual(float64_tanh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(float64_tanh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(float64_tanh.larray.double(), comparison))
 
         # hyperbolic tangent of ints, automatic conversion to intermediate floats
         int32_tensor = ht.arange(elements, dtype=ht.int32)
         int32_tanh = ht.tanh(int32_tensor)
         self.assertIsInstance(int32_tanh, ht.DNDarray)
         self.assertEqual(int32_tanh.dtype, ht.float32)
-        self.assertTrue(torch.allclose(int32_tanh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int32_tanh.larray.double(), comparison))
 
         # hyperbolic tangent of longs, automatic conversion to intermediate floats
         int64_tensor = ht.arange(elements, dtype=ht.int64)
         int64_tanh = ht.tanh(int64_tensor)
         self.assertIsInstance(int64_tanh, ht.DNDarray)
         self.assertEqual(int64_tanh.dtype, ht.float64)
-        self.assertTrue(torch.allclose(int64_tanh._DNDarray__array.double(), comparison))
+        self.assertTrue(torch.allclose(int64_tanh.larray.double(), comparison))
 
         # check exceptions
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_types.py
+++ b/heat/core/tests/test_types.py
@@ -23,8 +23,8 @@ class TestTypes(TestCase):
         no_value = heat_type()
         self.assertIsInstance(no_value, ht.DNDarray)
         self.assertEqual(no_value.shape, (1,))
-        self.assertEqual((no_value._DNDarray__array == 0).all().item(), 1)
-        self.assertEqual(no_value._DNDarray__array.dtype, torch_type)
+        self.assertEqual((no_value.larray == 0).all().item(), 1)
+        self.assertEqual(no_value.larray.dtype, torch_type)
 
         # check a type constructor with a complex value
         ground_truth = [[3, 2, 1], [4, 5, 6]]
@@ -33,14 +33,14 @@ class TestTypes(TestCase):
         self.assertEqual(elaborate_value.shape, (2, 3))
         self.assertEqual(
             (
-                elaborate_value._DNDarray__array
+                elaborate_value.larray
                 == torch.tensor(ground_truth, dtype=torch_type, device=self.device.torch_device)
             )
             .all()
             .item(),
             1,
         )
-        self.assertEqual(elaborate_value._DNDarray__array.dtype, torch_type)
+        self.assertEqual(elaborate_value.larray.dtype, torch_type)
 
         # check exception when there is more than one parameter
         with self.assertRaises(TypeError):

--- a/heat/core/tiling.py
+++ b/heat/core/tiling.py
@@ -210,7 +210,7 @@ class SplitTiles:
         if arr.comm.rank not in self.tile_locations[key]:
             return None
         arb_slices = self.get_tile_slices(key)
-        return arr._DNDarray__array[tuple(arb_slices)]
+        return arr.larray[tuple(arb_slices)]
 
     def get_tile_slices(self, key):
         arr = self.__DNDarray
@@ -426,20 +426,20 @@ class SquareDiagTiles:
         if arr.gshape[0] < arr.gshape[1]:
             row_inds_hold = []
             for i in torch.nonzero(
-                input=torch.tensor(row_inds, device=arr._DNDarray__array.device), as_tuple=False
+                input=torch.tensor(row_inds, device=arr.larray.device), as_tuple=False
             ).flatten():
                 row_inds_hold.append(row_inds[i.item()])
             row_inds = row_inds_hold
 
         tile_map = torch.zeros(
-            [len(row_inds), len(col_inds), 3], dtype=torch.int, device=arr._DNDarray__array.device
+            [len(row_inds), len(col_inds), 3], dtype=torch.int, device=arr.larray.device
         )
         # if arr.split == 0:  # adjust the 1st dim to be the cumsum
         col_inds = [0] + col_inds[:-1]
-        col_inds = torch.tensor(col_inds, device=arr._DNDarray__array.device).cumsum(dim=0)
+        col_inds = torch.tensor(col_inds, device=arr.larray.device).cumsum(dim=0)
         # if arr.split == 1:  # adjust the 0th dim to be the cumsum
         row_inds = [0] + row_inds[:-1]
-        row_inds = torch.tensor(row_inds, device=arr._DNDarray__array.device).cumsum(dim=0)
+        row_inds = torch.tensor(row_inds, device=arr.larray.device).cumsum(dim=0)
 
         for num, c in enumerate(col_inds):  # set columns
             tile_map[:, num, 1] = c
@@ -498,13 +498,11 @@ class SquareDiagTiles:
             r += 1
         # if the 1st dim is > 0th dim then in split=1 the cols need to be extended
         col_proc_ind = torch.cumsum(
-            torch.tensor(col_per_proc_list, device=arr._DNDarray__array.device), dim=0
+            torch.tensor(col_per_proc_list, device=arr.larray.device), dim=0
         )
         for pr in range(arr.comm.size):
             lshape_cumsum = torch.cumsum(lshape_map[..., 1], dim=0)
-            col_cumsum = torch.cumsum(
-                torch.tensor(col_inds, device=arr._DNDarray__array.device), dim=0
-            )
+            col_cumsum = torch.cumsum(torch.tensor(col_inds, device=arr.larray.device), dim=0)
             diff = lshape_cumsum[pr] - col_cumsum[col_proc_ind[pr] - 1]
             if diff > 0 and pr <= last_diag_pr:
                 col_per_proc_list[pr] += 1
@@ -623,7 +621,7 @@ class SquareDiagTiles:
         diag_crossings[-1] = (
             diag_crossings[-1] if diag_crossings[-1] <= min(arr.gshape) else min(arr.gshape)
         )
-        dev = arr._DNDarray__array.device
+        dev = arr.larray.device
         diag_crossings = torch.cat((torch.tensor([0], device=dev), diag_crossings), dim=0)
         # create the tile columns sizes, saved to list
         col_inds = []
@@ -646,7 +644,7 @@ class SquareDiagTiles:
         rows which are chunked evenly into `tiles_per_proc` rows/
         """
         nz = torch.nonzero(
-            input=torch.tensor(row_inds, device=arr._DNDarray__array.device) == 0, as_tuple=False
+            input=torch.tensor(row_inds, device=arr.larray.device) == 0, as_tuple=False
         )
         for i in range(last_diag_pr.item() + 1, arr.comm.size):
             # loop over all of the rest of the processes
@@ -918,7 +916,7 @@ class SquareDiagTiles:
         """
         arr = self.__DNDarray
         tile_map = self.__tile_map
-        local_arr = arr._DNDarray__array
+        local_arr = arr.larray
         if not isinstance(key, (int, tuple, slice)):
             raise TypeError(
                 "key must be an int, tuple, or slice, is currently {}".format(type(key))
@@ -1135,7 +1133,7 @@ class SquareDiagTiles:
             self.__tile_map = torch.zeros(
                 (self.tile_rows, self.tile_columns, 3),
                 dtype=torch.int,
-                device=match_dnd._DNDarray__array.device,
+                device=match_dnd.larray.device,
             )
             for i in range(self.tile_rows):
                 self.__tile_map[..., 0][i] = self.__row_inds[i]
@@ -1182,7 +1180,7 @@ class SquareDiagTiles:
             self.__row_per_proc_list = []
             st = 0
             rows_per = torch.tensor(
-                rows_per + [base_dnd.shape[0]], device=tiles_to_match.arr._DNDarray__array.device
+                rows_per + [base_dnd.shape[0]], device=tiles_to_match.arr.larray.device
             )
             for i in range(base_dnd.comm.size):
                 # get the amount of data on each process, get the number of rows with
@@ -1197,7 +1195,7 @@ class SquareDiagTiles:
             self.__tile_map = torch.zeros(
                 (self.tile_rows, self.tile_columns, 3),
                 dtype=torch.int,
-                device=tiles_to_match.arr._DNDarray__array.device,
+                device=tiles_to_match.arr.larray.device,
             )
             for i in range(self.tile_rows):
                 self.__tile_map[..., 0][i] = self.__row_inds[i]

--- a/heat/graph/laplacian.py
+++ b/heat/graph/laplacian.py
@@ -70,11 +70,9 @@ class Laplacian:
         degree.resplit_(axis=None)
         # Find stand-alone vertices with no connections
         temp = torch.ones(
-            degree.shape, dtype=degree._DNDarray__array.dtype, device=degree.device.torch_device
+            degree.shape, dtype=degree.larray.dtype, device=degree.device.torch_device
         )
-        degree._DNDarray__array = torch.where(
-            degree._DNDarray__array == 0, temp, degree._DNDarray__array
-        )
+        degree.larray = torch.where(degree.larray == 0, temp, degree.larray)
         L = A / ht.sqrt(ht.expand_dims(degree, axis=1))
         L = L / ht.sqrt(ht.expand_dims(degree, axis=0))
         L = L * (-1.0)

--- a/heat/graph/tests/test_laplacian.py
+++ b/heat/graph/tests/test_laplacian.py
@@ -11,8 +11,8 @@ class TestLaplacian(TestCase):
         size = ht.communication.MPI_WORLD.size
         rank = ht.communication.MPI_WORLD.rank
         X = ht.ones((size * 2, 4), split=0)
-        X._DNDarray__array[0, :] *= rank
-        X._DNDarray__array[1, :] *= rank + 0.5
+        X.larray[0, :] *= rank
+        X.larray[1, :] *= rank + 0.5
 
         L = ht.graph.Laplacian(lambda x: ht.spatial.cdist(x, quadratic_expansion=True))
         res = L.construct(X)

--- a/heat/naive_bayes/gaussianNB.py
+++ b/heat/naive_bayes/gaussianNB.py
@@ -349,9 +349,7 @@ class GaussianNB(ht.ClassificationMixin, ht.BaseEstimator):
             if y_i in classes:
                 i = ht.where(classes == y_i).item()
             else:
-                classes_ext = torch.cat(
-                    (classes._DNDarray__array, y_i._DNDarray__array.unsqueeze(0))
-                )
+                classes_ext = torch.cat((classes._DNDarray__array, y_i.larray.unsqueeze(0)))
                 i = torch.argsort(classes_ext)[-1].item()
             where_y_i = ht.where(y == y_i)
             X_i = X[where_y_i, :]
@@ -390,7 +388,7 @@ class GaussianNB(ht.ClassificationMixin, ht.BaseEstimator):
         Returns ht.DNDarray joint_log_likelihood(n_samples, n_classes).
         """
 
-        jll_size = self.classes_._DNDarray__array.numel()
+        jll_size = self.classes_.larray.numel()
         jll_shape = (X.shape[0], jll_size)
         joint_log_likelihood = ht.empty(jll_shape, dtype=X.dtype, split=X.split, device=X.device)
         for i in range(jll_size):
@@ -518,7 +516,7 @@ class GaussianNB(ht.ClassificationMixin, ht.BaseEstimator):
         log_prob_x_shape = (jll.gshape[0], 1)
         log_prob_x = ht.empty(log_prob_x_shape, dtype=jll.dtype, split=jll.split, device=jll.device)
         # normalize by P(x) = P(f_1, ..., f_n)
-        log_prob_x._DNDarray__array = self.logsumexp(jll, axis=1)._DNDarray__array.unsqueeze(1)
+        log_prob_x.larray = self.logsumexp(jll, axis=1).larray.unsqueeze(1)
         return jll - log_prob_x
 
     def predict_proba(self, X):

--- a/heat/regression/lasso.py
+++ b/heat/regression/lasso.py
@@ -100,7 +100,7 @@ class Lasso(ht.RegressionMixin, ht.BaseEstimator):
         yest : HeAT tensor, shape (1,)
             Thresholded model data
         """
-        return ht.sqrt((ht.mean((gt - yest) ** 2)))._DNDarray__array.item()
+        return ht.sqrt((ht.mean((gt - yest) ** 2))).larray.item()
 
     def fit(self, X, y):
         """
@@ -135,10 +135,10 @@ class Lasso(ht.RegressionMixin, ht.BaseEstimator):
             # Looping through each coordinate
             for j in range(n):
 
-                X_j = ht.array(X._DNDarray__array[:, j : j + 1], is_split=0)
+                X_j = ht.array(X.larray[:, j : j + 1], is_split=0)
 
                 y_est = X @ theta
-                theta_j = theta._DNDarray__array[j].item()
+                theta_j = theta.larray[j].item()
 
                 rho = (X_j * (y - y_est + theta_j * X_j)).mean()
 

--- a/heat/spatial/tests/test_distances.py
+++ b/heat/spatial/tests/test_distances.py
@@ -209,7 +209,7 @@ class TestDistances(TestCase):
         for i in range(n):
             A[2 * i, :] = A[2 * i, :] * (2 * i)
             A[2 * i + 1, :] = A[2 * i + 1, :] * (2 * i + 1)
-        res = torch.cdist(A._DNDarray__array, A._DNDarray__array)
+        res = torch.cdist(A.larray, A.larray)
 
         A = ht.ones((n * 2, 6), dtype=ht.float32, split=0)
         for i in range(n):
@@ -226,7 +226,7 @@ class TestDistances(TestCase):
         for i in range(n):
             A[2 * i, :] = A[2 * i, :] * (2 * i)
             A[2 * i + 1, :] = A[2 * i + 1, :] * (2 * i + 1)
-        res = torch.cdist(A._DNDarray__array, A._DNDarray__array)
+        res = torch.cdist(A.larray, A.larray)
 
         A = ht.ones((n * 2, 6), dtype=ht.float32, split=0)
         for i in range(n):


### PR DESCRIPTION
## Description

Introduction of property `larray`, which allows access to the underlying local torch tensor (`_DNDarray__array` / `__array` attribute of `DNDarray`).
For the setter, I included a warning as requested in the issue.

Consequently, I replaced all usages of `_DNDarray__array` within the project space with `larray`. 

As I specified torch.tensor as the only valid dtype for this attribute, I had to adapt function `average` in statistics, simply wrapping a float assignment into a tensor containing that specific float (just one line (328) modified).

Issue/s resolved: #538

## Changes proposed:
- Introduction of property `larray` in dndarray
- replacement of all usages of `_DNDarray__array` with `larray` within the project space
- Corresponding tests (especially for the setter)
- Minimal adaption of function `average` in statistics (line 328)

## Type of change
- New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no (, not after the presented modification of `average` in statistics. Without the wrapping, a TypeError is thrown as specified in the setter of `larray`, which expected a torch.tensor but got a float (in the corresponding tests) instead).

