### PR TITLE
Bug/828 getitem typechecking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Example on 2 processes:
 - [#811](https://github.com/helmholtz-analytics/heat/pull/811) Fixed memory leak in `DNDarray.larray`
 - [#820](https://github.com/helmholtz-analytics/heat/pull/820) `randn` values are pushed away from 0 by the minimum value the given dtype before being transformed into the Gaussian shape
 - [#821](https://github.com/helmholtz-analytics/heat/pull/821) Fixed `__getitem__` handling of distributed `DNDarray` key element
+- [#831](https://github.com/helmholtz-analytics/heat/pull/831) `__getitem__` handling of `array-like` 1-element key
 
 ## Feature additions
 ### Exponential

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Citing Heat
 
 If you find Heat helpful for your research, please mention it in your academic publications. You can cite:
 
-- Götz, M., Debus, C., Coquelin, D., Krajsek, K., Comito, C., Knechtges, P., .Hagemeier, B., Tarnawa, M., Hanselmann, S., Siggel, S., Basermann, A. & Streit, A. (2020). HeAT - a Distributed and GPU-accelerated Tensor Framework for Data Analytics. In 2020 IEEE International Conference on Big Data (Big Data) (pp. 276-287). IEEE, DOI: 10.1109/BigData50022.2020.9378050.
+- Götz, M., Debus, C., Coquelin, D., Krajsek, K., Comito, C., Knechtges, P., Hagemeier, B., Tarnawa, M., Hanselmann, S., Siggel, S., Basermann, A. & Streit, A. (2020). HeAT - a Distributed and GPU-accelerated Tensor Framework for Data Analytics. In 2020 IEEE International Conference on Big Data (Big Data) (pp. 276-287). IEEE, DOI: 10.1109/BigData50022.2020.9378050.
 
 ```
 @inproceedings{heat2020,

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -730,7 +730,7 @@ class DNDarray:
             slices = [slice(None)] * (self.ndim - (len(kst) + len(kend)))
             key = kst + slices + kend
 
-        def _is_singular(obj: any) -> bool:
+        def __is_singular(obj: any) -> bool:
             """
             Checks if obj has size one, and thereby reduces the dimensionalty of
             the output
@@ -764,7 +764,7 @@ class DNDarray:
                 new_split = 0
             else:
                 for i in range(len(key[: self.split + 1])):
-                    if _is_singular(key[i]):
+                    if __is_singular(key[i]):
                         new_split = None if i == self.split else new_split - 1
 
         key = tuple(key)
@@ -872,7 +872,7 @@ class DNDarray:
                 lout[new_split] = 0
                 arr = torch.empty(lout, dtype=self.__array.dtype, device=self.__array.device)
 
-        elif _is_singular(key[self.split]):
+        elif __is_singular(key[self.split]):
             # getting one item along split axis:
             key = list(key)
             if isinstance(key[self.split], list):

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -881,12 +881,6 @@ class DNDarray:
             balanced=True if new_split is None else None,
         )
 
-    @staticmethod
-    def __getitem_is_key_singular(key: any, axis: int, self_proxy: torch.Tensor) -> bool:
-        # determine if the key gets a singular item
-        zeros = tuple([0] * (self_proxy.ndim - 1))
-        return self_proxy[(*zeros[:axis], key[axis], *zeros[axis:])].ndim == 0
-
     if torch.cuda.device_count() > 0:
 
         def gpu(self) -> DNDarray:
@@ -934,6 +928,12 @@ class DNDarray:
         Determines whether the data of this ``DNDarray`` is distributed across multiple processes.
         """
         return self.split is not None and self.comm.is_distributed()
+
+    @staticmethod
+    def __is_key_singular(key: any, axis: int, self_proxy: torch.Tensor) -> bool:
+        # determine if the key gets a singular item
+        zeros = tuple([0] * (self_proxy.ndim - 1))
+        return self_proxy[(*zeros[:axis], key[axis], *zeros[axis:])].ndim == 0
 
     def item(self):
         """

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -739,7 +739,9 @@ class DNDarray:
             else:
                 for i in range(len(key[: self.split + 1])):
                     if not isinstance(key[i], slice) and (
-                        isinstance(key[i], int) or len(key[i].shape == 0) or len(key[i]) == 1
+                        isinstance(key[i], int)
+                        or (hasattr(key[i], "shape") and len(key[i].shape) == 0)
+                        or len(key[i]) == 1
                     ):
                         new_split = None if i == self.split else new_split - 1
 
@@ -850,8 +852,8 @@ class DNDarray:
 
         elif (
             isinstance(key[self.split], int)
-            or isinstance(key[self.split], (list, torch.Tensor, DNDarray, np.ndarray))
-            and len(key[self.split]) == 1
+            or (hasattr(key[self.split], "shape") and len(key[self.split].shape) == 0)
+            or len(key[self.split]) == 1
         ):
             # getting one item along split axis:
             key = list(key)

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -739,7 +739,7 @@ class DNDarray:
                 new_split = 0
             else:
                 for i in range(len(key[: self.split + 1])):
-                    if self.__getitem_is_key_singular(key, i, self_proxy):
+                    if self.__is_key_singular(key, i, self_proxy):
                         new_split = None if i == self.split else new_split - 1
 
         key = tuple(key)
@@ -846,7 +846,7 @@ class DNDarray:
                 lout[new_split] = 0
                 arr = torch.empty(lout, dtype=self.__array.dtype, device=self.__array.device)
 
-        elif self.__getitem_is_key_singular(key, self.split, self_proxy):
+        elif self.__is_key_singular(key, self.split, self_proxy):
             # getting one item along split axis:
             key = list(key)
             if isinstance(key[self.split], list):

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -739,7 +739,7 @@ class DNDarray:
             else:
                 for i in range(len(key[: self.split + 1])):
                     if not isinstance(key[i], slice) and (
-                        isinstance(key[i], int) or len(key[i]) == 1
+                        isinstance(key[i], int) or len(key[i].shape == 0) or len(key[i]) == 1
                     ):
                         new_split = None if i == self.split else new_split - 1
 

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -1069,7 +1069,7 @@ class TestDNDarray(TestCase):
         # slice in 1st dim across 1 node (2nd) w/ singular second dim
         c = ht.zeros((13, 5), split=0)
         c[8:12, 1] = 1
-        b = c[8:12, np.array(1)]
+        b = c[8:12, np.int64(1)]
         self.assertTrue((b == 1).all())
         self.assertEqual(b.gshape, (4,))
         self.assertEqual(b.split, 0)

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -996,13 +996,13 @@ class TestDNDarray(TestCase):
         # set and get single value
         a = ht.zeros((13, 5), split=0)
         # set value on one node
-        a[10, 0] = 1
+        a[10, np.array(0)] = 1
         self.assertEqual(a[10, 0], 1)
         self.assertEqual(a[10, 0].dtype, ht.float32)
 
         a = ht.zeros((13, 5), split=0)
         a[10] = 1
-        b = a[10]
+        b = a[torch.tensor(10)]
         self.assertTrue((b == 1).all())
         self.assertEqual(b.dtype, ht.float32)
         self.assertEqual(b.gshape, (5,))
@@ -1042,7 +1042,7 @@ class TestDNDarray(TestCase):
         # slice in 1st dim only on 1 node w/ singular second dim
         a = ht.zeros((13, 5), split=0)
         a[1:4, 1] = 1
-        b = a[1:4, 1]
+        b = a[1:4, np.array(1)]
         self.assertTrue((b == 1).all())
         self.assertEqual(b.gshape, (3,))
         self.assertEqual(b.split, 0)
@@ -1058,7 +1058,7 @@ class TestDNDarray(TestCase):
         a[1:11, 1] = 1
         self.assertTrue((a[1:11, 1] == 1).all())
         self.assertEqual(a[1:11, 1].gshape, (10,))
-        self.assertEqual(a[1:11, 1].split, 0)
+        self.assertEqual(a[1:11, torch.tensor(1)].split, 0)
         self.assertEqual(a[1:11, 1].dtype, ht.float32)
         if a.comm.size == 2:
             if a.comm.rank == 1:
@@ -1069,7 +1069,7 @@ class TestDNDarray(TestCase):
         # slice in 1st dim across 1 node (2nd) w/ singular second dim
         c = ht.zeros((13, 5), split=0)
         c[8:12, 1] = 1
-        b = c[8:12, 1]
+        b = c[8:12, np.array(1)]
         self.assertTrue((b == 1).all())
         self.assertEqual(b.gshape, (4,))
         self.assertEqual(b.split, 0)

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -1042,7 +1042,7 @@ class TestDNDarray(TestCase):
         # slice in 1st dim only on 1 node w/ singular second dim
         a = ht.zeros((13, 5), split=0)
         a[1:4, 1] = 1
-        b = a[1:4, np.array(1)]
+        b = a[1:4, np.int64(1)]
         self.assertTrue((b == 1).all())
         self.assertEqual(b.gshape, (3,))
         self.assertEqual(b.split, 0)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Expanded type-checking of `key` within `getitem`, so that 1-element `array-like` objects are allowed. This includes 0-dim arrays.

Issue/s resolved: #828 

## Changes proposed:
- private function `__is_singular()` does the checking within `getitem`, thanks @ben-bou !
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->

