### PR TITLE
add sign, sgn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Example on 2 processes:
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) New feature: unary positive and negative operations
 ### Manipulations
 - [#796](https://github.com/helmholtz-analytics/heat/pull/796) `DNDarray.reshape(shape)`: method now allows shape elements to be passed in as single arguments.
+### Rounding
+- [#827](https://github.com/helmholtz-analytics/heat/pull/827) New feature: `sign`, `sgn`
 ### Trigonometrics / Arithmetic
 - [#806](https://github.com/helmholtz-analytics/heat/pull/809) New feature: `square`
 - [#809](https://github.com/helmholtz-analytics/heat/pull/809) New feature: `acosh`, `asinh`, `atanh`

--- a/heat/core/tests/test_rounding.py
+++ b/heat/core/tests/test_rounding.py
@@ -301,6 +301,74 @@ class TestRounding(TestCase):
         self.assertEqual(float64_round_distrbd.dtype, ht.float64)
         self.assert_array_equal(float64_round_distrbd, comparison)
 
+    def test_sign(self):
+        # floats 1d
+        a = ht.array([-1, -0.5, 0, 0.5, 1])
+        signed = ht.sign(a)
+        comparison = ht.array([-1.0, -1, 0, 1, 1])
+
+        self.assertEqual(signed.dtype, comparison.dtype)
+        self.assertEqual(signed.shape, comparison.shape)
+        self.assertEqual(signed.device, a.device)
+        self.assertEqual(signed.split, a.split)
+        self.assertTrue(ht.equal(signed, comparison))
+
+        # complex + 2d + split
+        a = ht.array([[1 - 2j, -0.5 + 1j], [0, 4 + 6j]], split=0)
+        signed = ht.sign(a)
+        comparison = ht.array([[1 + 0j, -1 + 0j], [0 + 0j, 1 + 0j]])
+
+        self.assertEqual(signed.dtype, comparison.dtype)
+        self.assertEqual(signed.shape, comparison.shape)
+        self.assertEqual(signed.device, a.device)
+        self.assertEqual(signed.split, a.split)
+        self.assertTrue(ht.equal(signed, comparison))
+
+        # complex + split + out
+        a = ht.array([[1 - 2j, -0.5 + 1j], [0, 4 + 6j]], split=1)
+        b = ht.empty_like(a)
+        signed = ht.sign(a, b)
+        comparison = ht.array([[1 + 0j, -1 + 0j], [0 + 0j, 1 + 0j]])
+
+        self.assertIs(b, signed)
+        self.assertEqual(signed.dtype, comparison.dtype)
+        self.assertEqual(signed.shape, comparison.shape)
+        self.assertEqual(signed.device, a.device)
+        self.assertEqual(signed.split, a.split)
+        self.assertTrue(ht.equal(signed, comparison))
+
+        # zeros + 3d + complex + split
+        a = ht.zeros((4, 4, 4), dtype=ht.complex128, split=2)
+        signed = ht.sign(a)
+        comparison = ht.zeros((4, 4, 4), dtype=ht.complex128)
+
+        self.assertEqual(signed.dtype, comparison.dtype)
+        self.assertEqual(signed.shape, comparison.shape)
+        self.assertEqual(signed.device, a.device)
+        self.assertEqual(signed.split, a.split)
+        self.assertTrue(ht.equal(signed, comparison))
+
+    def test_sgn(self):
+        # floats
+        a = ht.array([-1, -0.5, 0, 0.5, 1])
+        signed = ht.sgn(a)
+        comparison = ht.array([-1.0, -1, 0, 1, 1])
+
+        self.assertEqual(signed.dtype, comparison.dtype)
+        self.assertEqual(signed.shape, comparison.shape)
+        self.assertEqual(signed.device, a.device)
+        self.assertTrue(ht.equal(signed, comparison))
+
+        # complex
+        a = ht.array([[1 - 2j, -0.5 + 1j], [0 - 3j, 4 + 6j]], split=0)
+        signed = ht.sgn(a)
+        comparison = torch.sgn(torch.tensor([[1 - 2j, -0.5 + 1j], [0 - 3j, 4 + 6j]]))
+
+        self.assertEqual(signed.dtype, ht.heat_type_of(comparison))
+        self.assertEqual(signed.shape, a.shape)
+        self.assertEqual(signed.device, a.device)
+        self.assertTrue(ht.equal(signed, ht.array(comparison)))
+
     def test_trunc(self):
         base_array = np.random.randn(20)
 


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR adds the `sign ` & `sgn` functions to heat. The former behaves like numpy on complex values, the latter like pytorch.

Issue/s resolved: #780 

## Changes proposed:
- add `sign`
- add `sgn`

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- New feature

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
