### PR TITLE
add unary negative / positive + fix deg2rad / rad2deg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Pending additions
 
 ## Highlights
+- [#768](https://github.com/helmholtz-analytics/heat/pull/768) New feature: unary positive and negative operations
 
 ## Breaking Changes
 
 ## Bug fixes
+- [#768](https://github.com/helmholtz-analytics/heat/pull/768) Fixed an issue where `deg2rad` and `rad2deg`are not working with the 'out' parameter.
 
 
 # v1.0.0

--- a/heat/core/arithmetics.py
+++ b/heat/core/arithmetics.py
@@ -5,11 +5,12 @@ Arithmetic functions for DNDarrays
 from __future__ import annotations
 
 import torch
-from typing import Union, Tuple
+from typing import Optional, Union, Tuple
 
 from . import factories
 from . import manipulations
 from . import _operations
+from . import sanitation
 from . import stride_tricks
 from . import types
 
@@ -44,6 +45,10 @@ __all__ = [
     "mod",
     "mul",
     "multiply",
+    "neg",
+    "negative",
+    "pos",
+    "positive",
     "pow",
     "power",
     "prod",
@@ -250,6 +255,7 @@ def cumprod(a: DNDarray, axis: int, dtype: datatype = None, out=None) -> DNDarra
 
 # Alias support
 cumproduct = cumprod
+"""Alias for :py:func:`cumprod`"""
 
 
 def cumsum(a: DNDarray, axis: int, dtype: datatype = None, out=None) -> DNDarray:
@@ -457,6 +463,7 @@ DNDarray.__rtruediv__.__doc__ = div.__doc__
 
 # Alias in compliance with numpy API
 divide = div
+"""Alias for :py:func:`div`"""
 
 
 def fmod(t1: Union[DNDarray, float], t2: Union[DNDarray, float]) -> DNDarray:
@@ -520,6 +527,7 @@ DNDarray.__rfloordiv__.__doc__ = floordiv.__doc__
 
 # Alias in compliance with numpy API
 floor_divide = floordiv
+"""Alias for :py:func:`floordiv`"""
 
 
 def invert(a: DNDarray, out: DNDarray = None) -> DNDarray:
@@ -554,6 +562,7 @@ DNDarray.__invert__.__doc__ = invert.__doc__
 
 # alias for invert
 bitwise_not = invert
+"""Alias for :py:func:`invert`"""
 
 
 def left_shift(t1: DNDarray, t2: Union[DNDarray, float]) -> DNDarray:
@@ -664,6 +673,81 @@ DNDarray.__rmul__.__doc__ = mul.__doc__
 
 # Alias in compliance with numpy API
 multiply = mul
+"""Alias for :py:func:`mul`"""
+
+
+def neg(a: DNDarray, out: Optional[DNDarray] = None) -> DNDarray:
+    """
+    Element-wise negative of `a`.
+
+    Parameters
+    ----------
+    a:   DNDarray
+         The input array.
+    out: DNDarray, optional
+         The output array. It must have a shape that the inputs broadcast to
+
+    Examples
+    --------
+    >>> ht.neg(ht.array([-1, 1]))
+    DNDarray([ 1, -1], dtype=ht.int64, device=cpu:0, split=None)
+    >>> -ht.array([-1., 1.])
+    DNDarray([ 1., -1.], dtype=ht.float32, device=cpu:0, split=None)
+    """
+    sanitation.sanitize_in(a)
+
+    return _operations.__local_op(torch.neg, a, out, no_cast=True)
+
+
+DNDarray.__neg__ = lambda self: neg(self)
+DNDarray.__neg__.__doc__ = neg.__doc__
+
+# Alias in compliance with numpy API
+negative = neg
+"""Alias for :py:func:`neg`"""
+
+
+def pos(a: DNDarray, out: Optional[DNDarray] = None) -> DNDarray:
+    """
+    Element-wise positive of `a`.
+
+    Parameters
+    ----------
+    a:   DNDarray
+         The input array.
+    out: DNDarray, optional
+         The output array. It must have a shape that the inputs broadcast to.
+
+    Notes
+    -----
+    Equivalent to a.copy().
+
+    Examples
+    --------
+    >>> ht.pos(ht.array([-1, 1]))
+    DNDarray([-1,  1], dtype=ht.int64, device=cpu:0, split=None)
+    >>> +ht.array([-1., 1.])
+    DNDarray([-1.,  1.], dtype=ht.float32, device=cpu:0, split=None)
+    """
+    sanitation.sanitize_in(a)
+
+    def torch_pos(torch_tensor, out=None):
+        if not torch.is_tensor(torch_tensor):
+            raise TypeError("Input is not a torch tensor but {}".format(type(torch_tensor)))
+        return out.copy_(torch_tensor)
+
+    if out is not None:
+        return _operations.__local_op(torch_pos, a, out, no_cast=True)
+
+    return a.copy()
+
+
+DNDarray.__pos__ = lambda self: pos(self)
+DNDarray.__pos__.__doc__ = pos.__doc__
+
+# Alias in compliance with numpy API
+positive = pos
+"""Alias for :py:func:`pos`"""
 
 
 def pow(t1: Union[DNDarray, float], t2: Union[DNDarray, float]) -> DNDarray:
@@ -703,6 +787,7 @@ DNDarray.__rpow__.__doc__ = pow.__doc__
 
 # Alias in compliance with numpy API
 power = pow
+"""Alias for :py:func:`pow`"""
 
 
 def remainder(t1: Union[DNDarray, float], t2: Union[DNDarray, float]) -> DNDarray:
@@ -850,6 +935,9 @@ DNDarray.__rsub__.__doc__ = sub.__doc__
 
 # Alias in compliance with numpy API
 subtract = sub
+"""
+Alias for :py:func:`sub`
+"""
 
 
 def sum(

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -412,6 +412,32 @@ class TestArithmetics(TestCase):
         with self.assertRaises(TypeError):
             ht.mul("T", "s")
 
+    def test_neg(self):
+        self.assertTrue(ht.equal(ht.neg(ht.array([-1, 1])), ht.array([1, -1])))
+        self.assertTrue(ht.equal(-ht.array([-1.0, 1.0]), ht.array([1.0, -1.0])))
+
+        a = ht.array([1 + 1j, 2 - 2j, 3, 4j, 5], split=0)
+        b = out = ht.empty(5, dtype=ht.complex64, split=0)
+        ht.negative(a, out=out)
+        self.assertTrue(ht.equal(out, ht.array([-1 - 1j, -2 + 2j, -3, -4j, -5], split=0)))
+        self.assertIs(out, b)
+
+        with self.assertRaises(TypeError):
+            ht.neg(1)
+
+    def test_pos(self):
+        self.assertTrue(ht.equal(ht.pos(ht.array([-1, 1])), ht.array([-1, 1])))
+        self.assertTrue(ht.equal(+ht.array([-1.0, 1.0]), ht.array([-1.0, 1.0])))
+
+        a = ht.array([1 + 1j, 2 - 2j, 3, 4j, 5], split=0)
+        b = out = ht.empty(5, dtype=ht.complex64, split=0)
+        ht.positive(a, out=out)
+        self.assertTrue(ht.equal(out, a))
+        self.assertIs(out, b)
+
+        with self.assertRaises(TypeError):
+            ht.pos(1)
+
     def test_pow(self):
         result = ht.array([[1.0, 4.0], [9.0, 16.0]])
         commutated_result = ht.array([[2.0, 4.0], [8.0, 16.0]])

--- a/heat/core/trigonometrics.py
+++ b/heat/core/trigonometrics.py
@@ -233,13 +233,7 @@ def deg2rad(x: DNDarray, out: Optional[DNDarray] = None) -> DNDarray:
     >>> ht.deg2rad(ht.array([0.,20.,45.,78.,94.,120.,180., 270., 311.]))
     DNDarray([0.0000, 0.3491, 0.7854, 1.3614, 1.6406, 2.0944, 3.1416, 4.7124, 5.4280], dtype=ht.float32, device=cpu:0, split=None)
     """
-    # deg2rad torch version
-    def torch_deg2rad(torch_tensor):
-        if not torch.is_tensor(torch_tensor):
-            raise TypeError("Input is not a torch tensor but {}".format(type(torch_tensor)))
-        return torch_tensor * pi / 180.0
-
-    return local_op(torch_deg2rad, x, out)
+    return local_op(torch.deg2rad, x, out)
 
 
 def degrees(x: DNDarray, out: Optional[DNDarray] = None) -> DNDarray:
@@ -279,13 +273,7 @@ def rad2deg(x: DNDarray, out: Optional[DNDarray] = None) -> DNDarray:
     >>> ht.rad2deg(ht.array([0.,0.2,0.6,0.9,1.2,2.7,3.14]))
     DNDarray([  0.0000,  11.4592,  34.3775,  51.5662,  68.7549, 154.6986, 179.9088], dtype=ht.float32, device=cpu:0, split=None)
     """
-    # rad2deg torch version
-    def torch_rad2deg(torch_tensor):
-        if not torch.is_tensor(torch_tensor):
-            raise TypeError("Input is not a torch tensor but {}".format(type(torch_tensor)))
-        return 180.0 * torch_tensor / pi
-
-    return local_op(torch_rad2deg, x, out=out)
+    return local_op(torch.rad2deg, x, out=out)
 
 
 def radians(x: DNDarray, out: Optional[DNDarray] = None) -> DNDarray:


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

implement unary positive and negative operations + fix deg2rad / rad2deg

Issue/s resolved: #763 

## Changes proposed:
- add unary +
- add unary -
- deg2rad: replace with pytorch function
- rad2deg: replace with pytorch function
- add documentation for alias functions in arithmetics.py

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Documentation update

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
