### PR TITLE
Features/681 balanced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## New features
 - [#680](https://github.com/helmholtz-analytics/heat/pull/680) New property: larray
 - [#683](https://github.com/helmholtz-analytics/heat/pull/683) New properties: nbytes, gnbytes, lnbytes
+- [#687](https://github.com/helmholtz-analytics/heat/pull/687) New DNDarray property: balanced
 ### Manipulations
 ### Statistical Functions
 ### Linear Algebra

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -38,13 +38,13 @@ def __binary_op(operation, t1, t2, out=None):
     """
     if np.isscalar(t1):
         try:
-            t1 = factories.array([t1], balanced=True)
+            t1 = factories.array([t1])
         except (ValueError, TypeError):
             raise TypeError("Data type not supported, input was {}".format(type(t1)))
 
         if np.isscalar(t2):
             try:
-                t2 = factories.array([t2], balanced=True)
+                t2 = factories.array([t2])
             except (ValueError, TypeError):
                 raise TypeError(
                     "Only numeric scalars are supported, but input was {}".format(type(t2))
@@ -71,7 +71,7 @@ def __binary_op(operation, t1, t2, out=None):
     elif isinstance(t1, dndarray.DNDarray):
         if np.isscalar(t2):
             try:
-                t2 = factories.array([t2], device=t1.device, balanced=True)
+                t2 = factories.array([t2], device=t1.device)
                 output_shape = t1.shape
                 output_split = t1.split
                 output_device = t1.device
@@ -82,23 +82,11 @@ def __binary_op(operation, t1, t2, out=None):
         elif isinstance(t2, dndarray.DNDarray):
             if t1.split is None:
                 t1 = factories.array(
-                    t1,
-                    split=t2.split,
-                    copy=False,
-                    comm=t1.comm,
-                    balanced=True,
-                    device=t1.device,
-                    ndmin=-t2.ndim,
+                    t1, split=t2.split, copy=False, comm=t1.comm, device=t1.device, ndmin=-t2.ndim
                 )
             elif t2.split is None:
                 t2 = factories.array(
-                    t2,
-                    split=t1.split,
-                    copy=False,
-                    comm=t2.comm,
-                    balanced=True,
-                    device=t2.device,
-                    ndmin=-t1.ndim,
+                    t2, split=t1.split, copy=False, comm=t2.comm, device=t2.device, ndmin=-t1.ndim
                 )
             elif t1.split != t2.split:
                 # It is NOT possible to perform binary operations on tensors with different splits, e.g. split=0
@@ -144,6 +132,7 @@ def __binary_op(operation, t1, t2, out=None):
     if t1.balanced and t2.balanced:
         pass
     elif not t1.balanced and t1.split is not None or not t2.balanced and t2.split is not None:
+        # TODO: fine tuning. Allow imbalanced operation if/when it makes sense
         raise NotImplementedError(
             "Not implemented for imbalanced dndarray: t1.balanced is {}, t2.balanced is {}".format(
                 t1.balanced, t2.balanced

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -5,8 +5,9 @@ import warnings
 
 from .communication import MPI, MPI_WORLD
 from . import factories
-from . import stride_tricks
 from . import sanitation
+from . import statistics
+from . import stride_tricks
 from . import dndarray
 from . import types
 
@@ -419,6 +420,10 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
         balanced = True
         if x.comm.is_distributed():
             x.comm.Allreduce(MPI.IN_PLACE, partial, reduction_op)
+
+    ARG_OPS = [statistics.MPI_ARGMAX, statistics.MPI_ARGMIN]
+    if reduction_op in ARG_OPS:
+        partial = partial.chunk(2)[-1].type(torch.int64)
 
     # if reduction_op is a Boolean operation, then resulting tensor is bool
     tensor_type = bool if reduction_op in __BOOLEAN_OPS else partial.dtype

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -412,6 +412,7 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
         axis = (axis,)
     keepdim = kwargs.get("keepdim")
     split = x.split
+    balanced = x.balanced
 
     # if local tensor is empty, replace it with the identity element
     if 0 in x.lshape and (axis is None or (x.split in axis)):
@@ -432,6 +433,7 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
     if axis is None:
         partial = partial_op(partial).reshape(-1)
         output_shape = (1,)
+        balanced = True
     else:
         output_shape = x.gshape
         for dim in axis:
@@ -458,6 +460,7 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
     # perform a reduction operation in case the tensor is distributed across the reduction axis
     if x.split is not None and (axis is None or (x.split in axis)):
         split = None
+        balanced = True
         if x.comm.is_distributed():
             x.comm.Allreduce(MPI.IN_PLACE, partial, reduction_op)
 
@@ -480,4 +483,5 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
         split=split,
         device=x.device,
         comm=x.comm,
+        balanced=balanced,
     )

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -388,13 +388,13 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
     """
     # perform sanitation
     sanitation.sanitize_in(x)
-    out = kwargs.get("out")
 
     # no further checking needed, sanitize axis will raise the proper exceptions
     axis = stride_tricks.sanitize_axis(x.shape, kwargs.get("axis"))
     if isinstance(axis, int):
         axis = (axis,)
     keepdim = kwargs.get("keepdim")
+    out = kwargs.get("out")
     split = x.split
     balanced = x.balanced
 
@@ -409,7 +409,6 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
             dtype=x.dtype.torch_type(),
             device=x.device.torch_device,
         )
-
     else:
         partial = x._DNDarray__array
 
@@ -434,7 +433,6 @@ def __reduce_op(x, partial_op, reduction_op, neutral=None, **kwargs):
                 lshape_losedim = (partial.shape[0],) + lshape_losedim[1:]
             if len(lshape_losedim) > 0:
                 partial = partial.reshape(lshape_losedim)
-
     # perform a reduction operation in case the tensor is distributed across the reduction axis
     if x.split is not None and (axis is None or (x.split in axis)):
         split = None

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -128,18 +128,6 @@ def __binary_op(operation, t1, t2, out=None):
     else:
         raise NotImplementedError("Not implemented for non scalar")
 
-    # check `balanced` attribute
-    if t1.balanced and t2.balanced:
-        pass
-    elif not t1.balanced and t1.split is not None or not t2.balanced and t2.split is not None:
-        # TODO: fine tuning. Allow imbalanced operation if/when it makes sense
-        raise NotImplementedError(
-            "Not implemented for imbalanced dndarray: t1.balanced is {}, t2.balanced is {}".format(
-                t1.balanced, t2.balanced
-            )
-        )
-    output_balanced = True
-
     # sanitize output
     if out is not None:
         sanitation.sanitize_out(out, output_shape, output_split, output_device)
@@ -176,7 +164,7 @@ def __binary_op(operation, t1, t2, out=None):
         output_split,
         output_device,
         output_comm,
-        output_balanced,
+        balanced=None,
     )
 
 

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -338,7 +338,13 @@ def __local_op(operation, x, out, no_cast=False, **kwargs):
     if out is None:
         result = operation(x._DNDarray__array.type(torch_type), **kwargs)
         return dndarray.DNDarray(
-            result, x.gshape, types.canonical_heat_type(result.dtype), x.split, x.device, x.comm
+            result,
+            x.gshape,
+            types.canonical_heat_type(result.dtype),
+            x.split,
+            x.device,
+            x.comm,
+            x.balanced,
         )
 
     # output buffer writing requires a bit more work

--- a/heat/core/constants.py
+++ b/heat/core/constants.py
@@ -14,29 +14,3 @@ inf = Inf = Infty = Infinity = INF
 nan = NaN = NAN
 pi = PI
 e = Euler = E
-
-
-def sanitize_infinity(dtype):
-    """
-    Returns largest possible value for the specified dtype.
-
-    Parameters:
-    -----------
-    dtype: torch dtype
-
-    Returns:
-    --------
-    large_enough: largest possible value for the given dtype
-    """
-    if dtype is torch.int8:
-        large_enough = (1 << 7) - 1
-    elif dtype is torch.int16:
-        large_enough = (1 << 15) - 1
-    elif dtype is torch.int32:
-        large_enough = (1 << 31) - 1
-    elif dtype is torch.int64:
-        large_enough = (1 << 63) - 1
-    else:
-        large_enough = float("inf")
-
-    return large_enough

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1804,8 +1804,8 @@ class DNDarray:
         balanced = 1 if test_lshape == self.lshape else 0
 
         out = self.comm.allreduce(balanced, MPI.SUM)
-        self.__balanced = True if out == self.comm.size else False
-        return self.balanced
+        balanced = True if out == self.comm.size else False
+        return balanced
 
     def is_distributed(self):
         """

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -76,6 +76,7 @@ class DNDarray:
         self.__split = split
         self.__device = device
         self.__comm = comm
+        self.__balanced = False
         self.__ishalo = False
         self.__halo_next = None
         self.__halo_prev = None
@@ -89,12 +90,8 @@ class DNDarray:
             self.__array = self.__array.to(devices.sanitize_device(self.__device).torch_device)
 
     @property
-    def halo_next(self):
-        return self.__halo_next
-
-    @property
-    def halo_prev(self):
-        return self.__halo_prev
+    def balanced(self):
+        return self.__balanced
 
     @property
     def comm(self):
@@ -113,6 +110,14 @@ class DNDarray:
         return self.__gshape
 
     @property
+    def halo_next(self):
+        return self.__halo_next
+
+    @property
+    def halo_prev(self):
+        return self.__halo_prev
+
+    @property
     def nbytes(self):
         """
         Equivalent to property gnbytes.
@@ -126,6 +131,16 @@ class DNDarray:
         return self._DNDarray__array.element_size() * self.size
 
     @property
+    def ndim(self):
+        """
+        Returns
+        -------
+        number_of_dimensions : int
+            the number of dimensions of the DNDarray
+        """
+        return len(self.__gshape)
+
+    @property
     def numdims(self):
         """
         Returns
@@ -137,16 +152,6 @@ class DNDarray:
           `numdims` will be removed in HeAT 1.0.0, it is replaced by `ndim` because the latter is numpy API compliant.
         """
         warnings.warn("numdims is deprecated, use ndim instead", DeprecationWarning)
-        return len(self.__gshape)
-
-    @property
-    def ndim(self):
-        """
-        Returns
-        -------
-        number_of_dimensions : int
-            the number of dimensions of the DNDarray
-        """
         return len(self.__gshape)
 
     @property

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -165,7 +165,6 @@ class DNDarray:
                 "might corrupt/invalidate the metadata in a DNDarray instance"
             )
         self.__array = array
