### PR TITLE
Lanczos Bugfix in Solver

### DIFF
--- a/heat/core/linalg/solver.py
+++ b/heat/core/linalg/solver.py
@@ -155,13 +155,13 @@ def lanczos(A, m, v0=None, V_out=None, T_out=None):
                 b = torch.dot(vi_loc, vi_loc)
                 A.comm.Allreduce(ht.communication.MPI.IN_PLACE, a, ht.communication.MPI.SUM)
                 A.comm.Allreduce(ht.communication.MPI.IN_PLACE, b, ht.communication.MPI.SUM)
-                vr._DNDarray__array -= a / b * vi_loc
+                vr._DNDarray__array = vr._DNDarray__array - a / b * vi_loc
 
             vi = vr / ht.norm(vr)
 
         w = ht.matmul(A, vi)
         alpha = ht.dot(w, vi)
-        w -= alpha * vi - beta * V[:, i - 1]
+        w = w - alpha * vi - beta * V[:, i - 1]
 
         T[i - 1, i] = beta
         T[i, i - 1] = beta


### PR DESCRIPTION
Reverted inplace calculation from commit 80577f70cf7c91822569288817296bfd858cff73, because this was causing incorrect eigenvalue calculations

## Description
Spectral clustering was yielding negative Eigenvalues, which cannot be due to the Laplacian being a positive semidefinite matrix. It turns out that a change in the solver class to inplace operations for updating the w vector caused wrong calculations. 


## Changes proposed:
-```w -= alpha * vi - beta * V[:, i - 1]``` -->  ``` w = w - alpha * vi - beta * V[:, i - 1]``` 

## Type of change
Bug fix (non-breaking change which fixes an issue)



#### Does this change modify the behaviour of other functions? If so, which?
 no

