### PR TITLE
fix binary_op on operands with single element

### DIFF
--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -9,7 +9,6 @@ import warnings
 
 from .communication import MPI, MPI_WORLD
 from . import factories
-from . import devices
 from . import stride_tricks
 from . import sanitation
 from . import statistics
@@ -117,22 +116,26 @@ def __binary_op(
                     # warnings.warn(
                     #     "Broadcasting requires transferring data of first operator between MPI ranks!"
                     # )
-                    if t1.comm.rank > 0:
+                    color = 0 if t1.comm.rank < t2.shape[t1.split] else 1
+                    newcomm = t1.comm.Split(color, t1.comm.rank)
+                    if t1.comm.rank > 0 and color == 0:
                         t1.larray = torch.zeros(
                             t1.shape, dtype=t1.dtype.torch_type(), device=t1.device.torch_device
                         )
-                    t1.comm.Bcast(t1)
+                    newcomm.Bcast(t1)
 
             if t2.split is not None:
                 if t2.shape[t2.split] == 1 and t2.comm.is_distributed():
                     # warnings.warn(
                     #     "Broadcasting requires transferring data of second operator between MPI ranks!"
                     # )
-                    if t2.comm.rank > 0:
+                    color = 0 if t2.comm.rank < t1.shape[t2.split] else 1
+                    newcomm = t2.comm.Split(color, t2.comm.rank)
+                    if t2.comm.rank > 0 and color == 0:
                         t2.larray = torch.zeros(
                             t2.shape, dtype=t2.dtype.torch_type(), device=t2.device.torch_device
                         )
-                    t2.comm.Bcast(t2)
+                    newcomm.Bcast(t2)
 
         else:
             raise TypeError(

--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -436,6 +436,19 @@ class MPICommunication(Communication):
 
         return self.as_mpi_memory(obj), (recvcount, recvdispls), recvtypes
 
+    def Split(self, color: int = 0, key: int = 0):
+        """
+        Split communicator by color and key.
+
+        Parameters
+        ----------
+        color : int, optional
+            Determines the new communicator for a process.
+        key: int, optional
+            Ordering within the new communicator.
+        """
+        return MPICommunication(self.handle.Split(color, key))
+
     def Irecv(
         self,
         buf: Union[DNDarray, torch.Tensor, Any],

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -196,6 +196,19 @@ class TestCommunication(TestCase):
         with self.assertRaises(TypeError):
             ht.use_comm("1")
 
+    def test_split(self):
+        a = ht.zeros((4, 5), split=0)
+
+        color = a.comm.rank % 2
+        newcomm = a.comm.Split(color, key=a.comm.rank)
+
+        self.assertIsInstance(newcomm, ht.MPICommunication)
+        if ht.MPI_WORLD.size == 1:
+            self.assertTrue(newcomm.size == a.comm.size)
+        else:
+            self.assertTrue(newcomm.size < a.comm.size)
+        self.assertIsNot(newcomm, a.comm)
+
     def test_allgather(self):
         # contiguous data
         data = ht.ones((1, 7))


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
This PR fixes a known bug in _operations.__binary_op() where the data of an DNDarray is copied to all processors if it only contains one element.

The fix introduces the method 'Split()' to MPICommunicator for splitting it into new ones. These new ones are used for the data transfer in __binary_op()

Issue/s resolved: #866 

## Changes proposed:
- add MPICommunicator.Split()
- fix data transfer in __binary_op()
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- Bug fix / New feature

## Due Diligence

- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no
