### PR TITLE
Bug/795-reshape split none to new split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,14 +37,18 @@ Example on 2 processes:
   ```
 
 ## Bug Fixes
+- [#796](https://github.com/helmholtz-analytics/heat/pull/796) `heat.reshape(a, shape, new_split)` now always returns a distributed `DNDarray` if `new_split is not None` (inlcuding when the original input `a` is not distributed)
 - [#758](https://github.com/helmholtz-analytics/heat/pull/758) Fix indexing inconsistencies in `DNDarray.__getitem__()`
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) Fixed an issue where `deg2rad` and `rad2deg`are not working with the 'out' parameter.
 - [#785](https://github.com/helmholtz-analytics/heat/pull/785) Removed `storage_offset` when finding the mpi buffer (`communication. MPICommunication.as_mpi_memory()`).
 - [#785](https://github.com/helmholtz-analytics/heat/pull/785) added allowance for 1 dimensional non-contiguous local tensors in `communication. MPICommunication.mpi_type_and_elements_of()`
 - [#790](https://github.com/helmholtz-analytics/heat/pull/790) catch incorrect device after `bcast` in `DNDarray.__getitem__`
+
 ### Linear Algebra
 - [#718](https://github.com/helmholtz-analytics/heat/pull/718) New feature: `trace()`
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) New feature: unary positive and negative operations
+### Manipulations
+- [#796](https://github.com/helmholtz-analytics/heat/pull/796) `DNDarray.reshape(shape)`: method now allows shape elements to be passed in as single arguments.
 ### Misc.
 - [#761](https://github.com/helmholtz-analytics/heat/pull/761) New feature: `result_type`
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Citing Heat
 
 If you find Heat helpful for your research, please mention it in your academic publications. You can cite:
 
-- Götz, M., Debus, C., Coquelin, D., Krajsek, K., Comito, C., Knechtges, P., .Hagemeier, B., Tarnawa, M., Hanselmann, S., Siggel, S., Basermann, A. & Streit, A. (2020). HeAT - a Distributed and GPU-accelerated Tensor Framework for Data Analytics. In Proceedings of the 19th IEEE International Conference on Big Data (BigData) (pp. 276-288). IEEE.
+- Götz, M., Debus, C., Coquelin, D., Krajsek, K., Comito, C., Knechtges, P., .Hagemeier, B., Tarnawa, M., Hanselmann, S., Siggel, S., Basermann, A. & Streit, A. (2020). HeAT - a Distributed and GPU-accelerated Tensor Framework for Data Analytics. In 2020 IEEE International Conference on Big Data (Big Data) (pp. 276-287). IEEE, DOI: 10.1109/BigData50022.2020.9378050.
 
 ```
 @inproceedings{heat2020,

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If you find Heat helpful for your research, please mention it in your academic p
       Achim Basermann and
       Achim Streit
     },
