### PR TITLE
Features/590 nbytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Pending additions
 ## New features
+- [#683](https://github.com/helmholtz-analytics/heat/pull/683) New properties: nbytes, gnbytes, lnbytes
 ### Manipulations
 ### Statistical Functions
 ### Linear Algebra

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -113,6 +113,18 @@ class DNDarray:
         return self.__gshape
 
     @property
+    def nbytes(self):
+        """
+        Equivalent to property gnbytes.
+
+        Returns
+        -------
+        global_number_of_bytes : int
+            number of bytes consumed by the global tensor
+        """
+        return self._DNDarray__array.element_size() * self.size
+
+    @property
     def numdims(self):
         """
         Returns
@@ -148,6 +160,17 @@ class DNDarray:
         return torch.prod(torch.tensor(self.gshape, device=self.device.torch_device)).item()
 
     @property
+    def gnbytes(self):
+        """
+
+        Returns
+        -------
+        global_number_of_bytes : int
+            number of bytes consumed by the global tensor
+        """
+        return self.nbytes
+
+    @property
     def gnumel(self):
         """
 
@@ -157,6 +180,17 @@ class DNDarray:
             number of total elements of the tensor
         """
         return self.size
+
+    @property
+    def lnbytes(self):
+        """
+
+        Returns
+        -------
+        local_number_of_bytes : int
+            number of bytes consumed by the local tensor
+        """
+        return self._DNDarray__array.element_size() * self._DNDarray__array.nelement()
 
     @property
     def lnumel(self):

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -116,6 +116,7 @@ class DNDarray:
     def nbytes(self):
         """
         Equivalent to property gnbytes.
+        Note: Does not include memory consumed by non-element attributes of the DNDarray object.
 
         Returns
         -------
@@ -162,6 +163,7 @@ class DNDarray:
     @property
     def gnbytes(self):
         """
+        Note: Does not include memory consumed by non-element attributes of the DNDarray object.
 
         Returns
         -------
@@ -184,6 +186,7 @@ class DNDarray:
     @property
     def lnbytes(self):
         """
+        Note: Does not include memory consumed by non-element attributes of the DNDarray object.
 
         Returns
         -------

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -493,6 +493,85 @@ class TestDNDarray(TestCase):
         with self.assertRaises(TypeError):
             ht.array([True]) << 2
 
+    def test_nbytes(self):
+        # undistributed case
+
+        # integer
+        x_uint8 = ht.arange(6 * 7 * 8, dtype=ht.uint8).reshape((6, 7, 8))
+        x_int8 = ht.arange(6 * 7 * 8, dtype=ht.int8).reshape((6, 7, 8))
+        x_int16 = ht.arange(6 * 7 * 8, dtype=ht.int16).reshape((6, 7, 8))
+        x_int32 = ht.arange(6 * 7 * 8, dtype=ht.int32).reshape((6, 7, 8))
+        x_int64 = ht.arange(6 * 7 * 8, dtype=ht.int64).reshape((6, 7, 8))
+
+        # float
+        x_float32 = ht.arange(6 * 7 * 8, dtype=ht.float32).reshape((6, 7, 8))
+        x_float64 = ht.arange(6 * 7 * 8, dtype=ht.float64).reshape((6, 7, 8))
+
+        # bool
+        x_bool = ht.arange(6 * 7 * 8, dtype=ht.bool).reshape((6, 7, 8))
+
+        self.assertEqual(x_uint8.nbytes, 336 * 1)
+        self.assertEqual(x_int8.nbytes, 336 * 1)
+        self.assertEqual(x_int16.nbytes, 336 * 2)
+        self.assertEqual(x_int32.nbytes, 336 * 4)
+        self.assertEqual(x_int64.nbytes, 336 * 8)
+
+        self.assertEqual(x_float32.nbytes, 336 * 4)
+        self.assertEqual(x_float64.nbytes, 336 * 8)
+
+        self.assertEqual(x_bool.nbytes, 336 * 1)
+
+        # equivalent function gnbytes
+        self.assertEqual(x_uint8.nbytes, x_uint8.gnbytes)
+        self.assertEqual(x_int8.nbytes, x_int8.gnbytes)
+        self.assertEqual(x_int16.nbytes, x_int16.gnbytes)
+        self.assertEqual(x_int32.nbytes, x_int32.gnbytes)
+        self.assertEqual(x_int64.nbytes, x_int64.gnbytes)
+
+        self.assertEqual(x_float32.nbytes, x_float32.gnbytes)
+        self.assertEqual(x_float64.nbytes, x_float64.gnbytes)
+
+        self.assertEqual(x_bool.nbytes, x_bool.gnbytes)
+
+        # distributed case
+
+        # integer
+        x_uint8_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.uint8)
+        x_int8_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.int8)
+        x_int16_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.int16)
+        x_int32_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.int32)
+        x_int64_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.int64)
+
+        # float
+        x_float32_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.float32)
+        x_float64_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.float64)
+
+        # bool
+        x_bool_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.bool)
+
+        self.assertEqual(x_uint8_d.nbytes, 336 * 1)
+        self.assertEqual(x_int8_d.nbytes, 336 * 1)
+        self.assertEqual(x_int16_d.nbytes, 336 * 2)
+        self.assertEqual(x_int32_d.nbytes, 336 * 4)
+        self.assertEqual(x_int64_d.nbytes, 336 * 8)
+
+        self.assertEqual(x_float32_d.nbytes, 336 * 4)
+        self.assertEqual(x_float64_d.nbytes, 336 * 8)
+
+        self.assertEqual(x_bool_d.nbytes, 336 * 1)
+
+        # equivalent function gnbytes
+        self.assertEqual(x_uint8_d.nbytes, x_uint8_d.gnbytes)
+        self.assertEqual(x_int8_d.nbytes, x_int8_d.gnbytes)
+        self.assertEqual(x_int16_d.nbytes, x_int16_d.gnbytes)
+        self.assertEqual(x_int32_d.nbytes, x_int32_d.gnbytes)
+        self.assertEqual(x_int64_d.nbytes, x_int64_d.gnbytes)
+
+        self.assertEqual(x_float32_d.nbytes, x_float32_d.gnbytes)
+        self.assertEqual(x_float64_d.nbytes, x_float64_d.gnbytes)
+
+        self.assertEqual(x_bool_d.nbytes, x_bool_d.gnbytes)
+
     def test_ndim(self):
         a = ht.empty([2, 3, 3, 2])
         self.assertEqual(a.ndim, 4)

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -482,6 +482,61 @@ class TestDNDarray(TestCase):
         self.assertTrue(torch.all(a._DNDarray__array[3:7:2, 2:5:2] == 1))
         self.assertEqual(a.lloc[3:7:2, 2:5:2].dtype, torch.float32)
 
