### PR TITLE
[Bug] Set explicit encoding in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 ### ...
 
 ## Bug fixes
+- [#709](https://github.com/helmholtz-analytics/heat/pull/709) Set the encoding for README.md in setup.py explicitly.
+
 # v0.5.2
 
 - [#706](https://github.com/helmholtz-analytics/heat/pull/706) Bug fix: prevent `__setitem__`, `__getitem__` from modifying key in place

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup, find_packages
+import codecs
 
 
-with open("README.md", "r") as handle:
+with codecs.open("README.md", "r", "utf-8") as handle:
     long_description = handle.read()
 
 __version__ = None  # appeases flake, assignment in exec() below


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

On the GPU Cluster, setup.py uses the wrong encoding when reading README.md which contains umlauts. This PR sets it explicitly to UTF-8.

## Changes proposed:
- explicit encoding in setup.py

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
Bug fix

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no