### PR TITLE
meshgrid implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Example on 2 processes:
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) New feature: unary positive and negative operations
 ### Misc.
 - [#761](https://github.com/helmholtz-analytics/heat/pull/761) New feature: `result_type`
+- [#794](https://github.com/helmholtz-analytics/heat/pull/794) New feature: `meshgrid`
 
 
 # v1.0.0

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -1053,13 +1053,9 @@ def meshgrid(*arrays: Sequence[DNDarray], indexing: str = "xy") -> List[DNDarray
     ----------
     arrays : Sequence[ DNDarray ]
         one-dimensional arrays representing grid coordinates. If exactly one vector is distributed, the returned matrices will
-        be distributed along the axis equal to the index of this vector in the input list. See Note for special case.
+        be distributed along the axis equal to the index of this vector in the input list.
     indexing : str, optional
         Cartesian ‘xy’ or matrix ‘ij’ indexing of output. It is ignored if zero or one one-dimensional arrays are provided. Default: 'xy' .
-
-    Note
-    ----
-    If `indexing == xy` and the vector at position 0 or 1 is distributed, the split axis for the returned arrays will be switched.
 
     Raises
     ------
@@ -1103,9 +1099,11 @@ def meshgrid(*arrays: Sequence[DNDarray], indexing: str = "xy") -> List[DNDarray
     if indexing == "xy" and len(arrays) > 1:
         arrays[0], arrays[1] = arrays[1], arrays[0]
         if splitted == 0:
-            splitted = 1
+            arrays[0] = arrays[0].resplit(0)
+            arrays[1] = arrays[1].resplit(None)
         elif splitted == 1:
-            splitted = 0
+            arrays[0] = arrays[0].resplit(None)
+            arrays[1] = arrays[1].resplit(0)
 
     grids = torch.meshgrid(*(array.larray for array in arrays))
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -4,12 +4,13 @@ import numpy as np
 import torch
 import warnings
 
-from typing import Callable, Iterable, Optional, Sequence, Tuple, Type, Union
+from typing import Callable, Iterable, Optional, Sequence, Tuple, Type, Union, List
 
 from .communication import MPI, sanitize_comm, Communication
 from .devices import Device
 from .dndarray import DNDarray
 from .memory import sanitize_memory_layout
+from .sanitation import sanitize_in, sanitize_sequence
 from .stride_tricks import sanitize_axis, sanitize_shape
 from .types import datatype
 
@@ -28,6 +29,7 @@ __all__ = [
     "full_like",
     "linspace",
     "logspace",
+    "meshgrid",
     "ones",
     "ones_like",
     "zeros",
@@ -1041,6 +1043,78 @@ def logspace(
     if dtype is None:
         return pow(base, y)
     return pow(base, y).astype(dtype, copy=False)
+
+
+def meshgrid(*arrays: Sequence[DNDarray], indexing: str = "xy") -> List[DNDarray]:
+    """
+    Returns coordinate matrices from coordinate vectors.
+
+    Parameters
+    ----------
+    arrays : Sequence[ DNDarray ]
+        one-dimensional arrays representing grid coordinates. If exactly one vector is distributed, the returned matrices will
+        be distributed along the axis equal to the index of this vector in the input list. See Note for special case.
+    indexing : str, optional
+        Cartesian ‘xy’ or matrix ‘ij’ indexing of output. It is ignored if zero or one one-dimensional arrays are provided. Default: 'xy' .
+
+    Note
+    ----
+    If `indexing == xy` and the vector at position 0 or 1 is distributed, the split axis for the returned arrays will be switched.
+
+    Raises
+    ------
+    ValueError
+        If `indexing` is not 'xy' or 'ij'.
+    ValueError
+        If more than one input vector is distributed.
+
+    Examples
+    --------
+    >>> x = ht.arange(4)
+    >>> y = ht.arange(3)
+    >>> xx, yy = ht.meshgrid(x,y)
+    >>> xx
+    DNDarray([[0, 1, 2, 3],
+          [0, 1, 2, 3],
+          [0, 1, 2, 3]], dtype=ht.int32, device=cpu:0, split=None)
+    >>> yy
+    DNDarray([[0, 0, 0, 0],
+          [1, 1, 1, 1],
+          [2, 2, 2, 2]], dtype=ht.int32, device=cpu:0, split=None)
+    """
+    splitted = None
+
+    if indexing not in ["xy", "ij"]:
+        raise ValueError("Valid values for `indexing` are 'xy' and 'ij'.")
+
+    if len(arrays) == 0:
+        return []
+
+    arrays = sanitize_sequence(arrays)
+
+    for idx, array in enumerate(arrays):
+        sanitize_in(array)
+        if array.split is not None:
+            if splitted is not None:
+                raise ValueError("split != None are not supported.")
+            splitted = idx
+
+    # pytorch does not support the indexing keyword: switch vectors
+    if indexing == "xy" and len(arrays) > 1:
+        arrays[0], arrays[1] = arrays[1], arrays[0]
+        if splitted == 0:
+            splitted = 1
+        elif splitted == 1:
+            splitted = 0
+
+    grids = torch.meshgrid(*(array.larray for array in arrays))
+
+    # pytorch does not support indexing keyword: switch back
+    if indexing == "xy" and len(arrays) > 1:
+        grids = list(grids)
+        grids[0], grids[1] = grids[1], grids[0]
+
+    return list(asarray(grid, is_split=splitted) for grid in grids)
 
 
 def ones(

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -1112,7 +1112,20 @@ def meshgrid(*arrays: Sequence[DNDarray], indexing: str = "xy") -> List[DNDarray
         grids = list(grids)
         grids[0], grids[1] = grids[1], grids[0]
 
-    return list(asarray(grid, is_split=splitted) for grid in grids)
+    shape = tuple(array.size for array in arrays)
+
+    return list(
+        DNDarray(
+            array=grid,
+            gshape=shape,
+            dtype=types.heat_type_of(grid),
+            split=splitted,
+            device=devices.sanitize_device(grid.device.type),
+            comm=sanitize_comm(None),
+            balanced=True,
+        )
+        for grid in grids
+    )
 
 
 def ones(

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -2,7 +2,6 @@ import numpy as np
 import torch
 
 import heat as ht
-from torch._C import Value
 from .test_suites.basic_test import TestCase
 
 

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -740,26 +740,26 @@ class TestFactories(TestCase):
         # 3 arrays
         z = ht.linspace(0, 1, 3, split=0)
 
-        # special case 'xy' split 1
+        # split 0
         zz, xx, yy = ht.meshgrid(z, x, y)
 
         res_zz, res_xx, res_yy = np.meshgrid(z.numpy(), x.numpy(), y.numpy())
 
-        self.assertEqual(xx.split, 1)
-        self.assertEqual(yy.split, 1)
-        self.assertEqual(zz.split, 1)
+        self.assertEqual(xx.split, 0)
+        self.assertEqual(yy.split, 0)
+        self.assertEqual(zz.split, 0)
         self.assertTrue(ht.equal(xx, ht.array(res_xx)))
         self.assertTrue(ht.equal(yy, ht.array(res_yy)))
         self.assertTrue(ht.equal(zz, ht.array(res_zz)))
 
-        # special case 'xy' split 0
+        # split 1
         xx, zz, yy = ht.meshgrid(x, z, y)
 
         res_xx, res_zz, res_yy = np.meshgrid(x.numpy(), z.numpy(), y.numpy())
 
-        self.assertEqual(xx.split, 0)
-        self.assertEqual(yy.split, 0)
-        self.assertEqual(zz.split, 0)
+        self.assertEqual(xx.split, 1)
+        self.assertEqual(yy.split, 1)
+        self.assertEqual(zz.split, 1)
         self.assertTrue(ht.equal(xx, ht.array(res_xx)))
         self.assertTrue(ht.equal(yy, ht.array(res_yy)))
         self.assertTrue(ht.equal(zz, ht.array(res_zz)))

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 
 import heat as ht
+from torch._C import Value
 from .test_suites.basic_test import TestCase
 
 
@@ -689,6 +690,98 @@ class TestFactories(TestCase):
             ht.logspace(-5, 3, num=-1)
         with self.assertRaises(ValueError):
             ht.logspace(-5, 3, num=0)
+
+    def test_meshgrid(self):
+        # arrays < 2
+        self.assertEqual(ht.meshgrid(), [])
+        self.assertEqual(ht.meshgrid(ht.array(1)), [ht.array(1)])
+
+        # 2 arrays
+        x = ht.arange(4)
+        y = ht.arange(3)
+        xx, yy = ht.meshgrid(x, y)
+        res_xx = ht.array([[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]], dtype=ht.int32, split=None)
+        res_yy = ht.array([[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]], dtype=ht.int32, split=None)
+
+        self.assertEqual(xx.shape, res_xx.shape)
+        self.assertEqual(yy.shape, res_yy.shape)
+        self.assertEqual(xx.device, res_xx.device)
+        self.assertEqual(yy.device, res_yy.device)
+        self.assertEqual(xx.dtype, x.dtype)
+        self.assertEqual(yy.dtype, y.dtype)
+        self.assertTrue(ht.equal(xx, res_xx))
+        self.assertTrue(ht.equal(yy, res_yy))
+
+        # different dtype + indexing parameter
+        x = ht.linspace(0, 4, 3)
+        y = ht.linspace(0, 4, 5)
+        xx, yy = ht.meshgrid(x, y, indexing="ij")
+
+        res_xx = ht.array(
+            [[0.0, 0.0, 0.0, 0.0, 0.0], [2.0, 2.0, 2.0, 2.0, 2.0], [4.0, 4.0, 4.0, 4.0, 4.0]],
+            dtype=ht.float32,
+            split=None,
+        )
+        res_yy = ht.array(
+            [[0.0, 1.0, 2.0, 3.0, 4.0], [0.0, 1.0, 2.0, 3.0, 4.0], [0.0, 1.0, 2.0, 3.0, 4.0]],
+            dtype=ht.float32,
+            split=None,
+        )
+
+        self.assertEqual(xx.shape, res_xx.shape)
+        self.assertEqual(yy.shape, res_yy.shape)
+        self.assertEqual(xx.device, res_xx.device)
+        self.assertEqual(yy.device, res_yy.device)
+        self.assertEqual(xx.dtype, x.dtype)
+        self.assertEqual(yy.dtype, y.dtype)
+        self.assertTrue(ht.equal(xx, res_xx))
+        self.assertTrue(ht.equal(yy, res_yy))
+
+        # 3 arrays
+        z = ht.linspace(0, 1, 3, split=0)
+
+        # special case 'xy' split 1
+        zz, xx, yy = ht.meshgrid(z, x, y)
+
+        res_zz, res_xx, res_yy = np.meshgrid(z.numpy(), x.numpy(), y.numpy())
+
+        self.assertEqual(xx.split, 1)
+        self.assertEqual(yy.split, 1)
+        self.assertEqual(zz.split, 1)
+        self.assertTrue(ht.equal(xx, ht.array(res_xx)))
+        self.assertTrue(ht.equal(yy, ht.array(res_yy)))
+        self.assertTrue(ht.equal(zz, ht.array(res_zz)))
+
+        # special case 'xy' split 0
+        xx, zz, yy = ht.meshgrid(x, z, y)
+
+        res_xx, res_zz, res_yy = np.meshgrid(x.numpy(), z.numpy(), y.numpy())
+
+        self.assertEqual(xx.split, 0)
+        self.assertEqual(yy.split, 0)
+        self.assertEqual(zz.split, 0)
+        self.assertTrue(ht.equal(xx, ht.array(res_xx)))
+        self.assertTrue(ht.equal(yy, ht.array(res_yy)))
+        self.assertTrue(ht.equal(zz, ht.array(res_zz)))
+
+        # split 2
+        xx, yy, zz = ht.meshgrid(x, y, z)
+
+        res_xx, res_yy, res_zz = np.meshgrid(x.numpy(), y.numpy(), z.numpy())
+
+        self.assertEqual(xx.split, 2)
+        self.assertEqual(yy.split, 2)
+        self.assertEqual(zz.split, 2)
+        self.assertTrue(ht.equal(xx, ht.array(res_xx)))
+        self.assertTrue(ht.equal(yy, ht.array(res_yy)))
+        self.assertTrue(ht.equal(zz, ht.array(res_zz)))
+
+        # exceptions
+        with self.assertRaises(ValueError):
+            ht.meshgrid(ht.array(1), indexing="abc")
+
+        with self.assertRaises(ValueError):
+            ht.meshgrid(ht.array([0, 1], split=0), ht.array([1, 2], split=0))
 
     def test_ones(self):
         # scalar input


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Implements meshgrid functionality to Heat. It uses the pytorch function of the same name. That function does not support the indexing parameter. As a hotfix for now, the first and second vector are switched during computation when using 'xy'. If the split is on the first or second axis, they are resplitted beforehand.

Issue/s resolved: #775 

## Changes proposed:
- add meshgrid function

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- New feature

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no