### PR TITLE
added device call after the bcast in the getitem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Example on 2 processes:
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) Fixed an issue where `deg2rad` and `rad2deg`are not working with the 'out' parameter.
 - [#785](https://github.com/helmholtz-analytics/heat/pull/785) Removed `storage_offset` when finding the mpi buffer (`communication. MPICommunication.as_mpi_memory()`).
 - [#785](https://github.com/helmholtz-analytics/heat/pull/785) added allowance for 1 dimensional non-contiguous local tensors in `communication. MPICommunication.mpi_type_and_elements_of()`
+- [#790](https://github.com/helmholtz-analytics/heat/pull/790) catch incorrect device after `bcast` in `DNDarray.__getitem__`
 ### Linear Algebra
 - [#718](https://github.com/helmholtz-analytics/heat/pull/718) New feature: `trace()`
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) New feature: unary positive and negative operations

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -884,6 +884,7 @@ class DNDarray:
             # TODO: Replace with `self.comm.Bcast(arr, root=active_rank)` after fixing #784
             arr = self.comm.bcast(arr, root=active_rank)
             if arr.device != self.larray.device:
+                # todo: remove when unnecessary (also after #784)
                 arr = arr.to(device=self.larray.device)
 
         return DNDarray(

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -883,6 +883,8 @@ class DNDarray:
             # broadcast result
             # TODO: Replace with `self.comm.Bcast(arr, root=active_rank)` after fixing #784
             arr = self.comm.bcast(arr, root=active_rank)
+            if arr.device != self.larray.device:
+                arr = arr.to(device=self.larray.device)
 
         return DNDarray(
             arr.type(l_dtype),


### PR DESCRIPTION
## Description

a minor bug was showing up where the `bcast` operation was not putting the data onto the proper GPU in the `__getitem__` function. the code added may not be hit all the time, but it is safeguard for when this may happen. 

Issue/s resolved: n/a

## Changes proposed:
- move the local array to the proper GPU after the `bcast` when there are integers in the getitem key

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no