-        # TODO: implement __update_metadata() for gshape, lshape, dtype
 
     @property
     def nbytes(self):

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -2628,10 +2628,7 @@ class DNDarray:
                 ]
             self.__balanced = True
         else:
-            if not isinstance(target_map, torch.Tensor):
-                raise TypeError(
-                    "target_map must be a torch.Tensor, currently {}".format(type(target_map))
-                )
+            sanitation.sanitize_in_tensor(target_map)
             if target_map[..., self.split].sum() != self.shape[self.split]:
                 raise ValueError(
                     "Sum along the split axis of the target map must be equal to the "
@@ -2643,6 +2640,7 @@ class DNDarray:
                         (self.comm.size, len(self.gshape)), target_map.shape
                     )
                 )
+            # no info on balanced status
             self.__balanced = False
         lshape_cumsum = torch.cumsum(lshape_map[..., self.split], dim=0)
         chunk_cumsum = torch.cat(
@@ -2727,7 +2725,7 @@ class DNDarray:
         send_amt : int, single element torch.Tensor
             Amount of data to be sent by the sending process
         rcv_pr : int, single element torch.Tensor
-            Recieving process
+            Receiving process
         snd_dtype : torch.type
             Torch type of the data in question
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -69,14 +69,14 @@ class DNDarray:
         The communications object for sending and recieving data
     """
 
-    def __init__(self, array, gshape, dtype, split, device, comm):
+    def __init__(self, array, gshape, dtype, split, device, comm, balanced):
         self.__array = array
         self.__gshape = gshape
         self.__dtype = dtype
         self.__split = split
         self.__device = device
         self.__comm = comm
-        self.__balanced = False
+        self.__balanced = balanced
         self.__ishalo = False
         self.__halo_next = None
         self.__halo_prev = None

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -772,7 +772,9 @@ class DNDarray:
         dtype = types.canonical_heat_type(dtype)
         casted_array = self.__array.type(dtype.torch_type())
         if copy:
-            return DNDarray(casted_array, self.shape, dtype, self.split, self.device, self.comm)
+            return DNDarray(
+                casted_array, self.shape, dtype, self.split, self.device, self.comm, self.balanced
+            )
 
         self.__array = casted_array
         self.__dtype = dtype
@@ -1537,7 +1539,13 @@ class DNDarray:
                     new_split = self.split
 
                 return DNDarray(
-                    self.__array[key], gout, self.dtype, new_split, self.device, self.comm
+                    self.__array[key],
+                    gout,
+                    self.dtype,
+                    new_split,
+                    self.device,
+                    self.comm,
+                    self.balanced,
                 )
 
         else:
@@ -1652,6 +1660,7 @@ class DNDarray:
                 new_split,
                 self.device,
                 self.comm,
+                balanced=False,
             )
 
     if torch.cuda.device_count() > 0:

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -83,7 +83,7 @@ class DNDarray:
         self.__split = split
         self.__device = device
         self.__comm = comm
-        self.__balanced = balanced
+        self.__balanced = None
         self.__ishalo = False
         self.__halo_next = None
         self.__halo_prev = None
@@ -1783,16 +1783,26 @@ class DNDarray:
         """
         return arithmetics.invert(self)
 
-    def is_balanced(self):
+    def is_balanced(self, force_check=False):
         """
-        Determine if a DNDarray is balanced evenly (or as evenly as possible) across all nodes
+        Returns the balanced status of a `DNDarray`, i.e. whether it is
+        distributed evenly (or as evenly as possible) across all processes.
+        This is equivalent to returning `self.balanced`. If no information
+        is available (`self.balanced = None`), the balanced status will be
+        assessed via collective communication.
+
+        Parameters
+        force_check : bool, optional
+            If True, the balanced status of the DNDarray will be assessed via
+            collective communication in any case.
 
         Returns
         -------
         balanced : bool
             True if balanced, False if not
         """
-        if self.balanced is not None:
+
+        if not force_check and self.balanced is not None:
             return self.balanced
 
         _, _, chk = self.comm.chunk(self.shape, self.split)

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -143,7 +143,6 @@ def array(
     is_split=None,
     device=None,
     comm=None,
-    balanced=None,
 ):
     """
     Create a tensor.
@@ -179,9 +178,6 @@ def array(
         Specifies the device the tensor shall be allocated on, defaults to None (i.e. globally set default device).
     comm: Communication, optional
         Handle to the nodes holding distributed tensor chunks.
-    balanced : None or bool, optional
-        Provides information about the distribution of the array across nodes. If None, no information is available,
-        if needed status must be verified with the `is_balanced()` method (requires communication).
 
     Returns
     -------
@@ -330,6 +326,7 @@ def array(
     is_split = sanitize_axis(obj.shape, is_split)
     if split is not None and is_split is not None:
         raise ValueError("split and is_split are mutually exclusive parameters")
+    balanced = False if is_split else True
 
     # sanitize device and object
     device = devices.sanitize_device(device)

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -332,7 +332,8 @@ def array(
     comm = sanitize_comm(comm)
 
     # determine the local and the global shape, if not split is given, they are identical
-    gshape = lshape = obj.shape
+    gshape = list(obj.shape)
+    lshape = gshape.copy()
     balanced = True
 
     # content shall be split, chunk the passed data object up
@@ -342,7 +343,8 @@ def array(
         obj = memory.sanitize_memory_layout(obj, order=order)
     # check with the neighboring rank whether the local shape would fit into a global shape
     elif is_split is not None:
-        gshape = lshape = np.array(lshape)
+        gshape = np.array(gshape)
+        lshape = np.array(lshape)
         obj = memory.sanitize_memory_layout(obj, order=order)
         if comm.rank < comm.size - 1:
             comm.Isend(lshape, dest=comm.rank + 1)
@@ -388,7 +390,7 @@ def array(
     elif split is None and is_split is None:
         obj = memory.sanitize_memory_layout(obj, order=order)
 
-    return dndarray.DNDarray(obj, gshape, dtype, split, device, comm, balanced)
+    return dndarray.DNDarray(obj, tuple(gshape), dtype, split, device, comm, balanced)
 
 
 def empty(shape, dtype=types.float32, split=None, device=None, comm=None, order="C"):

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -852,7 +852,7 @@ def logspace(
     split: int, optional
         The axis along which the array is split and distributed, defaults to None (no distribution).
     device : str, ht.Device or None, optional
-        Specifies the device the tensoimport nur shall be allocated on, defaults to None (i.e. globally set default device).
+        Specifies the device the tensor shall be allocated on, defaults to None (i.e. globally set default device).
     comm: Communication, optional
         Handle to the nodes holding distributed parts or copies of this tensor.
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -120,12 +120,12 @@ def arange(*args, dtype=None, split=None, device=None, comm=None):
     gshape = (num,)
     split = sanitize_axis(gshape, split)
     offset, lshape, _ = comm.chunk(gshape, split)
+    balanced = True
 
     # compose the local tensor
     start += offset * step
     stop = start + lshape[0] * step
     data = torch.arange(start, stop, step, device=device.torch_device)
-    balanced = True
 
     htype = types.canonical_heat_type(dtype)
     data = data.type(htype.torch_type())
@@ -331,7 +331,7 @@ def array(
     device = devices.sanitize_device(device)
     comm = sanitize_comm(comm)
 
-    # determine the local and the global shape, if not split is given, they are identical
+    # determine the local and the global shape. If split is None, they are identical
     gshape = list(obj.shape)
     lshape = gshape.copy()
     balanced = True

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -3,6 +3,7 @@ import torch
 from .communication import MPI
 from . import dndarray
 from . import factories
+from . import sanitation
 from . import types
 
 __all__ = ["nonzero", "where"]
@@ -58,6 +59,8 @@ def nonzero(a):
     [0/1] tensor([[4, 5, 6]])
     [1/1] tensor([[7, 8, 9]])
     """
+    sanitation.sanitize_in(a)
+
     if a.dtype == types.bool:
         a._DNDarray__array = a._DNDarray__array.float()
     if a.split is None:
@@ -88,6 +91,7 @@ def nonzero(a):
         split=is_split,
         device=a.device,
         comm=a.comm,
+        balanced=False,
     )
 
 

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -145,7 +145,7 @@ def where(cond, x=None, y=None):
         for var in [x, y]:
             if isinstance(var, int):
                 var = float(var)
