### PR TITLE
Features/807 roll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Example on 2 processes:
 - [#768](https://github.com/helmholtz-analytics/heat/pull/768) New feature: unary positive and negative operations
 ### Manipulations
 - [#796](https://github.com/helmholtz-analytics/heat/pull/796) `DNDarray.reshape(shape)`: method now allows shape elements to be passed in as single arguments.
+- [#829] (https://github.com/helmholtz-analytics/heat/pull/796) New feature: `roll`
 ### Trigonometrics / Arithmetic
 - [#806](https://github.com/helmholtz-analytics/heat/pull/809) New feature: `square`
 - [#809](https://github.com/helmholtz-analytics/heat/pull/809) New feature: `acosh`, `asinh`, `atanh`

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -2306,6 +2306,165 @@ class TestManipulations(TestCase):
         with self.assertRaises(TypeError):
             ht.reshape(ht.zeros((4, 3)), (3.4, 3.2))
 
+    def test_roll(self):
+        # no split
+        # vector
+        a = ht.arange(5)
+        rolled = ht.roll(a, 1)
+        compare = ht.array([4, 0, 1, 2, 3])
+
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(ht.equal(rolled, compare))
+
+        rolled = ht.roll(a, -1)
+        compare = ht.array([1, 2, 3, 4, 0])
+
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(ht.equal(rolled, compare))
+
+        # matrix
+        a = ht.arange(20.0).reshape((4, 5))
+
+        rolled = ht.roll(a, -1)
+        compare = torch.roll(a.larray, -1)
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(torch.equal(rolled.larray, compare))
+
+        rolled = ht.roll(a, 1, 0)
+        compare = torch.roll(a.larray, 1, 0)
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(torch.equal(rolled.larray, compare))
+
+        rolled = ht.roll(a, -2, (0, 1))
+        compare = np.roll(a.larray.numpy(), -2, (0, 1))
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(np.array_equal(rolled.larray.cpu().numpy(), compare))
+
+        rolled = ht.roll(a, (1, 2, 1), (0, 1, -2))
+        compare = torch.roll(a.larray, (1, 2, 1), (0, 1, -2))
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(torch.equal(rolled.larray, compare))
+
+        # split
+        # vector
+        a = ht.arange(5, dtype=ht.uint8, split=0)
+        rolled = ht.roll(a, 1)
+        compare = ht.array([4, 0, 1, 2, 3], dtype=ht.uint8, split=0)
+
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(ht.equal(rolled, compare))
+
+        rolled = ht.roll(a, -1)
+        compare = ht.array([1, 2, 3, 4, 0], ht.uint8, split=0)
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(ht.equal(rolled, compare))
+
+        # matrix
+        a = ht.arange(20.0).reshape((4, 5), dtype=ht.int16, split=0)
+
+        rolled = ht.roll(a, -1)
+        compare = torch.roll(a.larray, -1)
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(torch.equal(rolled.larray, compare))
+
+        rolled = ht.roll(a, 1, 0)
+        compare = torch.roll(a.larray, 1, 0)
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(torch.equal(rolled.larray, compare))
+
+        rolled = ht.roll(a, -2, (0, 1))
+        compare = np.roll(a.larray.cpu().numpy(), -2, (0, 1))
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(np.array_equal(rolled.larray.cpu().numpy(), compare))
+
+        rolled = ht.roll(a, (1, 2, 1), (0, 1, -2))
+        compare = torch.roll(a.larray, (1, 2, 1), (0, 1, -2))
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(torch.equal(rolled.larray, compare))
+
+        a = ht.arange(20, dtype=ht.complex64).reshape((4, 5), split=1)
+
+        rolled = ht.roll(a, -1)
+        compare = torch.roll(a.larray, -1)
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(torch.equal(rolled.larray, compare))
+
+        rolled = ht.roll(a, 1, 0)
+        compare = torch.roll(a.larray, 1, 0)
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(torch.equal(rolled.larray, compare))
+
+        rolled = ht.roll(a, -2, [0, 1])
+        compare = np.roll(a.larray.cpu().numpy(), -2, [0, 1])
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(np.array_equal(rolled.larray.cpu().numpy(), compare))
+
+        rolled = ht.roll(a, [1, 2, 1], [0, 1, -2])
+        compare = torch.roll(a.larray, [1, 2, 1], [0, 1, -2])
+        self.assertEqual(rolled.device, a.device)
+        self.assertEqual(rolled.size, a.size)
+        self.assertEqual(rolled.dtype, a.dtype)
+        self.assertEqual(rolled.split, a.split)
+        self.assertTrue(torch.equal(rolled.larray, compare))
+
+        with self.assertRaises(TypeError):
+            ht.roll(a, 1.0, 0)
+        with self.assertRaises(TypeError):
+            ht.roll(a, 1, 1.0)
+        with self.assertRaises(TypeError):
+            ht.roll(a, 1, (1.0, 0.0))
+        with self.assertRaises(TypeError):
+            ht.roll(a, (-1, 1), 0.0)
+        with self.assertRaises(TypeError):
+            ht.roll(a, (-1.0, 1.0), 0)
+        with self.assertRaises(ValueError):
+            ht.roll(a, [1, 1, 1], [0, 0])
+
     def test_rot90(self):
         size = ht.MPI_WORLD.size
         m = ht.arange(size ** 3, dtype=ht.int).reshape((size, size, size))


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR adds roll function to Heat. It uses PyTorch if the roll is not along the split axis. It improves on it that it is now possible to use a single shift on multiple axes (int/tuple) similar to NumPy.

Issue/s resolved: #807 

## Changes proposed:
- add `roll`

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- New feature

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no