### PR TITLE
torchvision version range compatibility with pytorch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Pending additions
+- [#864](https://github.com/helmholtz-analytics/heat/pull/864) Dependencies: constrain `torchvision` version range to match supported `pytorch` version range.
+
 # v1.1.0
 
 ## Highlights

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -179,9 +179,6 @@ class DNDarray:
     def ndim(self) -> int:
         """
         Number of dimensions of the ``DNDarray``
-
-        .. deprecated:: 0.5.0
-          `numdims` will be removed in HeAT 1.0.0, it is replaced by `ndim` because the latter is numpy API compliant.
         """
         return len(self.__gshape)
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -57,7 +57,7 @@ class DNDarray:
     balanced: bool or None
         Describes whether the data are evenly distributed across processes.
         If this information is not available (``self.balanced is None``), it
-        can be gathered via the :func:`is_distributed()` method (requires communication).
+        can be gathered via the :func:`is_balanced()` method (requires communication).
     """
 
     def __init__(

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "torch>=1.7.0, <1.9",
         "scipy>=0.14.0",
         "pillow>=6.0.0",
-        "torchvision>=0.8.0",
+        "torchvision>=0.8.0, <0.10",
     ],
     extras_require={
         "docutils": ["docutils>=0.16"],


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Current `torchvision` version 0.10 requires PyTorch 1.9, which we are not supporting with Heat 1.1.x.

 

## Changes proposed:
- Constraining `torchvision<0.10` to match the supported `pytorch` version range.

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue) 
- 
## Due Diligence

- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no 

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