-        return (cond == 0) * y + cond * x
+        return cond.dtype(cond == 0) * y + cond * x
     elif x is None and y is None:
         return nonzero(cond)
     else:

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -142,11 +142,10 @@ def where(cond, x=None, y=None):
     if isinstance(x, (dndarray.DNDarray, int, float)) and isinstance(
         y, (dndarray.DNDarray, int, float)
     ):
-        if isinstance(y, int):
-            y = float(y)
-        if isinstance(x, int):
-            x = float(x)
-        return cond.dtype((cond == 0)) * y + cond * x
+        for var in [x, y]:
+            if isinstance(var, int):
+                var = float(var)
+        return (cond == 0) * y + cond * x
     elif x is None and y is None:
         return nonzero(cond)
     else:

--- a/heat/core/io.py
+++ b/heat/core/io.py
@@ -454,7 +454,7 @@ def load_csv(
     comm=MPI_WORLD,
 ):
     """
-    Loads data from an CSV file. The data will be distributed along the 0 axis.
+    Loads data from a CSV file. The data will be distributed along the 0 axis.
 
     Parameters
     ----------

--- a/heat/core/io.py
+++ b/heat/core/io.py
@@ -101,6 +101,7 @@ else:
             dims = len(gshape)
             split = sanitize_axis(gshape, split)
             _, _, indices = comm.chunk(gshape, split)
+            balanced = True
             if split is None:
                 data = torch.tensor(
                     data[indices], dtype=dtype.torch_type(), device=device.torch_device
@@ -122,7 +123,7 @@ else:
                 )
                 data = data[slice2]
 
-            return dndarray.DNDarray(data, gshape, dtype, split, device, comm)
+            return dndarray.DNDarray(data, gshape, dtype, split, device, comm, balanced)
 
     def save_hdf5(data, path, dataset, mode="w", **kwargs):
         """
@@ -297,6 +298,7 @@ else:
 
             # chunk up the data portion
             _, local_shape, indices = comm.chunk(gshape, split)
+            balanced = True
             if split is None or local_shape[split] > 0:
                 data = torch.tensor(
                     data[indices], dtype=dtype.torch_type(), device=device.torch_device
@@ -306,7 +308,7 @@ else:
                     local_shape, dtype=dtype.torch_type(), device=device.torch_device
                 )
 
-            return dndarray.DNDarray(data, gshape, dtype, split, device, comm)
+            return dndarray.DNDarray(data, gshape, dtype, split, device, comm, balanced)
 
     def save_netcdf(data, path, variable, mode="w", **kwargs):
         """

--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -304,7 +304,7 @@ def __split0_r_calc(r_tiles, q_dict, q_dict_waits, col_num, diag_pr, not_complet
     """
 
     Function to do the QR calculations to calculate the global R of the array `a`.
-    This function uses a binary merge structure in the globabl R merge.
+    This function uses a binary merge structure in the global R merge.
 
     Parameters
     ----------

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -542,9 +542,6 @@ class TestLinalgBasics(TestCase):
         t_out = torch.empty((a.gshape[0], b.gshape[0]), dtype=torch.float32)
         with self.assertRaises(TypeError):
             ht.outer(a, b, out=t_out)
-        ht_out_wrong_dtype = ht.empty((a.gshape[0], b.gshape[0]), dtype=ht.float64)
-        with self.assertRaises(TypeError):
-            ht.outer(a, b, out=ht_out_wrong_dtype)
         ht_out_wrong_shape = ht.empty((7, b.gshape[0]), dtype=ht.float32)
         with self.assertRaises(ValueError):
             ht.outer(a, b, out=ht_out_wrong_shape)

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1940,10 +1940,7 @@ def stack(arrays, axis=0, out=None):
         raise ValueError("stack expects a sequence of at least 2 DNDarrays")
 
     for i, array in enumerate(arrays):
