### PR TITLE
make create_lshape_map safe for empty processes

### DIFF
--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -261,6 +261,13 @@ class TestDNDarray(TestCase):
         data.balance_()
         self.assertTrue(data.is_balanced())
 
+        data = ht.zeros((2, 3, 4, 100), split=3)
+        data = data[:, :, :, :2]  # only rank 0 has data
+        lshape_map = data.create_lshape_map()
+        lshape_map = lshape_map[:, : data.split]  # remove split-axis
+        for lshape in lshape_map:  # all others should be the same
+            self.assertTrue(all(lshape == lshape_map[0]))
+
         data = ht.zeros((70, 20), split=0, dtype=ht.float64)
         data = data[:50]
         data.balance_()


### PR DESCRIPTION
## Description

By @coquelin77 [comment](https://github.com/helmholtz-analytics/heat/issues/656#issuecomment-678262744) on issue #656  should individual functions handle the case that a process has no data. This PR adds that functionality to the `create_lshape_map` function (which currently throws an exception every time it encounters a process with no data).

Is this actually needed? Because it's so small I figured that just creating the PR is faster than asking beforehand. 

Additional note: Once the lshape is (0,) (#656), it is impossible to know in which dimension(s) the zero is, therefore I assume it to be in the split dimension if the dndarray is split. Another possibility might be to check the gshape for zeros as well.
<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #656

## Changes proposed:
- check if the local process is empty
- If so, use gshape instead of lshape
- Check if split is not None
- Add zero in the split-dimension

## Type of change
Non-breaking
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Due Diligence

- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
