### PR TITLE
Bug/808 clustering tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Example on 2 processes:
 - [#787](https://github.com/helmholtz-analytics/heat/pull/787) Fixed an issue where Heat cannot be imported when some optional dependencies are not available.
 - [#790](https://github.com/helmholtz-analytics/heat/pull/790) catch incorrect device after `bcast` in `DNDarray.__getitem__`
 - [#811](https://github.com/helmholtz-analytics/heat/pull/811) Fixed memory leak in `DNDarray.larray`
+- [#821](https://github.com/helmholtz-analytics/heat/pull/821) Fixed `__getitem__` handling of distributed `DNDarray` key element
 
 ### Exponential
 - [#812](https://github.com/helmholtz-analytics/heat/pull/712) New feature: `logaddexp`, `logaddexp2`
@@ -56,6 +57,7 @@ Example on 2 processes:
 - [#809](https://github.com/helmholtz-analytics/heat/pull/809) New feature: `acosh`, `asinh`, `atanh`
 ### Misc.
 - [#761](https://github.com/helmholtz-analytics/heat/pull/761) New feature: `result_type`
+- [#821](https://github.com/helmholtz-analytics/heat/pull/821) Enhancement: it is no longer necessary to load-balance an imbalanced `DNDarray` before gathering it onto all processes. In short: `ht.resplit(array, None)` now works on imbalanced arrays as well.
 
 # v1.0.0
 

--- a/doc/source/tutorial_clustering.rst
+++ b/doc/source/tutorial_clustering.rst
@@ -131,12 +131,12 @@ The Iris Dataset
 ------------------------------
 The _iris_ dataset is a well known example for clustering analysis. It contains 4 measured features for samples from
 three different types of iris flowers. A subset of 150 samples is included in formats h5, csv and netcdf in Heat,
-located under 'heat/heat/datasets/data/iris.h5', and can be loaded in a distributed manner with Heat's parallel
+located under 'heat/heat/datasets/iris.h5', and can be loaded in a distributed manner with Heat's parallel
 dataloader
 
 .. code:: python
 
-    iris = ht.load("heat/datasets/data/iris.csv", sep=";", split=0)
+    iris = ht.load("heat/datasets/iris.csv", sep=";", split=0)
 Fitting the dataset with kmeans:
 
 .. code:: python

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -542,7 +542,7 @@ class DNDarray:
         """
         return self.__cast(complex)
 
-    def counts_displs(self) -> Tuple[torch.Tensor, torch.Tensor]:
+    def counts_displs(self) -> Tuple[Tuple[int], Tuple[int]]:
         """
         Returns actual counts (number of items per process) and displacements (offsets) of the DNDarray.
         Does not assume load balance.
@@ -555,7 +555,7 @@ class DNDarray:
                     torch.cumsum(counts, dim=0)[:-1],
                 )
             )
-            return (counts, displs)
+            return (tuple(counts.tolist()), tuple(displs.tolist()))
         else:
             raise ValueError("Non-distributed DNDarray. Cannot calculate counts and displacements.")
 
@@ -678,7 +678,6 @@ class DNDarray:
             """ if the key is a DNDarray and it has as many dimensions as self, then each of the entries in the 0th
                 dim refer to a single element. To handle this, the key is split into the torch tensors for each dimension.
                 This signals that advanced indexing is to be used. """
-            key.balance_()
             key = manipulations.resplit(key.copy())
             if key.ndim > 1:
                 key = list(key.larray.split(1, dim=1))
@@ -694,7 +693,6 @@ class DNDarray:
                 lists mean advanced indexing will be used"""
             h = [slice(None, None, None)] * self.ndim
             if isinstance(key, DNDarray):
-                key.balance_()
                 key = manipulations.resplit(key.copy())
                 h[0] = key.larray.tolist()
             elif isinstance(key, torch.Tensor):
@@ -709,6 +707,7 @@ class DNDarray:
             for i, k in enumerate(key):
                 if isinstance(k, DNDarray):
                     # extract torch tensor
+                    k = manipulations.resplit(k.copy())
                     key[i] = k.larray.type(torch.int64)
             key = tuple(key)
 
@@ -716,7 +715,7 @@ class DNDarray:
         self_proxy = torch.ones((1,)).as_strided(self.gshape, [0] * self.ndim)
         gout_full = list(self_proxy[key].shape)
 
-        # ellipsis stuff
+        # ellipsis
         key = list(key)
         key_classes = [type(n) for n in key]
         # if any(isinstance(n, ellipsis) for n in key):
@@ -755,6 +754,7 @@ class DNDarray:
         arr = torch.tensor([], dtype=self.__array.dtype, device=self.__array.device)
         rank = self.comm.rank
         counts, chunk_starts = self.counts_displs()
+        counts, chunk_starts = torch.tensor(counts), torch.tensor(chunk_starts)
         chunk_ends = chunk_starts + counts
         chunk_start = chunk_starts[rank]
         chunk_end = chunk_ends[rank]
@@ -1241,7 +1241,7 @@ class DNDarray:
             gathered = torch.empty(
                 self.shape, dtype=self.dtype.torch_type(), device=self.device.torch_device
             )
-            counts, displs, _ = self.comm.counts_displs_shape(self.shape, self.split)
+            counts, displs = self.counts_displs()
             self.comm.Allgatherv(self.__array, (gathered, counts, displs), recv_axis=self.split)
             self.__array = gathered
             self.__split = axis

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -3037,7 +3037,7 @@ def resplit(arr: DNDarray, axis: int = None) -> DNDarray:
         gathered = torch.empty(
             arr.shape, dtype=arr.dtype.torch_type(), device=arr.device.torch_device
         )
-        counts, displs, _ = arr.comm.counts_displs_shape(arr.shape, arr.split)
+        counts, displs = arr.counts_displs()
         arr.comm.Allgatherv(arr.larray, (gathered, counts, displs), recv_axis=arr.split)
         new_arr = factories.array(gathered, is_split=axis, device=arr.device, dtype=arr.dtype)
         return new_arr

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -354,8 +354,8 @@ class TestDNDarray(TestCase):
         a = ht.arange(128, split=0).reshape((8, 8, 2))
         counts, displs = a.counts_displs()
         comm_counts, comm_displs, _ = a.comm.counts_displs_shape(a.gshape, a.split)
-        self.assertTrue(tuple(counts.tolist()) == comm_counts)
-        self.assertTrue(tuple(displs.tolist()) == comm_displs)
+        self.assertTrue(counts == comm_counts)
+        self.assertTrue(displs == comm_displs)
 
         # non-balanced distributed DNDarray
         rank = a.comm.rank
@@ -365,8 +365,8 @@ class TestDNDarray(TestCase):
         comp_displs = torch.cumsum(comp_counts, dim=0)
         a = ht.array(t_a, is_split=1)
         counts, displs = a.counts_displs()
-        self.assertTrue((counts == comp_counts).all())
-        self.assertTrue((displs[1:] == comp_displs[:-1]).all())
+        self.assertTrue((torch.tensor(counts) == comp_counts).all())
+        self.assertTrue((torch.tensor(displs[1:]) == comp_displs[:-1]).all())
 
         # exception
         a_nosplit = ht.arange(128).reshape((8, 8, 2))


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Fixed `__getitem__` issue where a tuple `key` containing a distributed `DNDarray` wasn't being handled correctly.

Issue/s resolved: #808 

## Changes proposed:
- gather distributed DNDarray key element within tuple
- modify `array.resplit_(None)` and `manipulations.resplit(array, None)` to use the actual `array` counts and displacements `array.counts_displs()`. It is no longer necessary to `array.balance_()` before `resplit(array, None)`
- Update data path in clustering tutorial 

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Documentation update

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