-        if not isinstance(array, dndarray.DNDarray):
-            raise TypeError(
-                "all arrays in sequence must be DNDarrays, array {} was {}".format(i, type(array))
-            )
+        sanitation.sanitize_in(array)
 
     arrays_metadata = list(
         [array.gshape, array.split, array.device, array.balanced] for array in arrays

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -207,8 +207,10 @@ def concatenate(arrays, axis=0):
     [1/1]         [1., 1.],
     [1/1]         [1., 1.]])
     """
-    if not isinstance(arrays, (tuple, list)):
-        raise TypeError("arrays must be a list or a tuple")
+    # input sanitation
+    arrays = sanitation.sanitize_sequence(arrays)
+    for arr in arrays:
+        sanitation.sanitize_in(arr)
 
     # a single array cannot be concatenated
     if len(arrays) < 2:
@@ -221,11 +223,8 @@ def concatenate(arrays, axis=0):
         return res
 
     # unpack the arrays
-    arr0, arr1 = arrays[0], arrays[1]
+    arr0, arr1 = arrays
 
-    # input sanitation
-    if not isinstance(arr0, dndarray.DNDarray) or not isinstance(arr1, dndarray.DNDarray):
-        raise TypeError("Both arrays must be DNDarrays")
     if not isinstance(axis, int):
         raise TypeError("axis must be an integer, currently: {}".format(type(axis)))
     axis = stride_tricks.sanitize_axis(arr0.gshape, axis)
@@ -265,18 +264,15 @@ def concatenate(arrays, axis=0):
 
     # unsplit and split array
     elif (s0 is None and s1 != axis) or (s1 is None and s0 != axis):
-        out_shape = tuple(
-            arr1.gshape[x] if x != axis else arr0.gshape[x] + arr1.gshape[x]
-            for x in range(len(arr1.gshape))
-        )
-        out = factories.empty(
-            out_shape, split=s1 if s1 is not None else s0, device=arr1.device, comm=arr0.comm
-        )
-
         _, _, arr0_slice = arr1.comm.chunk(arr0.shape, arr1.split)
         _, _, arr1_slice = arr0.comm.chunk(arr1.shape, arr0.split)
-        out.larray = torch.cat((arr0.larray[arr0_slice], arr1.larray[arr1_slice]), dim=axis)
-        out._DNDarray__comm = arr0.comm
+        out = factories.array(
+            torch.cat((arr0.larray[arr0_slice], arr1.larray[arr1_slice]), dim=axis),
+            dtype=out_dtype,
+            is_split=s1 if s1 is not None else s0,
+            device=arr1.device,
+            comm=arr0.comm,
+        )
 
         return out
 
@@ -284,18 +280,19 @@ def concatenate(arrays, axis=0):
         if s0 != axis and all([s is not None for s in [s0, s1]]):
             # the axis is different than the split axis, this case can be easily implemented
             # torch cat arrays together and return a new array that is_split
-            out_shape = tuple(
-                arr1.gshape[x] if x != axis else arr0.gshape[x] + arr1.gshape[x]
-                for x in range(len(arr1.gshape))
+
+            out = factories.array(
+                torch.cat((arr0.larray, arr1.larray), dim=axis),
+                dtype=out_dtype,
+                is_split=s0,
+                device=arr0.device,
+                comm=arr0.comm,
             )
-            out = factories.empty(out_shape, split=s0, dtype=out_dtype, device=arr0.device)
-            out.larray = torch.cat((arr0.larray, arr1.larray), dim=axis)
-            out._DNDarray__comm = arr0.comm
             return out
 
         else:
-            arr0 = arr0.copy()
-            arr1 = arr1.copy()
+            t_arr0 = arr0.larray
+            t_arr1 = arr1.larray
             # maps are created for where the data is and the output shape is calculated
             lshape_map = torch.zeros((2, arr0.comm.size, len(arr0.gshape)), dtype=torch.int)
             lshape_map[0, arr0.comm.rank, :] = torch.Tensor(arr0.lshape)
@@ -306,7 +303,7 @@ def concatenate(arrays, axis=0):
             arr0_shape[axis] += arr1_shape[axis]
             out_shape = tuple(arr0_shape)
 
-            # the chunk map is used for determine how much data should be on each process
+            # the chunk map is used to determine how much data should be on each process
             chunk_map = torch.zeros((arr0.comm.size, len(arr0.gshape)), dtype=torch.int)
             _, _, chk = arr0.comm.chunk(out_shape, s0 if s0 is not None else s1)
             for i in range(len(out_shape)):
@@ -325,18 +322,17 @@ def concatenate(arrays, axis=0):
                         for pr in range(spr):
                             send_amt = abs((chunk_map[pr, axis] - lshape_map[0, pr, axis]).item())
                             send_amt = (
-                                send_amt if send_amt < arr0.lshape[axis] else arr0.lshape[axis]
+                                send_amt if send_amt < t_arr0.shape[axis] else t_arr0.shape[axis]
                             )
                             if send_amt:
                                 send_slice[arr0.split] = slice(0, send_amt)
-                                keep_slice[arr0.split] = slice(send_amt, arr0.lshape[axis])
-
+                                keep_slice[arr0.split] = slice(send_amt, t_arr0.shape[axis])
                                 send = arr0.comm.Isend(
-                                    arr0.lloc[send_slice].clone(),
+                                    t_arr0[send_slice].clone(),
                                     dest=pr,
                                     tag=pr + arr0.comm.size + spr,
                                 )
-                                arr0.larray = arr0.lloc[keep_slice].clone()
+                                t_arr0 = t_arr0[keep_slice].clone()
                                 send.Wait()
                     for pr in range(spr):
                         snt = abs((chunk_map[pr, s0] - lshape_map[0, pr, s0]).item())
@@ -353,13 +349,14 @@ def concatenate(arrays, axis=0):
                             )
 
                             arr0.comm.Recv(data, source=spr, tag=pr + arr0.comm.size + spr)
-                            arr0.larray = torch.cat((arr0.larray, data), dim=arr0.split)
+                            t_arr0 = torch.cat((t_arr0, data), dim=arr0.split)
                         lshape_map[0, pr, arr0.split] += snt
                         lshape_map[0, spr, arr0.split] -= snt
 
             if s1 is not None:
                 send_slice = [slice(None)] * arr0.ndim
                 keep_slice = [slice(None)] * arr0.ndim
+
                 # push the data backwards (arr1), making the data the proper size for arr1 on the last nodes
                 # the data is "compressed" on np/2 processes. data is sent from
                 for spr in range(arr0.comm.size - 1, -1, -1):
@@ -368,20 +365,19 @@ def concatenate(arrays, axis=0):
                             # calculate the amount of data to send from the chunk map
                             send_amt = abs((chunk_map[pr, axis] - lshape_map[1, pr, axis]).item())
                             send_amt = (
-                                send_amt if send_amt < arr1.lshape[axis] else arr1.lshape[axis]
+                                send_amt if send_amt < t_arr1.shape[axis] else t_arr1.shape[axis]
                             )
                             if send_amt:
                                 send_slice[axis] = slice(
-                                    arr1.lshape[axis] - send_amt, arr1.lshape[axis]
+                                    t_arr1.shape[axis] - send_amt, t_arr1.shape[axis]
                                 )
-                                keep_slice[axis] = slice(0, arr1.lshape[axis] - send_amt)
-
+                                keep_slice[axis] = slice(0, t_arr1.shape[axis] - send_amt)
                                 send = arr1.comm.Isend(
-                                    arr1.lloc[send_slice].clone(),
+                                    t_arr1[send_slice].clone(),
                                     dest=pr,
                                     tag=pr + arr1.comm.size + spr,
                                 )
-                                arr1.larray = arr1.lloc[keep_slice].clone()
+                                t_arr1 = t_arr1[keep_slice].clone()
                                 send.Wait()
                     for pr in range(arr1.comm.size - 1, spr, -1):
                         snt = abs((chunk_map[pr, axis] - lshape_map[1, pr, axis]).item())
@@ -398,7 +394,7 @@ def concatenate(arrays, axis=0):
                                 shp, dtype=out_dtype.torch_type(), device=arr1.device.torch_device
                             )
                             arr1.comm.Recv(data, source=spr, tag=pr + arr1.comm.size + spr)
-                            arr1.larray = torch.cat((data, arr1.larray), dim=axis)
+                            t_arr1 = torch.cat((data, t_arr1), dim=axis)
                         lshape_map[1, pr, axis] += snt
                         lshape_map[1, spr, axis] -= snt
 
@@ -415,18 +411,18 @@ def concatenate(arrays, axis=0):
                 if arr0.comm.rank == 0:
                     lcl_slice = [slice(None)] * arr0.ndim
                     lcl_slice[axis] = slice(chunk_map[0, axis].item())
-                    arr0.larray = arr0.larray[lcl_slice].clone().squeeze()
+                    t_arr0 = t_arr0[lcl_slice].clone().squeeze()
                 ttl = chunk_map[0, axis].item()
                 for en in range(1, arr0.comm.size):
                     sz = chunk_map[en, axis]
                     if arr0.comm.rank == en:
                         lcl_slice = [slice(None)] * arr0.ndim
                         lcl_slice[axis] = slice(ttl, sz.item() + ttl, 1)
-                        arr0.larray = arr0.larray[lcl_slice].clone().squeeze()
+                        t_arr0 = t_arr0[lcl_slice].clone().squeeze()
                     ttl += sz.item()
 
-                if len(arr0.lshape) < len(arr1.lshape):
-                    arr0.larray.unsqueeze_(axis)
+                if len(t_arr0.shape) < len(t_arr1.shape):
+                    t_arr0.unsqueeze_(axis)
 
             if s1 is None:
                 arb_slice = [None] * len(arr0.shape)
@@ -438,33 +434,30 @@ def concatenate(arrays, axis=0):
                 if arr1.comm.rank == arr1.comm.size - 1:
                     lcl_slice = [slice(None)] * arr1.ndim
                     lcl_slice[axis] = slice(
-                        arr1.lshape[axis] - chunk_map[-1, axis].item(), arr1.lshape[axis], 1
+                        t_arr1.shape[axis] - chunk_map[-1, axis].item(), t_arr1.shape[axis], 1
                     )
-                    arr1.larray = arr1.larray[lcl_slice].clone().squeeze()
+                    t_arr1 = t_arr1[lcl_slice].clone().squeeze()
                 ttl = chunk_map[-1, axis].item()
                 for en in range(arr1.comm.size - 2, -1, -1):
                     sz = chunk_map[en, axis]
                     if arr1.comm.rank == en:
                         lcl_slice = [slice(None)] * arr1.ndim
                         lcl_slice[axis] = slice(
-                            arr1.lshape[axis] - (sz.item() + ttl), arr1.lshape[axis] - ttl, 1
+                            t_arr1.shape[axis] - (sz.item() + ttl), t_arr1.shape[axis] - ttl, 1
                         )
-                        arr1.larray = arr1.larray[lcl_slice].clone().squeeze()
+                        t_arr1 = t_arr1[lcl_slice].clone().squeeze()
                     ttl += sz.item()
-                if len(arr1.lshape) < len(arr0.lshape):
-                    arr1.larray.unsqueeze_(axis)
+                if len(t_arr1.shape) < len(t_arr0.shape):
+                    t_arr1.unsqueeze_(axis)
 
-            # now that the data is in the proper shape, need to concatenate them on the nodes where they both exist for
-            # the others, just set them equal
-            out = factories.empty(
-                out_shape,
-                split=s0 if s0 is not None else s1,
+            res = torch.cat((t_arr0, t_arr1), dim=axis)
+            out = factories.array(
+                res,
+                is_split=s0 if s0 is not None else s1,
                 dtype=out_dtype,
                 device=arr0.device,
                 comm=arr0.comm,
             )
-            res = torch.cat((arr0.larray, arr1.larray), dim=axis)
-            out.larray = res
 
             return out
 
@@ -508,14 +501,14 @@ def diag(a, offset=0):
     >>> ht.diag(a)
     tensor([1, 4])
     """
