### PR TITLE
Bug/843 setitem advanced

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -692,7 +692,6 @@ class DNDarray:
         # key = getattr(key, "copy()", key)
         l_dtype = self.dtype.torch_type()
         advanced_ind = False
-        # key, self_proxy, gout_full = self.__xitem_prepare_key(key)
         if isinstance(key, DNDarray) and key.ndim == self.ndim:
             """ if the key is a DNDarray and it has as many dimensions as self, then each of the
                 entries in the 0th dim refer to a single element. To handle this, the key is split
@@ -724,9 +723,10 @@ class DNDarray:
         if isinstance(key, (list, tuple)):
             key = list(key)
             for i, k in enumerate(key):
+                # this might be a good place to check if the dtype is there
                 try:
                     k = manipulations.resplit(k)
-                    key[i] = k.larray  # .to(torch.int64)
+                    key[i] = k.larray
                 except AttributeError:
                     pass
 
@@ -796,7 +796,6 @@ class DNDarray:
             if isinstance(key[self.split], DNDarray):
                 lkey[self.split] = key[self.split].larray
 
-            # adjust the bools to be ints
             if not isinstance(lkey[self.split], torch.Tensor):
                 inds = torch.tensor(
                     lkey[self.split], dtype=torch.long, device=self.device.torch_device
@@ -807,13 +806,7 @@ class DNDarray:
                     inds = torch.nonzero(lkey[self.split])
                 else:
                     inds = lkey[self.split]
-            # if lkey[self.split]
-
-            # inds = (
-            #     torch.tensor(lkey[self.split], dtype=torch.long, device=self.device.torch_device)
-            #     if not isinstance(lkey[self.split], torch.Tensor)
-            #     else lkey[self.split]
-            # )
+            # todo: remove where in favor of nonzero? might be a speed upgrade. testing required
             loc_inds = torch.where((inds >= chunk_start) & (inds < chunk_end))
             # if there are no local indices on a process, then `arr` is empty
             # if local indices exist:
@@ -1450,14 +1443,11 @@ class DNDarray:
         if isinstance(key, (list, tuple)):
             key = list(key)
             for i, k in enumerate(key):
-                # if isinstance(k, DNDarray):
-                #     # extract torch tensor
-                try:
+                try:  # extract torch tensor
                     k = manipulations.resplit(k)
-                    key[i] = k.larray  # .to(torch.int64)
+                    key[i] = k.larray
                 except AttributeError:
                     pass
-            # key = tuple(key)
 
         key = list(key)
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -689,7 +689,7 @@ class DNDarray:
         (1/2) >>> tensor([0.])
         (2/2) >>> tensor([0., 0.])
         """
-        # key = getattr(key, "copy()", key)
+        key = getattr(key, "copy()", key)
         l_dtype = self.dtype.torch_type()
         advanced_ind = False
         if isinstance(key, DNDarray) and key.ndim == self.ndim:
@@ -1395,7 +1395,7 @@ class DNDarray:
         (2/2) >>> tensor([[0., 1., 0., 0., 0.],
                           [0., 1., 0., 0., 0.]])
         """
-        # key = getattr(key, "copy()", key)
+        key = getattr(key, "copy()", key)
         try:
             if value.split != self.split:
                 val_split = int(value.split)

--- a/heat/core/indexing.py
+++ b/heat/core/indexing.py
@@ -53,8 +53,6 @@ def nonzero(x: DNDarray) -> DNDarray:
     """
     sanitation.sanitize_in(x)
 
-    if x.dtype == types.bool:
-        x.larray = x.larray.float()
     if x.split is None:
         # if there is no split then just return the values from torch
         lcl_nonzero = torch.nonzero(input=x.larray, as_tuple=False)

--- a/heat/core/tiling.py
+++ b/heat/core/tiling.py
@@ -383,7 +383,7 @@ class SquareDiagTiles:
         if len(arr.shape) != 2:
             raise ValueError("Arr must be 2 dimensional, current shape {}".format(arr.shape))
 
-        lshape_map = arr.create_lshape_map()
+        lshape_map = arr.create_lshape_map(force_check=True)
 
         # if there is only one element of the diagonal on the next process
         d = 1 if tiles_per_proc <= 2 else tiles_per_proc - 1
@@ -514,6 +514,7 @@ class SquareDiagTiles:
         self.__tile_map = tile_map
         self.__row_inds = list(row_inds)
         self.__col_inds = list(col_inds)
+        arr.__lshape_map = None
 
     @staticmethod
     def __adjust_cols_sp1_m_ls_n(
@@ -1196,6 +1197,9 @@ class SquareDiagTiles:
             self.__tile_map[..., 2][sum(self.__row_per_proc_list[:i]) :] = i
             self.__col_per_proc_list = [self.tile_columns] * base_dnd.comm.size
             self.__last_diag_pr = base_dnd.comm.size - 1
+
+            self.__DNDarray.__lshape_map = None
+            tiles_to_match.__DNDarray.__lshape_map = None
 
     def __setitem__(
         self, key: Union[int, slice, Tuple[int, slice, ...]], value: Union[int, float, torch.Tensor]


### PR DESCRIPTION
## Description

This PR includes fixes for boolean indexing in setitem and some performance modifications. The most important of which is that `create_lshape_map` does not check every time anymore. This effects functions which change the shape of a DNDarray, such as `reshape`, `resplit`, `redistributed`, ...

Issue/s resolved: #843 

## Changes proposed:
- performance upgrades to xxxitem functions
- when bools are given as a key, they are converted to indexes via `nonzero`. 
-
-

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
yes. ANY FUNCTION WHICH CHANGES THE SHAPE OF A `DNDarray` MUST RESET THE LSHAPE MAP!