### PR TITLE
relational functions cast to boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ## Bug fixes
 - [#709](https://github.com/helmholtz-analytics/heat/pull/709) Set the encoding for README.md in setup.py explicitly.
+- [#735](https://github.com/helmholtz-analytics/heat/pull/735) Set return type to bool in relational functions.
 
 # v0.5.2
 

--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -2,6 +2,8 @@ import torch
 
 from .communication import MPI
 from . import _operations
+from . import dndarray
+from . import types
 
 __all__ = ["eq", "equal", "ge", "gt", "le", "lt", "ne"]
 
@@ -37,7 +39,20 @@ def eq(t1, t2):
     tensor([[0, 1],
             [0, 0]])
     """
-    return _operations.__binary_op(torch.eq, t1, t2)
+    res = _operations.__binary_op(torch.eq, t1, t2)
+
+    if res.dtype != types.bool:
+        res = dndarray.DNDarray(
+            res.larray.type(torch.bool),
+            res.gshape,
+            types.bool,
+            res.split,
+            res.device,
+            res.comm,
+            res.balanced,
+        )
+
+    return res
 
 
 def equal(t1, t2):
@@ -111,7 +126,20 @@ def ge(t1, t2):
     tensor([[0, 1],
             [1, 1]], dtype=torch.uint8)
     """
-    return _operations.__binary_op(torch.ge, t1, t2)
+    res = _operations.__binary_op(torch.ge, t1, t2)
+
+    if res.dtype != types.bool:
+        res = dndarray.DNDarray(
+            res.larray.type(torch.bool),
+            res.gshape,
+            types.bool,
+            res.split,
+            res.device,
+            res.comm,
+            res.balanced,
+        )
+
+    return res
 
 
 def gt(t1, t2):
@@ -147,7 +175,20 @@ def gt(t1, t2):
     tensor([[0, 0],
             [1, 1]], dtype=torch.uint8)
     """
-    return _operations.__binary_op(torch.gt, t1, t2)
+    res = _operations.__binary_op(torch.gt, t1, t2)
+
+    if res.dtype != types.bool:
+        res = dndarray.DNDarray(
+            res.larray.type(torch.bool),
+            res.gshape,
+            types.bool,
+            res.split,
+            res.device,
+            res.comm,
+            res.balanced,
+        )
+
+    return res
 
 
 def le(t1, t2):
@@ -182,7 +223,20 @@ def le(t1, t2):
     tensor([[1, 1],
             [0, 0]], dtype=torch.uint8)
     """
-    return _operations.__binary_op(torch.le, t1, t2)
+    res = _operations.__binary_op(torch.le, t1, t2)
+
+    if res.dtype != types.bool:
+        res = dndarray.DNDarray(
+            res.larray.type(torch.bool),
+            res.gshape,
+            types.bool,
+            res.split,
+            res.device,
+            res.comm,
+            res.balanced,
+        )
+
+    return res
 
 
 def lt(t1, t2):
@@ -217,7 +271,20 @@ def lt(t1, t2):
     tensor([[1, 0],
             [0, 0]], dtype=torch.uint8)
     """
-    return _operations.__binary_op(torch.lt, t1, t2)
+    res = _operations.__binary_op(torch.lt, t1, t2)
+
+    if res.dtype != types.bool:
+        res = dndarray.DNDarray(
+            res.larray.type(torch.bool),
+            res.gshape,
+            types.bool,
+            res.split,
+            res.device,
+            res.comm,
+            res.balanced,
+        )
+
+    return res
 
 
 def ne(t1, t2):
@@ -251,4 +318,17 @@ def ne(t1, t2):
     tensor([[1, 0],
             [1, 1]])
     """
-    return _operations.__binary_op(torch.ne, t1, t2)
+    res = _operations.__binary_op(torch.ne, t1, t2)
+
+    if res.dtype != types.bool:
+        res = dndarray.DNDarray(
+            res.larray.type(torch.bool),
+            res.gshape,
+            types.bool,
+            res.split,
+            res.device,
+            res.comm,
+            res.balanced,
+        )
+
+    return res

--- a/heat/core/tests/test_relational.py
+++ b/heat/core/tests/test_relational.py
@@ -20,15 +20,17 @@ class TestRelational(TestCase):
         cls.errorneous_type = (2, 2)
 
     def test_eq(self):
-        result = ht.uint8([[0, 1], [0, 0]])
+        result = ht.array([[False, True], [False, False]])
 
-        self.assertTrue(ht.equal(ht.eq(self.a_scalar, self.a_scalar), ht.uint8([1])))
+        self.assertTrue(ht.equal(ht.eq(self.a_scalar, self.a_scalar), ht.array([True])))
         self.assertTrue(ht.equal(ht.eq(self.a_tensor, self.a_scalar), result))
         self.assertTrue(ht.equal(ht.eq(self.a_scalar, self.a_tensor), result))
         self.assertTrue(ht.equal(ht.eq(self.a_tensor, self.another_tensor), result))
         self.assertTrue(ht.equal(ht.eq(self.a_tensor, self.a_vector), result))
         self.assertTrue(ht.equal(ht.eq(self.a_tensor, self.an_int_scalar), result))
         self.assertTrue(ht.equal(ht.eq(self.a_split_tensor, self.a_tensor), result))
+
+        self.assertEqual(ht.eq(self.a_split_tensor, self.a_tensor).dtype, ht.bool)
 
         with self.assertRaises(ValueError):
             ht.eq(self.a_tensor, self.another_vector)
@@ -44,16 +46,18 @@ class TestRelational(TestCase):
         self.assertFalse(ht.equal(self.another_tensor, self.a_scalar))
 
     def test_ge(self):
-        result = ht.uint8([[0, 1], [1, 1]])
-        commutated_result = ht.uint8([[1, 1], [0, 0]])
+        result = ht.uint8([[False, True], [True, True]])
+        commutated_result = ht.array([[True, True], [False, False]])
 
-        self.assertTrue(ht.equal(ht.ge(self.a_scalar, self.a_scalar), ht.uint8([1])))
+        self.assertTrue(ht.equal(ht.ge(self.a_scalar, self.a_scalar), ht.array([True])))
         self.assertTrue(ht.equal(ht.ge(self.a_tensor, self.a_scalar), result))
         self.assertTrue(ht.equal(ht.ge(self.a_scalar, self.a_tensor), commutated_result))
         self.assertTrue(ht.equal(ht.ge(self.a_tensor, self.another_tensor), result))
         self.assertTrue(ht.equal(ht.ge(self.a_tensor, self.a_vector), result))
         self.assertTrue(ht.equal(ht.ge(self.a_tensor, self.an_int_scalar), result))
         self.assertTrue(ht.equal(ht.ge(self.a_split_tensor, self.a_tensor), commutated_result))
+
+        self.assertEqual(ht.ge(self.a_split_tensor, self.a_tensor).dtype, ht.bool)
 
         with self.assertRaises(ValueError):
             ht.ge(self.a_tensor, self.another_vector)
@@ -63,16 +67,18 @@ class TestRelational(TestCase):
             ht.ge("self.a_tensor", "s")
 
     def test_gt(self):
-        result = ht.uint8([[0, 0], [1, 1]])
-        commutated_result = ht.uint8([[1, 0], [0, 0]])
+        result = ht.array([[False, False], [True, True]])
+        commutated_result = ht.array([[True, False], [False, False]])
 
-        self.assertTrue(ht.equal(ht.gt(self.a_scalar, self.a_scalar), ht.uint8([0])))
+        self.assertTrue(ht.equal(ht.gt(self.a_scalar, self.a_scalar), ht.array([False])))
         self.assertTrue(ht.equal(ht.gt(self.a_tensor, self.a_scalar), result))
         self.assertTrue(ht.equal(ht.gt(self.a_scalar, self.a_tensor), commutated_result))
         self.assertTrue(ht.equal(ht.gt(self.a_tensor, self.another_tensor), result))
         self.assertTrue(ht.equal(ht.gt(self.a_tensor, self.a_vector), result))
         self.assertTrue(ht.equal(ht.gt(self.a_tensor, self.an_int_scalar), result))
         self.assertTrue(ht.equal(ht.gt(self.a_split_tensor, self.a_tensor), commutated_result))
+
+        self.assertEqual(ht.gt(self.a_split_tensor, self.a_tensor).dtype, ht.bool)
 
         with self.assertRaises(ValueError):
             ht.gt(self.a_tensor, self.another_vector)
@@ -82,16 +88,18 @@ class TestRelational(TestCase):
             ht.gt("self.a_tensor", "s")
 
     def test_le(self):
-        result = ht.uint8([[1, 1], [0, 0]])
-        commutated_result = ht.uint8([[0, 1], [1, 1]])
+        result = ht.array([[True, True], [False, False]])
+        commutated_result = ht.array([[False, True], [True, True]])
 
-        self.assertTrue(ht.equal(ht.le(self.a_scalar, self.a_scalar), ht.uint8([1])))
+        self.assertTrue(ht.equal(ht.le(self.a_scalar, self.a_scalar), ht.array([True])))
         self.assertTrue(ht.equal(ht.le(self.a_tensor, self.a_scalar), result))
         self.assertTrue(ht.equal(ht.le(self.a_scalar, self.a_tensor), commutated_result))
         self.assertTrue(ht.equal(ht.le(self.a_tensor, self.another_tensor), result))
         self.assertTrue(ht.equal(ht.le(self.a_tensor, self.a_vector), result))
         self.assertTrue(ht.equal(ht.le(self.a_tensor, self.an_int_scalar), result))
         self.assertTrue(ht.equal(ht.le(self.a_split_tensor, self.a_tensor), commutated_result))
+
+        self.assertEqual(ht.le(self.a_split_tensor, self.a_tensor).dtype, ht.bool)
 
         with self.assertRaises(ValueError):
             ht.le(self.a_tensor, self.another_vector)
@@ -101,16 +109,18 @@ class TestRelational(TestCase):
             ht.le("self.a_tensor", "s")
 
     def test_lt(self):
-        result = ht.uint8([[1, 0], [0, 0]])
-        commutated_result = ht.uint8([[0, 0], [1, 1]])
+        result = ht.array([[True, False], [False, False]])
+        commutated_result = ht.array([[False, False], [True, True]])
 
-        self.assertTrue(ht.equal(ht.lt(self.a_scalar, self.a_scalar), ht.uint8([0])))
+        self.assertTrue(ht.equal(ht.lt(self.a_scalar, self.a_scalar), ht.array([False])))
         self.assertTrue(ht.equal(ht.lt(self.a_tensor, self.a_scalar), result))
         self.assertTrue(ht.equal(ht.lt(self.a_scalar, self.a_tensor), commutated_result))
         self.assertTrue(ht.equal(ht.lt(self.a_tensor, self.another_tensor), result))
         self.assertTrue(ht.equal(ht.lt(self.a_tensor, self.a_vector), result))
         self.assertTrue(ht.equal(ht.lt(self.a_tensor, self.an_int_scalar), result))
         self.assertTrue(ht.equal(ht.lt(self.a_split_tensor, self.a_tensor), commutated_result))
+
+        self.assertEqual(ht.lt(self.a_split_tensor, self.a_tensor).dtype, ht.bool)
 
         with self.assertRaises(ValueError):
             ht.lt(self.a_tensor, self.another_vector)
@@ -120,9 +130,9 @@ class TestRelational(TestCase):
             ht.lt("self.a_tensor", "s")
 
     def test_ne(self):
-        result = ht.uint8([[1, 0], [1, 1]])
+        result = ht.array([[True, False], [True, True]])
 
-        # self.assertTrue(ht.equal(ht.ne(self.a_scalar, self.a_scalar), ht.uint8([0])))
+        # self.assertTrue(ht.equal(ht.ne(self.a_scalar, self.a_scalar), ht.array([False])))
         # self.assertTrue(ht.equal(ht.ne(self.a_tensor, self.a_scalar), result))
         # self.assertTrue(ht.equal(ht.ne(self.a_scalar, self.a_tensor), result))
         # self.assertTrue(ht.equal(ht.ne(self.a_tensor, self.another_tensor), result))
@@ -130,6 +140,8 @@ class TestRelational(TestCase):
         # self.assertTrue(ht.equal(ht.ne(self.a_tensor, self.an_int_scalar), result))
         self.assertTrue(ht.equal(ht.ne(self.a_split_tensor, self.a_tensor), result))
         self.assertTrue(ht.equal(self.a_split_tensor != self.a_tensor, result))
+
+        self.assertEqual(ht.ne(self.a_split_tensor, self.a_tensor).dtype, ht.bool)
 
         with self.assertRaises(ValueError):
             ht.ne(self.a_tensor, self.another_vector)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         "mpi4py>=3.0.0",
         "numpy>=1.13.0",
-        "torch==1.7.0",
+        "torch>=1.7.0",
         "scipy>=0.14.0",
         "pillow>=6.0.0",
         "torchvision>=0.5.0",


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Cast the returned arrays in relational functions to bool.

Issue/s resolved: #729 

## Changes proposed:
- Check and cast array returned by all relational functions to bool if necessary

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no