+    def test_lnbytes(self):
+        # undistributed case
+
+        # integer
+        x_uint8 = ht.arange(6 * 7 * 8, dtype=ht.uint8).reshape((6, 7, 8))
+        x_int8 = ht.arange(6 * 7 * 8, dtype=ht.int8).reshape((6, 7, 8))
+        x_int16 = ht.arange(6 * 7 * 8, dtype=ht.int16).reshape((6, 7, 8))
+        x_int32 = ht.arange(6 * 7 * 8, dtype=ht.int32).reshape((6, 7, 8))
+        x_int64 = ht.arange(6 * 7 * 8, dtype=ht.int64).reshape((6, 7, 8))
+
+        # float
+        x_float32 = ht.arange(6 * 7 * 8, dtype=ht.float32).reshape((6, 7, 8))
+        x_float64 = ht.arange(6 * 7 * 8, dtype=ht.float64).reshape((6, 7, 8))
+
+        # bool
+        x_bool = ht.arange(6 * 7 * 8, dtype=ht.bool).reshape((6, 7, 8))
+
+        self.assertEqual(x_uint8.lnbytes, x_uint8.gnbytes)
+        self.assertEqual(x_int8.lnbytes, x_int8.gnbytes)
+        self.assertEqual(x_int16.lnbytes, x_int16.gnbytes)
+        self.assertEqual(x_int32.lnbytes, x_int32.gnbytes)
+        self.assertEqual(x_int64.lnbytes, x_int64.gnbytes)
+
+        self.assertEqual(x_float32.lnbytes, x_float32.gnbytes)
+        self.assertEqual(x_float64.lnbytes, x_float64.gnbytes)
+
+        self.assertEqual(x_bool.lnbytes, x_bool.gnbytes)
+
+        # distributed case
+
+        # integer
+        x_uint8_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.uint8)
+        x_int8_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.int8)
+        x_int16_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.int16)
+        x_int32_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.int32)
+        x_int64_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.int64)
+
+        # float
+        x_float32_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.float32)
+        x_float64_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.float64)
+
+        # bool
+        x_bool_d = ht.arange(6 * 7 * 8, split=0, dtype=ht.bool)
+
+        self.assertEqual(x_uint8_d.lnbytes, x_uint8_d.lnumel * 1)
+        self.assertEqual(x_int8_d.lnbytes, x_int8_d.lnumel * 1)
+        self.assertEqual(x_int16_d.lnbytes, x_int16_d.lnumel * 2)
+        self.assertEqual(x_int32_d.lnbytes, x_int32_d.lnumel * 4)
+        self.assertEqual(x_int64_d.lnbytes, x_int64_d.lnumel * 8)
+
+        self.assertEqual(x_float32_d.lnbytes, x_float32_d.lnumel * 4)
+        self.assertEqual(x_float64_d.lnbytes, x_float64_d.lnumel * 8)
+
+        self.assertEqual(x_bool_d.lnbytes, x_bool_d.lnumel * 1)
+
     def test_lshift(self):
         int_tensor = ht.array([[0, 1], [2, 3]])
         int_result = ht.array([[0, 4], [8, 12]])


### PR DESCRIPTION
## Description

Implementation of properties `nbytes, gnbytes, lnbytes` which return the memory consumed by the underlying tensor.
`nbytes` is equivalent to `gnbytes`, `lnbytes` refers to the local torch tensor.

Numpy analogue: https://numpy.org/doc/stable/reference/generated/numpy.ndarray.nbytes.html


Issue/s resolved: #590

## Changes proposed:
- Introduction of properties `nbytes, gnbytes, lnbytes`
- Implementation of corresponding tests

## Type of change
- New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

