### PR TITLE
Change MPI buffer creation + 1D non-contiguous tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@ Example on 2 processes:
 ## Bug Fixes
 - [#758](https://github.com/helmholtz-analytics/heat/pull/758) Fix indexing inconsistencies in `DNDarray.__getitem__()`
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) Fixed an issue where `deg2rad` and `rad2deg`are not working with the 'out' parameter.
-- TBD Removed `storage_offset` when finding the mpi buffer (`communication. MPICommunication.as_mpi_memory()`).
-- TBD added allowance for 1 dimensional non-contiguous local tensors in `communication. MPICommunication.mpi_type_and_elements_of()`
+- [#785](https://github.com/helmholtz-analytics/heat/pull/785) Removed `storage_offset` when finding the mpi buffer (`communication. MPICommunication.as_mpi_memory()`).
+- [#785](https://github.com/helmholtz-analytics/heat/pull/785) added allowance for 1 dimensional non-contiguous local tensors in `communication. MPICommunication.mpi_type_and_elements_of()`
 ### Linear Algebra
 - [#718](https://github.com/helmholtz-analytics/heat/pull/718) New feature: `trace()`
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) New feature: unary positive and negative operations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,16 +38,14 @@ Example on 2 processes:
 
 ## Bug Fixes
 - [#758](https://github.com/helmholtz-analytics/heat/pull/758) Fix indexing inconsistencies in `DNDarray.__getitem__()`
+- [#768](https://github.com/helmholtz-analytics/heat/pull/768) Fixed an issue where `deg2rad` and `rad2deg`are not working with the 'out' parameter.
+- TBD Removed `storage_offset` when finding the mpi buffer (`communication. MPICommunication.as_mpi_memory()`).
+- TBD added allowance for 1 dimensional non-contiguous local tensors in `communication. MPICommunication.mpi_type_and_elements_of()`
 ### Linear Algebra
 - [#718](https://github.com/helmholtz-analytics/heat/pull/718) New feature: `trace()`
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) New feature: unary positive and negative operations
 ### Misc.
 - [#761](https://github.com/helmholtz-analytics/heat/pull/761) New feature: `result_type`
-
-## Breaking Changes
-
-## Bug fixes
-- [#768](https://github.com/helmholtz-analytics/heat/pull/768) Fixed an issue where `deg2rad` and `rad2deg`are not working with the 'out' parameter.
 
 
 # v1.0.0

--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -277,9 +277,13 @@ class MPICommunication(Communication):
         elements = obj.shape[0]
         shape = obj.shape[1:]
         strides = [1] * len(shape)
-        strides[0] = obj.stride()[-1]
-        strides = strides[::-1]
-        offsets = [obj.element_size() * stride for stride in obj.stride()[:-1]]
+        if obj.ndim > 1:
+            strides[0] = obj.stride()[-1]
+            strides = strides[::-1]
+            offsets = [obj.element_size() * stride for stride in obj.stride()[:-1]]
+        else:
+            strides = obj.stride()
+            offsets = [0]
 
         # chain the types based on the
         for i in range(len(shape) - 1, -1, -1):
@@ -302,7 +306,7 @@ class MPICommunication(Communication):
             The tensor to be converted into a MPI memory view.
         """
         pointer = obj.data_ptr()
-        pointer += obj.storage_offset()
+        # pointer += obj.storage_offset()
 
         return MPI.memory.fromaddress(pointer, 0)
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -23,6 +23,7 @@ from . import types
 from . import _operations
 
 __all__ = [
+    "balance",
     "column_stack",
     "concatenate",
     "diag",
@@ -52,6 +53,35 @@ __all__ = [
     "vsplit",
     "vstack",
 ]
+
+
+def balance(array: DNDarray, copy=False) -> DNDarray:
+    """
+    Out of place balance function. More information on the meaning of balance can be found in
+    :func:`DNDarray.balance_() <heat.core.dndarray.DNDarray.balance_()>`.
+
+    Parameters
+    ----------
+    array : DNDarray
+        the DNDarray to be balanced
+    copy : bool, optional
+        if the DNDarray should be copied before being balanced. If false (default) this will balance
+        the original array and return that array. Otherwise (true), a balanced copy of the array
+        will be returned.
+        Default: False
+
+    Returns
+    -------
+    balanced : DNDarray
+        The balanced DNDarray
+    """
+    cpy = array.copy() if copy else array
+    cpy.balance_()
+    return cpy
+
+
+DNDarray.balance = lambda self, copy=False: balance(self, copy)
+DNDarray.balance.__doc__ = balance.__doc__
 
 
 def column_stack(arrays: Sequence[DNDarray, ...]) -> DNDarray:

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -968,6 +968,14 @@ class TestDNDarray(TestCase):
         self.assertEqual(resplit_a.dtype, ht.int64)
         del a
 
+        # 1D non-contiguous resplit testing
+        t1 = ht.arange(10 * 10, split=0).reshape((10, 10))
+        t1_sub = t1[:, 1]  # .expand_dims(0)
+        res = ht.array([1, 11, 21, 31, 41, 51, 61, 71, 81, 91])
+        t1_sub.resplit_(axis=None)
+        self.assertTrue(ht.all(t1_sub == res))
+        self.assertEqual(t1_sub.split, None)
+
     def test_rshift(self):
         int_tensor = ht.array([[0, 2], [4, 8]])
         int_result = ht.array([[0, 0], [1, 2]])

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -262,13 +262,11 @@ class TestDNDarray(TestCase):
         self.assertTrue(data.is_balanced())
 
         data = ht.zeros((70, 20), split=0, dtype=ht.float64)
-        data = data[:50]
-        data.balance_()
+        data = ht.balance(data[:50], copy=True)
         self.assertTrue(data.is_balanced())
 
         data = ht.zeros((4, 120), split=1, dtype=ht.int64)
-        data = data[:, 40:70]
-        data.balance_()
+        data = data[:, 40:70].balance()
         self.assertTrue(data.is_balanced())
 
         data = np.loadtxt("heat/datasets/iris.csv", delimiter=";")


### PR DESCRIPTION
## Description

Removed `storage_offset` when finding the mpi buffer (`communication. MPICommunication.as_mpi_memory()`).
Added allowance for 1 dimensional non-contiguous local tensors in `communication. MPICommunication.mpi_type_and_elements_of()`

Issue/s resolved: #769 #784 

## Changes proposed:
- removed `storage_offset` addition to data pointer in `communication. MPICommunication.as_mpi_memory()`
- added if block to determine strides for non-contiguous 1D local tensors in `communication. MPICommunication.mpi_type_and_elements_of()`

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