-    booktitle={2020 IEEE International Conference on Big Data (Big Data)}, 
+    booktitle={2020 IEEE International Conference on Big Data (Big Data)},
     year={2020},
     pages={276-287},
     month={December},

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you find Heat helpful for your research, please mention it in your academic p
 - Götz, M., Debus, C., Coquelin, D., Krajsek, K., Comito, C., Knechtges, P., .Hagemeier, B., Tarnawa, M., Hanselmann, S., Siggel, S., Basermann, A. & Streit, A. (2020). HeAT - a Distributed and GPU-accelerated Tensor Framework for Data Analytics. In Proceedings of the 19th IEEE International Conference on Big Data (BigData) (pp. 276-288). IEEE.
 
 ```
-@inproceedings{heat20,
+@inproceedings{heat2020,
     title={{HeAT -- a Distributed and GPU-accelerated Tensor Framework for Data Analytics}},
     author={
       Markus Götz and
@@ -124,11 +124,12 @@ If you find Heat helpful for your research, please mention it in your academic p
       Achim Basermann and
       Achim Streit
     },
-    booktitle={Proceedings of the 19th IEEE International Conference on Big Data},
+    booktitle={2020 IEEE International Conference on Big Data (Big Data)}, 
     year={2020},
-    pages={276-288},
+    pages={276-287},
     month={December},
-    publisher={IEEE}
+    publisher={IEEE},
+    doi={10.1109/BigData50022.2020.9378050}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,11 +138,7 @@ Acknowledgements
 
 *This work is supported by the [Helmholtz Association Initiative and
 Networking Fund](https://www.helmholtz.de/en/about_us/the_association/initiating_and_networking/)
-under project number ZT-I-0003.*
-
-*This work is supported by the [Helmholtz Association Initiative and
-Networking Fund](https://www.helmholtz.de/en/about_us/the_association/initiating_and_networking/)
-under the Helmholtz AI platform grant.*
+under project number ZT-I-0003 and the Helmholtz AI platform grant.*
 
 ---
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1685,7 +1685,7 @@ def repeat(a: Iterable, repeats: Iterable, axis: Optional[int] = None) -> DNDarr
     return repeated_array
 
 
-def reshape(a: DNDarray, shape: Tuple[int, ...], new_split: Optional[int] = None) -> DNDarray:
+def reshape(a: DNDarray, *shape: Tuple[int, ...], **kwargs) -> DNDarray:
     """
     Returns an array with the same data and number of elements as `a`, but with the specified shape.
 
@@ -1723,6 +1723,10 @@ def reshape(a: DNDarray, shape: Tuple[int, ...], new_split: Optional[int] = None
     """
     if not isinstance(a, DNDarray):
         raise TypeError("'a' must be a DNDarray, currently {}".format(type(a)))
+
+    # check for nested sequence
+    if isinstance(shape[0], (tuple, list)):
+        shape = shape[0]
 
     tdtype, tdevice = a.dtype.torch_type(), a.device.torch_device
 
@@ -1768,9 +1772,10 @@ def reshape(a: DNDarray, shape: Tuple[int, ...], new_split: Optional[int] = None
         raise TypeError("shape must be list, tuple, currently {}".format(type(shape)))
 
     # check new_split parameter
+    new_split = kwargs.get("new_split")
     if new_split is None:
         new_split = a.split
-    stride_tricks.sanitize_axis(shape, new_split)
+    new_split = stride_tricks.sanitize_axis(shape, new_split)
 
     # Check the type of shape and number elements
     shape = stride_tricks.sanitize_shape(shape, -1)
@@ -1791,8 +1796,27 @@ def reshape(a: DNDarray, shape: Tuple[int, ...], new_split: Optional[int] = None
 
     # Forward to Pytorch directly
     if a.split is None:
-        return factories.array(
-            torch.reshape(a.larray, shape), dtype=a.dtype, device=a.device, comm=a.comm
+        local_reshape = torch.reshape(a.larray, shape)
+        if new_split is None:
+            return DNDarray(
+                local_reshape,
+                tuple(shape),
+                dtype=a.dtype,
+                split=None,
+                device=a.device,
+                comm=a.comm,
+                balanced=True,
+            )
+        _, _, local_slice = a.comm.chunk(shape, new_split)
+        local_reshape = local_reshape[local_slice]
+        return DNDarray(
+            local_reshape,
+            tuple(shape),
+            dtype=a.dtype,
+            split=new_split,
+            comm=a.comm,
+            device=a.device,
+            balanced=True,
         )
 
     # Create new flat result tensor
@@ -1824,10 +1848,19 @@ def reshape(a: DNDarray, shape: Tuple[int, ...], new_split: Optional[int] = None
     # Reshape local tensor
     data = data.reshape(local_shape)
 
-    return factories.array(data, dtype=a.dtype, is_split=new_split, device=a.device, comm=a.comm)
+    # return factories.array(data, dtype=a.dtype, is_split=new_split, device=a.device, comm=a.comm)
+    return DNDarray(
+        data,
+        tuple(shape),
+        dtype=a.dtype,
+        split=new_split,
+        device=a.device,
+        comm=a.comm,
+        balanced=True,
+    )
 
 
-DNDarray.reshape = lambda self, shape, axis=None: reshape(self, shape, axis)
+DNDarray.reshape = lambda self, *shape, **kwargs: reshape(self, *shape, **kwargs)
 DNDarray.reshape.__doc__ = reshape.__doc__
 
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1685,7 +1685,7 @@ def repeat(a: Iterable, repeats: Iterable, axis: Optional[int] = None) -> DNDarr
     return repeated_array
 
 
-def reshape(a: DNDarray, *shape: Tuple[int, ...], **kwargs) -> DNDarray:
+def reshape(a: DNDarray, *shape: Union[int, Tuple[int, ...]], **kwargs) -> DNDarray:
     """
     Returns an array with the same data and number of elements as `a`, but with the specified shape.
 
@@ -1693,7 +1693,7 @@ def reshape(a: DNDarray, *shape: Tuple[int, ...], **kwargs) -> DNDarray:
     ----------
     a : DNDarray
         The input array
-    shape : Tuple[int,...]
+    shape : Union[int, Tuple[int,...]]
         Shape of the new array
     new_split : int, optional
         The new split axis if `a` is a split DNDarray. None denotes same axis.
@@ -1725,10 +1725,34 @@ def reshape(a: DNDarray, *shape: Tuple[int, ...], **kwargs) -> DNDarray:
         raise TypeError("'a' must be a DNDarray, currently {}".format(type(a)))
 
     # check for nested sequence
-    if isinstance(shape[0], (tuple, list)):
+    if not np.isscalar(shape[0]):
         shape = shape[0]
+    if shape == -1:
+        shape = (a.gnumel,)
 
     tdtype, tdevice = a.dtype.torch_type(), a.device.torch_device
+
+    # check for valid shape type, shape size
+    a_proxy = torch.ones((1,)).as_strided(a.gshape, [0] * a.ndim)
+    try:
+        a_proxy.reshape(shape)
+    except TypeError as e:
+        raise TypeError(e)
+    except (RuntimeError, ValueError):
+        shape = list(shape)
+        shape_size = torch.prod(torch.tensor(shape, dtype=torch.int, device=tdevice))
+        if shape.count(-1) > 1:
+            raise ValueError("too many unknown dimensions")
+        elif shape.count(-1) == 1:
+            if a.size % shape_size != 0:
+                raise ValueError(
+                    "cannot reshape array of size {} into shape {}".format(a.size, shape)
+                )
+        else:
+            if a.size != shape_size:
+                raise ValueError(
+                    "cannot reshape array of size {} into shape {}".format(a.size, shape)
+                )
 
     def reshape_argsort_counts_displs(
         shape1, lshape1, displs1, axis1, shape2, displs2, axis2, comm
@@ -1765,34 +1789,19 @@ def reshape(a: DNDarray, *shape: Tuple[int, ...], **kwargs) -> DNDarray:
         displs[1:] = torch.cumsum(counts[:-1], dim=0)
         return argsort, counts, displs
 
-    if shape == -1:
-        shape = (a.gnumel,)
-
-    if not isinstance(shape, (list, tuple)):
-        raise TypeError("shape must be list, tuple, currently {}".format(type(shape)))
-
     # check new_split parameter
     new_split = kwargs.get("new_split")
     if new_split is None:
         new_split = a.split
     new_split = stride_tricks.sanitize_axis(shape, new_split)
 
-    # Check the type of shape and number elements
-    shape = stride_tricks.sanitize_shape(shape, -1)
-
     shape = list(shape)
     shape_size = torch.prod(torch.tensor(shape, dtype=torch.int, device=tdevice))
 
-    # infer unknown dimension
-    if shape.count(-1) > 1:
-        raise ValueError("too many unknown dimensions")
-    elif shape.count(-1) == 1:
+    if shape.count(-1) == 1:
         pos = shape.index(-1)
         shape[pos] = int(-(a.size / shape_size).item())
         shape_size *= -shape[pos]
-
-    if shape_size != a.size:
-        raise ValueError("cannot reshape array of size {} into shape {}".format(a.size, shape))
 
     # Forward to Pytorch directly
     if a.split is None:
@@ -1837,7 +1846,7 @@ def reshape(a: DNDarray, *shape: Tuple[int, ...], **kwargs) -> DNDarray:
         shape, local_shape, new_displs, new_split, a.shape, old_displs, a.split, a.comm
     )
 
-    # rearange order
+    # rearrange order
     send = a.larray.flatten()[sendsort]
     a.comm.Alltoallv((send, sendcounts, senddispls), (data, recvcounts, recvdispls))
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1737,7 +1737,10 @@ def reshape(a: DNDarray, *shape: Union[int, Tuple[int, ...]], **kwargs) -> DNDar
     try:
         a_proxy.reshape(shape)
     except TypeError as e:
-        raise TypeError(e)
+        try:
+            shape = shape.tolist()
+        except AttributeError:
+            raise TypeError(e)
     except (RuntimeError, ValueError):
         shape = list(shape)
         shape_size = torch.prod(torch.tensor(shape, dtype=torch.int, device=tdevice))

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1848,7 +1848,6 @@ def reshape(a: DNDarray, *shape: Tuple[int, ...], **kwargs) -> DNDarray:
     # Reshape local tensor
     data = data.reshape(local_shape)
 
-    # return factories.array(data, dtype=a.dtype, is_split=new_split, device=a.device, comm=a.comm)
     return DNDarray(
         data,
         tuple(shape),

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1737,14 +1737,14 @@ def reshape(a: DNDarray, *shape: Union[int, Tuple[int, ...]], **kwargs) -> DNDar
     try:
         a_proxy.reshape(shape)
     except TypeError as e:
-        # allow array-like shape
+        # allow array-like `shape`
         try:
             shape = shape.tolist()
         except AttributeError:
             raise TypeError(e)
     except (RuntimeError, ValueError):
         shape = list(shape)
-        shape_size = torch.prod(torch.tensor(shape, dtype=torch.int, device=tdevice))
+        shape_size = torch.prod(torch.tensor(shape, dtype=torch.int, device=tdevice)).item()
         if shape.count(-1) > 1:
             raise ValueError("too many unknown dimensions")
         elif shape.count(-1) == 1:

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -1737,6 +1737,7 @@ def reshape(a: DNDarray, *shape: Union[int, Tuple[int, ...]], **kwargs) -> DNDar
     try:
         a_proxy.reshape(shape)
     except TypeError as e:
+        # allow array-like shape
         try:
             shape = shape.tolist()
         except AttributeError:

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -149,7 +149,7 @@ class TestDNDarray(TestCase):
                 self.assertTrue(data.halo_next is None)
                 self.assertEqual(data_with_halos.shape, (0, 12))
 
-            data = data.reshape((12, 2), axis=1)
+            data = data.reshape((12, 2), new_split=1)
             data.get_halo(1)
 
             data_with_halos = data.array_with_halos

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -1895,7 +1895,7 @@ class TestManipulations(TestCase):
         # -------------------
         # axis = None
         # -------------------
-        a = ht.arange(12, split=0).reshape((2, 2, 3), axis=1)
+        a = ht.arange(12, split=0).reshape((2, 2, 3), new_split=1)
         a_np = a.numpy()
 
         # repeats = scalar

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -2086,6 +2086,21 @@ class TestManipulations(TestCase):
         self.assertTrue(ht.equal(reshaped, result))
         self.assertEqual(reshaped.device, result.device)
 
+        b = ht.arange(4 * 5 * 6, dtype=ht.float64)
+        # test *shape input
+        reshaped = b.reshape(4, 5, 6)
+        self.assertTrue(reshaped.gshape == (4, 5, 6))
+        self.assertEqual(reshaped.dtype, b.dtype)
+        self.assertEqual(reshaped.split, b.split)
+        self.assertEqual(reshaped.device, b.device)
+        # test new_split not None
+        reshaped = b.reshape(4, 5, -1, new_split=-1)
+        self.assertTrue(reshaped.gshape == (4, 5, 6))
+        self.assertEqual(reshaped.dtype, b.dtype)
+        self.assertEqual(reshaped.split, 2)
+        self.assertEqual(reshaped.device, b.device)
+        self.assertEqual(reshaped.balanced, b.is_balanced(force_check=True))
+
         # shape = -1
         result = ht.zeros(12, device=self.device)
         reshaped = ht.reshape(a, -1)

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -2229,8 +2229,15 @@ class TestManipulations(TestCase):
 
         # unknown dimension
         a = ht.ones((4, 4, 4), split=0, device=self.device)
-        result = ht.ones((4, 16), split=0, device=self.device)
 
+        result = ht.ones((64), split=0, device=self.device)
+        reshaped = ht.reshape(a, -1)
+        self.assertEqual(reshaped.size, result.size)
+        self.assertEqual(reshaped.shape, result.shape)
+        self.assertTrue(ht.equal(reshaped, result))
+        self.assertEqual(reshaped.device, result.device)
+
+        result = ht.ones((4, 16), split=0, device=self.device)
         reshaped = ht.reshape(a, (4, -1))
         self.assertEqual(reshaped.size, result.size)
         self.assertEqual(reshaped.shape, result.shape)
@@ -2270,6 +2277,8 @@ class TestManipulations(TestCase):
             ht.reshape(ht.zeros((4, 3)), "(5, 7)")
         with self.assertRaises(ValueError):
             ht.reshape(ht.zeros((4, 3)), (-1, -1, 3))
+        with self.assertRaises(ValueError):
+            ht.reshape(ht.zeros((4, 3)), (5, -1))
         with self.assertRaises(ValueError):
             ht.reshape(ht.zeros((4, 3)), (3, -2))
         with self.assertRaises(TypeError):


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #795 

## Changes proposed:
- `reshape(a, shape, new_split)` now returns a distributed `DNDarray` if `new_split is not None` even if `a` is not distributed
- update keyword argument for `reshape()` method to `new_split` from old `axis`
- allow shape elements to be passed in as separate arguments when calling the `reshape()` method
- replace unnecessary `factories.array()` calls with `DNDarray()` for a significant improvement in performance
- update tests

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
