### PR TITLE
fix reshape boolean bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.5.1
+- [#684](https://github.com/helmholtz-analytics/heat/pull/684) Bug fix: distributed `reshape` does not work on booleans.
+
 # v0.5.0
 
 - [#488](https://github.com/helmholtz-analytics/heat/pull/488) Enhancement: Rework of the test device selection.

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1314,9 +1314,9 @@ def reshape(a, shape, new_split=None):
         """
         Compute the send order, counts, and displacements.
         """
-        shape1 = torch.tensor(shape1, dtype=tdtype, device=tdevice)
-        lshape1 = torch.tensor(lshape1, dtype=tdtype, device=tdevice)
-        shape2 = torch.tensor(shape2, dtype=tdtype, device=tdevice)
+        shape1 = torch.tensor(shape1, dtype=torch.int)
+        lshape1 = torch.tensor(lshape1, dtype=torch.int)
+        shape2 = torch.tensor(shape2, dtype=torch.int)
         # constants
         width = torch.prod(lshape1[axis1:], dtype=torch.int)
         height = torch.prod(lshape1[:axis1], dtype=torch.int)
@@ -1331,7 +1331,7 @@ def reshape(a, shape, new_split=None):
         mask = mask.flatten()
 
         # Compute return values
-        counts = torch.zeros(comm.size, dtype=torch.int, device=tdevice)
+        counts = torch.zeros(comm.size, dtype=torch.int)
         displs = torch.zeros_like(counts)
         argsort = torch.empty_like(mask, dtype=torch.long)
         plz = 0

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1431,9 +1431,9 @@ class TestManipulations(TestCase):
         self.assertEqual(reshaped.split, 1)
         self.assertTrue(ht.equal(reshaped, result))
 
-        x = ht.arange(4, split=0, dtype=ht.bool)
+        a = ht.arange(4, split=0, dtype=ht.bool)
         result = ht.array([[False, True], [True, True]], split=0, dtype=ht.bool)
-        x.reshape((2, 2))
+        reshaped = a.reshape((2, 2))
 
         self.assertEqual(reshaped.size, result.size)
         self.assertEqual(reshaped.shape, result.shape)

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1431,6 +1431,15 @@ class TestManipulations(TestCase):
         self.assertEqual(reshaped.split, 1)
         self.assertTrue(ht.equal(reshaped, result))
 
+        x = ht.arange(4, split=0, dtype=ht.bool)
+        result = ht.array([[False, True], [True, True]], split=0, dtype=ht.bool)
+        x.reshape((2, 2))
+
+        self.assertEqual(reshaped.size, result.size)
+        self.assertEqual(reshaped.shape, result.shape)
+        self.assertEqual(reshaped.device, result.device)
+        self.assertTrue(ht.equal(reshaped, result))
+
         # exceptions
         with self.assertRaises(ValueError):
             ht.reshape(ht.zeros((4, 3)), (5, 7))


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Fixes the reshape bug on booleans and on floats in some cases. Some tensors were using the dtype of the input by mistake. 

Issue/s resolved: #682 
Issue/s resolved: #654

## Changes proposed:
- fix reshape on booleans

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

Bug fix

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
