### PR TITLE
replace factories.array

### DIFF
--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -452,6 +452,7 @@ class TestStatistics(TestCase):
         self.assertEqual(res.shape, (7,))
         self.assertEqual(res.dtype, ht.float64)
         self.assertEqual(res.device, self.device)
+        self.assertEqual(res.split, None)
         self.assertTrue(torch.equal(res.larray, comp))
 
         # matrix and splits
@@ -463,6 +464,7 @@ class TestStatistics(TestCase):
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
+        self.assertEqual(res.split, None)
         self.assertTrue(torch.equal(res.larray, comp))
 
         a = ht.array(c, split=0)
@@ -470,6 +472,7 @@ class TestStatistics(TestCase):
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
+        self.assertEqual(res.split, None)
         self.assertTrue(torch.equal(res.larray, comp))
 
         a = ht.array(c, split=1)
@@ -477,6 +480,7 @@ class TestStatistics(TestCase):
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
+        self.assertEqual(res.split, None)
         self.assertTrue(torch.equal(res.larray, comp))
 
         a = ht.array(c, split=2)
@@ -484,6 +488,7 @@ class TestStatistics(TestCase):
         self.assertEqual(res.shape, (100,))
         self.assertEqual(res.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
+        self.assertEqual(res.split, None)
         self.assertTrue(torch.equal(res.larray, comp))
 
         # out parameter, min max
@@ -496,6 +501,7 @@ class TestStatistics(TestCase):
         self.assertEqual(out.shape, (20,))
         self.assertEqual(out.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
+        self.assertEqual(res.split, None)
         self.assertTrue(torch.equal(out.larray, comp))
 
         a = ht.array(c, split=0)
@@ -503,6 +509,7 @@ class TestStatistics(TestCase):
         self.assertEqual(out.shape, (20,))
         self.assertEqual(out.dtype, ht.float32)
         self.assertEqual(res.device, self.device)
+        self.assertEqual(res.split, None)
         self.assertTrue(torch.equal(out.larray, comp))
 
         # Alias


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Replacement of `factories.array` with `DNDarray`.
Instances where it was left in uses `copy=False` 

Issue/s resolved: #802 

## Changes proposed:
- replace factories.array

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- enhancement

## Due Diligence

- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
