### PR TITLE
restore repr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - [#735](https://github.com/helmholtz-analytics/heat/pull/735) Set return type to bool in relational functions.
 - [#744](https://github.com/helmholtz-analytics/heat/pull/744) Fix split semantics for reduction operations
 - [#756](https://github.com/helmholtz-analytics/heat/pull/756) Keep track of sent items while balancing within `sort()`
+- [#764](https://github.com/helmholtz-analytics/heat/pull/764) Fixed an issue where `repr` was giving the wrong output.
 
 ## Enhancements
 ### Manipulations

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -934,11 +934,11 @@ class DNDarray:
         dist = self.copy().resplit_(axis=None)
         return dist.larray.cpu().numpy()
 
-    def __repr__(self, *args):
+    def __repr__(self) -> str:
         """
-        Returns the ``DNDarray`` in string format
+        Computes a printable representation of the passed DNDarray.
         """
-        return self.__array.__repr__(*args)
+        return printing.__str__(self)
 
     def ravel(self):
         """

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -780,6 +780,10 @@ class TestDNDarray(TestCase):
             with self.assertRaises(ValueError):
                 st.redistribute_(target_map=torch.zeros((2, 4)))
 
+    def test_repr(self):
+        a = ht.array([1, 2, 3, 4])
+        self.assertEqual(a.__repr__(), a.__str__())
+
     def test_resplit(self):
         # resplitting with same axis, should leave everything unchanged
         shape = (ht.MPI_WORLD.size, ht.MPI_WORLD.size)


### PR DESCRIPTION
## Description

This PR fixes the wrong output of `DNDarray.__repr__()` introduced in e88a489e4980e35632b7f2aed503025e3887aad5
Issue/s resolved: #762 

## Changes proposed:
- fix __repr__

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