+    sanitation.sanitize_in(a)
+
     if len(a.shape) > 1:
         return diagonal(a, offset=offset)
     elif len(a.shape) < 1:
         raise ValueError("input array must be of dimension 1 or greater")
     if not isinstance(offset, int):
         raise ValueError("offset must be an integer, got", type(offset))
-    if not isinstance(a, dndarray.DNDarray):
-        raise ValueError("a must be a DNDarray, got", type(a))
 
     # 1-dimensional array, must be extended to a square diagonal matrix
     gshape = (a.shape[0] + abs(offset),) * 2

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1970,7 +1970,7 @@ def stack(arrays, axis=0, out=None):
                 )
             )
         balance = list(array.balanced for array in arrays)
-        if balance.count(balance[0]) != num_arrays:
+        if balance.count(True) != num_arrays:
             raise RuntimeError(
                 "DNDarrays distribution must be balanced across ranks, is_balanced() returns {}"
                 "You can balance a DNDarray with the balance_() method.".format(balance)

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -2222,12 +2222,6 @@ def stack(arrays, axis=0, out=None):
                     devices
                 )
             )
-        balance = list(array.balanced for array in arrays)
-        if balance.count(True) != num_arrays:
-            raise RuntimeError(
-                "DNDarrays distribution must be balanced across ranks, is_balanced() returns {}"
-                "You can balance a DNDarray with the balance_() method.".format(balance)
-            )
     else:
         array_shape, array_split, array_device, array_balanced = arrays_metadata[0][:4]
         # extract torch tensors

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -2524,10 +2524,9 @@ def topk(a, k, dim=None, largest=True, sorted=True, out=None):
     if dim is None:
         dim = len(a.shape) - 1
 
+    neutral_value = sanitation.sanitize_infinity(a)
     if largest:
-        neutral_value = -constants.sanitize_infinity(a.larray.dtype)
-    else:
-        neutral_value = constants.sanitize_infinity(a.larray.dtype)
+        neutral_value = -neutral_value
 
     def local_topk(*args, **kwargs):
         shape = a.lshape

--- a/heat/core/memory.py
+++ b/heat/core/memory.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 from . import dndarray
+from . import sanitation
 
 __all__ = ["copy", "sanitize_memory_layout"]
 
@@ -19,10 +20,9 @@ def copy(a):
     copied : ht.DNDarray
         A copy of the original
     """
-    if not isinstance(a, dndarray.DNDarray):
-        raise TypeError("input needs to be a tensor")
+    sanitation.sanitize_in(a)
     return dndarray.DNDarray(
-        a._DNDarray__array.clone(), a.shape, a.dtype, a.split, a.device, a.comm
+        a._DNDarray__array.clone(), a.shape, a.dtype, a.split, a.device, a.comm, a.balanced
     )
 
 

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -354,6 +354,7 @@ def rand(*args, dtype=types.float32, split=None, device=None, comm=None):
     split = stride_tricks.sanitize_axis(shape, split)
     device = devices.sanitize_device(device)
     comm = communication.sanitize_comm(comm)
+    balanced = True
 
     # generate the random sequence
     if dtype == types.float32:
@@ -376,7 +377,7 @@ def rand(*args, dtype=types.float32, split=None, device=None, comm=None):
         # Unsupported type
         raise ValueError("dtype is none of ht.float32 or ht.float64 but was {}".format(dtype))
 
-    return dndarray.DNDarray(values, shape, dtype, split, device, comm)
+    return dndarray.DNDarray(values, shape, dtype, split, device, comm, balanced)
 
 
 def randint(low, high=None, size=None, dtype=None, split=None, device=None, comm=None):
@@ -438,6 +439,8 @@ def randint(low, high=None, size=None, dtype=None, split=None, device=None, comm
     split = stride_tricks.sanitize_axis(shape, split)
     device = devices.sanitize_device(device)
     comm = communication.sanitize_comm(comm)
+    balanced = True
+
     # generate the random sequence
     x_0, x_1, lshape, lslice = __counter_sequence(shape, dtype.torch_type(), split, device, comm)
     if torch_dtype is torch.int32:
@@ -450,7 +453,7 @@ def randint(low, high=None, size=None, dtype=None, split=None, device=None, comm
     # ATTENTION: this is biased and known, bias-free rejection sampling is difficult to do in parallel
     values = (values.abs_() % span) + low
 
-    return dndarray.DNDarray(values, shape, dtype, split, device, comm)
+    return dndarray.DNDarray(values, shape, dtype, split, device, comm, balanced)
 
 
 # alias

--- a/heat/core/rounding.py
+++ b/heat/core/rounding.py
@@ -2,6 +2,7 @@ import torch
 
 from . import _operations
 from . import dndarray
+from . import sanitation
 from . import types
 
 __all__ = ["abs", "absolute", "ceil", "clip", "fabs", "floor", "modf", "round", "trunc"]
@@ -113,17 +114,23 @@ def clip(a, a_min, a_max, out=None):
         A tensor with the elements of this tensor, but where values < a_min are replaced with a_min, and those >
         a_max with a_max.
     """
-    if not isinstance(a, dndarray.DNDarray):
-        raise TypeError("a must be a tensor")
+    sanitation.sanitize_in(a)
+
     if a_min is None and a_max is None:
         raise ValueError("either a_min or a_max must be set")
 
     if out is None:
         return dndarray.DNDarray(
-            a._DNDarray__array.clamp(a_min, a_max), a.shape, a.dtype, a.split, a.device, a.comm
+            a._DNDarray__array.clamp(a_min, a_max),
+            a.shape,
+            a.dtype,
+            a.split,
+            a.device,
+            a.comm,
+            a.balanced,
         )
