### PR TITLE
docs copybutton

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,8 +45,8 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
+    "sphinx_copybutton",
 ]
-
 
 # Document Python Code
 autoapi_type = "python"
@@ -87,6 +87,9 @@ def setup(sphinx):
 templates_path = ["_templates"]
 napoleon_numpy_docstring = True
 napoleon_use_ivar = True
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 html_show_sourcelink = True
 

--- a/doc/source/tutorial_30_minutes.rst
+++ b/doc/source/tutorial_30_minutes.rst
@@ -51,7 +51,7 @@ Output:
     DNDarray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=ht.int32, device=cpu:0, split=None)
 
 
-The following snippet creates a column vector with :math:`5` element, each position filled with the value :math:`9` and the ``ht.int64`` data type.
+The following snippet creates a column vector with :math:`5` elements, each position filled with the value :math:`9` and the ``ht.int64`` data type.
 
 .. code:: python
 

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -38,7 +38,7 @@ Heat Tutorials
 
         <a class="reference external" href="tutorial_parallel_computation.html">
             <div class="tutorial-text">
-                <strong>Parallel Computing</strong>
+                <strong>Turn up the Heat - Parallel Computing</strong>
                 <p/>
                 <p>Speed up Heat even further with GPUs acceleration or distributed MPI computation.</p>
                 <em>Well-suited for beginners.</em>
@@ -57,7 +57,7 @@ Heat Tutorials
 
         <a class="reference external" href="tutorial_clustering.html">
             <div class="tutorial-text">
-                <strong>Cluster Analysis</strong>
+                <strong>Keep the Heat - Cluster Analysis</strong>
                 <p/>
                 <p>Automatically identify clusters in your data by employing unsupervised clustering methods.</p>
                 <em>For intermediate analysts.</em>


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

A small PR that adds the [copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/) extension for sphinx in the docs. Like the its name suggests, it adds a button at the side of an code block and copies the text to the Clipboard when clicked. Some configuration was done for stripping command prompts and outputs.

Small text change in the tutorials main page to stick to the heat theme + typo fix.

Issue/s resolved: #n/a

## Changes proposed:
- docs: copybutton extension
- docs: text rewrite

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- Documentation update

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