-    if not isinstance(out, dndarray.DNDarray):
-        raise TypeError("out must be a tensor")
+
+    sanitation.sanitize_out(out, a.gshape, a.split, a.device)
 
     return a._DNDarray__array.clamp(a_min, a_max, out=out._DNDarray__array) and out
 

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -77,19 +77,8 @@ def sanitize_sequence(seq):
         return seq
     elif isinstance(seq, tuple):
         return list(seq)
-    elif isinstance(seq, dndarray.DNDarray):
-        if seq.split is None:
-            return seq._DNDarray__array.tolist()
-        else:
-            raise ValueError(
-                "seq is a distributed DNDarray, expected a list, a tuple, or a process-local array."
-            )
-    elif isinstance(seq, torch.Tensor):
-        return seq.tolist()
     else:
-        raise TypeError(
-            "seq must be a list, a tuple, or a process-local array, got {}".format(type(seq))
-        )
+        raise TypeError("seq must be a list or a tuple, got {}".format(type(seq)))
 
 
 def scalar_to_1d(x):

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -10,10 +10,10 @@ from . import stride_tricks
 from . import types
 
 
-__all__ = ["sanitize_input", "sanitize_out", "sanitize_sequence", "scalar_to_1d"]
+__all__ = ["sanitize_in", "sanitize_out", "sanitize_sequence", "scalar_to_1d"]
 
 
-def sanitize_input(x):
+def sanitize_in(x):
     """
     Raise TypeError if input is not DNDarray
 

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -97,6 +97,10 @@ def argmax(x, axis=None, out=None, **kwargs):
 
         return torch.cat([maxima.double(), indices.double()])
 
+    # axis sanitation
+    if axis is not None and not isinstance(axis, int):
+        raise TypeError("axis must be None or int, was {}".format(type(axis)))
+
     # perform the global reduction
     smallest_value = -sanitation.sanitize_infinity(x)
     return _operations.__reduce_op(
@@ -165,6 +169,10 @@ def argmin(x, axis=None, out=None, **kwargs):
             indices += torch.tensor(offset, dtype=indices.dtype)
 
         return torch.cat([minimums.double(), indices.double()])
+
+    # axis sanitation
+    if axis is not None and not isinstance(axis, int):
+        raise TypeError("axis must be None or int, was {}".format(type(axis)))
 
     # perform the global reduction
     largest_value = sanitation.sanitize_infinity(x)
@@ -297,9 +305,11 @@ def average(x, axis=None, weights=None, returned=False):
 
     if returned:
         if cumwgt.gshape != result.gshape:
-            cumwgt.larray = torch.broadcast_tensors(cumwgt.larray, result.larray)[0]
-            cumwgt._DNDarray__gshape = result.gshape
-            cumwgt._DNDarray__split = result.split
+            cumwgt = factories.array(
+                torch.broadcast_tensors(cumwgt.larray, result.larray)[0],
+                is_split=result.split,
+                device=result.device,
+            )
         return (result, cumwgt)
 
     return result

--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -1028,7 +1028,7 @@ def __moment_w_axis(function, x, axis, elementwise_function, unbiased=None, Fisc
         output_shape = [output_shape[it] for it in range(len(output_shape)) if it != axis]
         output_shape = output_shape if output_shape else (1,)
 
-        if x.split is None:  # x is *not* distributed -> no need to distributed
+        if x.split is None:  # x is *not* distributed -> no need to distribute
             return factories.array(function(x.larray, **kwargs), dtype=x.dtype, device=x.device)
         elif axis == x.split:  # x is distributed and axis chosen is == to split
             return elementwise_function(output_shape)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -193,7 +193,7 @@ class TestArithmetics(TestCase):
             ht.cumprod(ht.ones((2, 2)), axis=None)
         with self.assertRaises(TypeError):
             ht.cumprod(ht.ones((2, 2)), axis="1")
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             ht.cumprod(a, 2, out=out)
         with self.assertRaises(ValueError):
             ht.cumprod(ht.ones((2, 2)), 2)
@@ -238,7 +238,7 @@ class TestArithmetics(TestCase):
             ht.cumsum(ht.ones((2, 2)), axis=None)
         with self.assertRaises(TypeError):
             ht.cumsum(ht.ones((2, 2)), axis="1")
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             ht.cumsum(a, 2, out=out)
         with self.assertRaises(ValueError):
             ht.cumsum(ht.ones((2, 2)), 2)
@@ -511,7 +511,7 @@ class TestArithmetics(TestCase):
         self.assertEqual(shape_noaxis_split_axis_neg_prod._DNDarray__array.dtype, torch.float32)
         self.assertEqual(shape_noaxis_split_axis_neg_prod.split, 1)
 
-        out_noaxis = ht.zeros((1, 2, 3, 5))
+        out_noaxis = ht.zeros((1, 2, 3, 5), split=1)
         ht.prod(shape_noaxis_split_axis_neg, axis=-2, out=out_noaxis)
 
         # check sum over all float elements of splitted 3d tensor with tuple axis
@@ -647,7 +647,7 @@ class TestArithmetics(TestCase):
         self.assertEqual(shape_noaxis_split_axis_neg_sum._DNDarray__array.dtype, torch.float32)
         self.assertEqual(shape_noaxis_split_axis_neg_sum.split, 1)
 
-        out_noaxis = ht.zeros((1, 2, 3, 5))
+        out_noaxis = ht.zeros((1, 2, 3, 5), split=1)
         ht.sum(shape_noaxis_split_axis_neg, axis=-2, out=out_noaxis)
 
         # check sum over all float elements of splitted 3d tensor with tuple axis

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -99,9 +99,7 @@ class TestDNDarray(TestCase):
             halo_2 = torch.tensor(np.array([[3], [9]]), device=data.device.torch_device)
             halo_3 = torch.tensor(np.array([[4], [10]]), device=data.device.torch_device)
             halo_4 = torch.tensor(np.array([[5], [11]]), device=data.device.torch_device)
-
             data.get_halo(1)
-
             data_with_halos = data.array_with_halos
 
             if data.comm.rank == 0:
@@ -116,7 +114,6 @@ class TestDNDarray(TestCase):
                 self.assertEqual(data.halo_next, None)
                 self.assertTrue(torch.equal(data.halo_prev, halo_3))
                 self.assertEqual(data_with_halos.shape, (2, 3))
-
             # exception on wrong argument type in get_halo
             with self.assertRaises(TypeError):
                 data.get_halo("wrong_type")
@@ -128,10 +125,10 @@ class TestDNDarray(TestCase):
                 data.get_halo(4)
             # exception on non balanced tensor
             with self.assertRaises(RuntimeError):
-                if data.comm.rank == 1:
-                    data.larray = torch.empty(0)
-                data.get_halo(1)
-
+                data_nobalance = ht.array(
+                    torch.empty(((data.comm.rank + 1) * 2, 3, 4)), is_split=0, device=data.device
+                )
+                data_nobalance.get_halo(1)
             # test no data on process
             data_np = np.arange(2 * 12).reshape(2, 12)
             data = ht.array(data_np, split=0)
@@ -178,14 +175,16 @@ class TestDNDarray(TestCase):
         self.assertIsInstance(x.larray, torch.Tensor)
         self.assertEqual(x.larray.shape, x.lshape)
 
-        x.larray = torch.arange(42)
+        x.larray = torch.randn(6, 7, 8)
 
         self.assertTrue((x.larray == x.larray).all())
-        self.assertTrue(x.gshape, (42,))
+        self.assertTrue(x.gshape, (6, 7, 8))
         self.assertIsInstance(x.larray, torch.Tensor)
         self.assertEqual(x.larray.shape, x.lshape)
 
         # Exceptions
+        with self.assertRaises(ValueError):
+            x.larray = torch.arange(42)
         with self.assertRaises(TypeError):
             x.larray = ht.array([1, 2, 3])
         with self.assertRaises(TypeError):
@@ -202,15 +201,18 @@ class TestDNDarray(TestCase):
         self.assertIsInstance(x.larray, torch.Tensor)
         self.assertEqual(x.larray.shape, x.lshape)
 
-        x.larray = torch.arange(42)
+        if x.comm.rank == 0:
+            x.larray = torch.randn(4, 7, 8)
 
         self.assertTrue((x.larray == x.larray).all())
-        self.assertTrue(x.gshape, (42,))
+        # self.assertTrue(x.gshape, (42,))
         self.assertIsInstance(x.larray, torch.Tensor)
         self.assertEqual(x.larray.shape, x.lshape)
         self.assertEqual(x.split, 0)
 
         # Exceptions
+        with self.assertRaises(ValueError):
+            x.larray = torch.arange(42)
         with self.assertRaises(TypeError):
             x.larray = ht.array([1, 2, 3])
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_indexing.py
+++ b/heat/core/tests/test_indexing.py
@@ -49,7 +49,7 @@ class TestIndexing(TestCase):
         )
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))
-        self.assertEqual(wh.dtype, ht.float)
+        self.assertEqual(wh.dtype, ht.float64)
 
         # split cond
         a = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, 4.0], [0.0, 3.0, 6.0]], split=0)
@@ -58,7 +58,7 @@ class TestIndexing(TestCase):
         self.assertTrue(ht.all(wh[ht.nonzero(a >= 4)] == -1))
         self.assertTrue(ht.equal(wh, res))
         self.assertEqual(wh.gshape, (3, 3))
-        self.assertEqual(wh.dtype, ht.float)
+        self.assertEqual(wh.dtype, ht.float64)
         self.assertEqual(wh.split, 0)
 
         a = ht.array([[0.0, 1.0, 2.0], [0.0, 2.0, 4.0], [0.0, 3.0, 6.0]], split=1)

--- a/heat/core/tests/test_logical.py
+++ b/heat/core/tests/test_logical.py
@@ -137,7 +137,7 @@ class TestLogical(TestCase):
         self.assertEqual(float_5d_is_one._DNDarray__array.dtype, torch.bool)
         self.assertEqual(float_5d_is_one.split, 1)
 
-        out_noaxis = ht.zeros((1, 2, 3, 5))
+        out_noaxis = ht.zeros((1, 2, 3, 5), split=1)
         ht.all(ones_noaxis_split_axis_neg, axis=-2, out=out_noaxis)
 
         # exceptions
@@ -185,7 +185,7 @@ class TestLogical(TestCase):
         self.assertTrue(ht.equal(any_tensor, res))
 
         # integer values, major axis, output tensor
-        any_tensor = ht.zeros((2,))
+        any_tensor = ht.zeros((2,), dtype=ht.bool)
         x = ht.int32([[0, 0], [0, 0], [0, 1]])
         ht.any(x, axis=0, out=any_tensor)
         res = ht.uint8([0, 1])

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -57,6 +57,7 @@ class TestManipulations(TestCase):
         x = ht.zeros((16, 15), split=None)
         y = ht.ones((16, 15), split=None)
         res = ht.concatenate((x, y), axis=0)
+
         self.assertEqual(res.gshape, (32, 15))
         self.assertEqual(res.dtype, ht.float)
         _, _, chk = res.comm.chunk((32, 15), res.split)
@@ -74,7 +75,6 @@ class TestManipulations(TestCase):
         for i in range(2):
             lshape[i] = chk[i].stop - chk[i].start
         self.assertEqual(res.lshape, tuple(lshape))
-
         # =============================================
         # None 0 0
         x = ht.zeros((16, 15), split=None)
@@ -381,6 +381,7 @@ class TestManipulations(TestCase):
 
         a = ht.array(data, split=0)
         res = ht.diag(a)
+
         self.assertEqual(res.split, a.split)
         self.assertEqual(res.shape, (size * 2, size * 2))
         self.assertEqual(res.lshape[res.split], 2)
@@ -389,6 +390,7 @@ class TestManipulations(TestCase):
             self.assertTrue(torch.equal(res[i, i].larray, exp[i, i]))
 
         res = ht.diag(a, offset=size)
+
         self.assertEqual(res.split, a.split)
         self.assertEqual(res.shape, (size * 3, size * 3))
         self.assertEqual(res.lshape[res.split], 3)
@@ -411,7 +413,7 @@ class TestManipulations(TestCase):
         res_2 = ht.diagonal(a)
         self.assertTrue(ht.equal(res_1, res_2))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             ht.diag(data)
 
         with self.assertRaises(ValueError):

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1969,9 +1969,6 @@ class TestManipulations(TestCase):
         out_wrong_type = torch.empty((3, 5, 4), dtype=torch.float32)
         with self.assertRaises(TypeError):
             ht.stack((ht_a_split, ht_b_split, ht_c_split), out=out_wrong_type)
-        out_wrong_dtype = ht.empty((3, 5, 4), dtype=ht.float64, split=1)
-        with self.assertRaises(TypeError):
-            ht.stack((ht_a_split, ht_b_split, ht_c_split), out=out_wrong_dtype)
         out_wrong_shape = ht.empty((2, 5, 4), dtype=ht.float32, split=1)
         with self.assertRaises(ValueError):
             ht.stack((ht_a_split, ht_b_split, ht_c_split), out=out_wrong_shape)

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1952,7 +1952,7 @@ class TestManipulations(TestCase):
             rank = ht_a_split.comm.rank
             t_a = torch.randn(rank + 1, 4, dtype=torch.float32)
             ht_a_unbalanced = ht.array(t_a, is_split=0)
-            ht_b_split = ht.empty_like(ht_a_unbalanced, split=0)
+            ht_b_split = ht.empty(ht_a_unbalanced.gshape, split=0, dtype=ht.float32)
             with self.assertRaises(RuntimeError):
                 ht.stack((ht_a_unbalanced, ht_b_split))
 

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1950,16 +1950,11 @@ class TestManipulations(TestCase):
             ht.stack((ht_a_split, ht_b_split, ht_c_split), out=out_wrong_split)
         if ht_a_split.comm.is_distributed():
             rank = ht_a_split.comm.rank
-            if rank == 0:
-                t_a = torch.randn(4, 4, dtype=torch.float32)
-            elif rank == 1:
-                t_a = torch.randn(1, 4, dtype=torch.float32)
-            else:
-                t_a = torch.randn(0, 4, dtype=torch.float32)
+            t_a = torch.randn(rank + 1, 4, dtype=torch.float32)
             ht_a_unbalanced = ht.array(t_a, is_split=0)
+            ht_b_split = ht.empty_like(ht_a_unbalanced, split=0)
             with self.assertRaises(RuntimeError):
-                ht.stack((ht_a_unbalanced, ht_b_split, ht_c_split))
-        # TODO test with DNDarrays on different devices
+                ht.stack((ht_a_unbalanced, ht_b_split))
 
     def test_topk(self):
         size = ht.MPI_WORLD.size

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -2443,15 +2443,6 @@ class TestManipulations(TestCase):
         out_wrong_split = ht.empty((3, 5, 4), dtype=ht.float32, split=0)
         with self.assertRaises(ValueError):
             ht.stack((ht_a_split, ht_b_split, ht_c_split), out=out_wrong_split)
-        if ht_a_split.comm.is_distributed():
-            rank = ht_a_split.comm.rank
-            size = ht_a_split.comm.size
-            split_size = np.arange(1, size + 1).sum()
-            ht_b_split = ht.empty((split_size, 4), split=0, dtype=ht.float32)
-            t_a = torch.randn(rank + 1, 4, dtype=torch.float32)
-            ht_a_unbalanced = ht.array(t_a, is_split=0)
-            with self.assertRaises(RuntimeError):
-                ht.stack((ht_a_unbalanced, ht_b_split))
 
     def test_topk(self):
         size = ht.MPI_WORLD.size

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1950,9 +1950,11 @@ class TestManipulations(TestCase):
             ht.stack((ht_a_split, ht_b_split, ht_c_split), out=out_wrong_split)
         if ht_a_split.comm.is_distributed():
             rank = ht_a_split.comm.rank
+            size = ht_a_split.comm.size
+            split_size = np.arange(1, size + 1).sum()
+            ht_b_split = ht.empty((split_size, 4), split=0, dtype=ht.float32)
             t_a = torch.randn(rank + 1, 4, dtype=torch.float32)
             ht_a_unbalanced = ht.array(t_a, is_split=0)
-            ht_b_split = ht.empty(ht_a_unbalanced.gshape, split=0, dtype=ht.float32)
             with self.assertRaises(RuntimeError):
                 ht.stack((ht_a_unbalanced, ht_b_split))
 

--- a/heat/core/tests/test_sanitation.py
+++ b/heat/core/tests/test_sanitation.py
@@ -6,13 +6,13 @@ from .test_suites.basic_test import TestCase
 
 
 class TestSanitation(TestCase):
-    def test_sanitize_input(self):
+    def test_sanitize_in(self):
         torch_x = torch.arange(10)
         with self.assertRaises(TypeError):
-            ht.sanitize_input(torch_x)
+            ht.sanitize_in(torch_x)
         np_x = np.arange(10)
         with self.assertRaises(TypeError):
-            ht.sanitize_input(np_x)
+            ht.sanitize_in(np_x)
 
     def test_sanitize_out(self):
         output_shape = (4, 5, 6)
@@ -37,17 +37,9 @@ class TestSanitation(TestCase):
         seq = (1, 2, 3)
         seq = ht.sanitize_sequence(seq)
         self.assertTrue(isinstance(seq, list))
-        # test DNDarray seq
-        seq = ht.arange(10, dtype=ht.float32)
-        seq = ht.sanitize_sequence(seq)
-        self.assertTrue(isinstance(seq, list))
-        # test torch seq
-        seq = torch.arange(10, dtype=torch.int64)
-        seq = ht.sanitize_sequence(seq)
-        self.assertTrue(isinstance(seq, list))
         # test exceptions
         split_seq = ht.arange(10, dtype=ht.float32, split=0)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             ht.sanitize_sequence(split_seq)
         np_seq = np.arange(10)
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -53,7 +53,6 @@ class TestStatistics(TestCase):
         self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (ht.MPI_WORLD.size * 4,))
         self.assertEqual(result.lshape, (4,))
-        self.assertEqual(result.split, 0 if ht.MPI_WORLD.size > 1 else None)
         self.assertTrue((result.larray == expected).all())
 
         # 2D split tensor, across the axis
@@ -76,7 +75,7 @@ class TestStatistics(TestCase):
         size = ht.MPI_WORLD.size * 2
         data = ht.tril(ht.ones((size, size), split=0), k=-1)
 
-        output = ht.empty((size,))
+        output = ht.empty((size,), dtype=ht.int64)
         result = ht.argmax(data, axis=0, out=output)
         expected = torch.tensor(np.argmax(data.numpy(), axis=0))
         self.assertIsInstance(result, ht.DNDarray)
@@ -142,7 +141,6 @@ class TestStatistics(TestCase):
         self.assertEqual(result.larray.dtype, torch.int64)
         self.assertEqual(result.shape, (ht.MPI_WORLD.size * 4,))
         self.assertEqual(result.lshape, (4,))
-        self.assertEqual(result.split, 0 if ht.MPI_WORLD.size > 1 else None)
         self.assertTrue((result.larray == expected).all())
 
         # 2D split tensor, across the axis
@@ -165,7 +163,7 @@ class TestStatistics(TestCase):
         size = ht.MPI_WORLD.size * 2
         data = ht.triu(ht.ones((size, size), split=0), k=1)
 
-        output = ht.empty((size,))
+        output = ht.empty((size,), dtype=ht.int64)
         result = ht.argmin(data, axis=0, out=output)
         expected = torch.tensor(np.argmin(data.numpy(), axis=0))
         self.assertIsInstance(result, ht.DNDarray)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -807,7 +807,7 @@ class TestStatistics(TestCase):
         ht_array = ht.array(data)
         comparison = torch.tensor(data, device=self.device.torch_device)
 
-        # check global max
+        # check global min
         minimum = ht.min(ht_array)
 
         self.assertIsInstance(minimum, ht.DNDarray)
@@ -818,7 +818,7 @@ class TestStatistics(TestCase):
         self.assertEqual(minimum._DNDarray__array.dtype, torch.int64)
         self.assertEqual(minimum, 1)
 
-        # maximum along first axis
+        # min along first axis
         ht_array = ht.array(data, dtype=ht.int8)
         minimum_vertical = ht.min(ht_array, axis=0)
 
@@ -832,7 +832,7 @@ class TestStatistics(TestCase):
             (minimum_vertical._DNDarray__array == comparison.min(dim=0, keepdim=True)[0]).all()
         )
 
-        # maximum along second axis
+        # min along second axis
         ht_array = ht.array(data, dtype=ht.int16)
         minimum_horizontal = ht.min(ht_array, axis=1, keepdim=True)
 
@@ -846,7 +846,7 @@ class TestStatistics(TestCase):
             (minimum_horizontal._DNDarray__array == comparison.min(dim=1, keepdim=True)[0]).all()
         )
 
-        # check max over all float elements of split 3d tensor, across split axis
+        # check min over all float elements of split 3d tensor, across split axis
         size = ht.MPI_WORLD.size
         random_volume = ht.random.randn(3, 3 * size, 3, split=1)
         minimum_volume = ht.min(random_volume, axis=1)
@@ -870,7 +870,7 @@ class TestStatistics(TestCase):
         self.assertEqual(minimum_volume.split, 0)
         self.assertTrue((minimum_volume == alt_minimum_volume).all())
 
-        # check max over all float elements of split 5d tensor, along split axis
+        # check min over all float elements of split 5d tensor, along split axis
         random_5d = ht.random.randn(1 * size, 2, 3, 4, 5, split=0)
         minimum_5d = ht.min(random_5d, axis=1)
 

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -97,6 +97,9 @@ class TestStatistics(TestCase):
             data.argmax(axis="y")
         with self.assertRaises(ValueError):
             ht.argmax(data, axis=-4)
+        output = ht.empty((size,), dtype=ht.float32)
+        with self.assertRaises(TypeError):
+            ht.argmax(data, axis=0, out=output)
 
     def test_argmin(self):
         torch.manual_seed(1)

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -95,7 +95,7 @@ class generic:
             raise ValueError(str(exception))
 
         return dndarray.DNDarray(
-            array, tuple(array.shape), cls, split=None, device=device, comm=comm
+            array, tuple(array.shape), cls, split=None, device=device, comm=comm, balanced=True
         )
 
     @classmethod


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #681  (see discussion in #668 )

## Changes proposed:
- New dndarray property `balanced`, can be`True` or `False`, or `None` if not enough info.
- `balanced` is set internally within the factories and cannot be specified by the user. It is always set to `True` except by `ht.array` where  `is_split is not None`, in which case the balanced status will be assessed (adds one more communication step to `ht.array()`, but eliminates the need for possibly repeated `is_balanced()` checks later).
- the dndarray method `is_balanced` now returns `self.balanced`, unless `self.balanced is None`, in which case it will perform the check as usual and set the `balanced` property.
- One major problem is our extended use of the construct `x.larray = new_local_torch_x` in code and tests. Very often `new_local_torch_x.shape != x.larray.shape` and results into a mess, among other things invalidating the `balanced` information.  I've introduced the following changes:
  - added a "local shape sanitation" to `dndarray.larray.setter`. To me it's still too lax. If not called from all processes, it will produce an imbalanced dndarray with inhomogeneous balanced status.    
  - replaced instances of brute-force larray-setting with `ht.array(new_local_torch_x, is_split=...)` (notably `concatenate`, `argmin` and `argmax`)
  - while I was at it, modified `__reduce_op` to return the correct `argmax`/ `argmin` result directly

- I've also expanded the sanitation module with `sanitize_in_tensor` (verify that input is torch.Tensor), `sanitize_lshape` (for larray.setter, see above), and I've modified `constants.sanitize_infinity` to use torch.finfo/iinfo and moved it to`sanitation.sanitize_infinity`.

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
