### PR TITLE
Bugfix/529 lasso example

### DIFF
--- a/examples/classification/demo_knn.py
+++ b/examples/classification/demo_knn.py
@@ -10,7 +10,7 @@ import heat as ht
 from heat.classification.kneighborsclassifier import KNeighborsClassifier
 
 # Load dataset from hdf5 file
-X = ht.load_hdf5("../../heat/datasets/data/iris.h5", dataset="data", split=0)
+X = ht.load_hdf5("../../heat/datasets/iris.h5", dataset="data", split=0)
 
 # Generate keys for the iris.h5 dataset
 keys = []

--- a/examples/lasso/demo.py
+++ b/examples/lasso/demo.py
@@ -1,8 +1,11 @@
 import numpy as np
 import torch
 import sys
+import os
 
-sys.path.append("../../")
+# Fix python path if run from terminal
+curdir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(curdir, "../../")))
 
 import heat as ht
 from matplotlib import pyplot as plt
@@ -14,8 +17,8 @@ import plotfkt
 diabetes = datasets.load_diabetes()
 
 # load diabetes dataset from hdf5 file
-X = ht.load_hdf5("../../heat/datasets/data/diabetes.h5", dataset="x", split=0)
-y = ht.load_hdf5("../../heat/datasets/data/diabetes.h5", dataset="y", split=0)
+X = ht.load_hdf5("../../heat/datasets/diabetes.h5", dataset="x", split=0)
+y = ht.load_hdf5("../../heat/datasets/diabetes.h5", dataset="y", split=0)
 
 # normalize dataset #DoTO this goes into the lasso fit routine soon as issue #106 is solved
 X = X / ht.sqrt((ht.mean(X ** 2, axis=0)))

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
         "hdf5": ["h5py>=2.8.0"],
         "netcdf": ["netCDF4>=1.5.6"],
         "dev": ["pre-commit>=1.18.3"],
+        "examples": ["scikit-learn>=0.24.0", "matplotlib>=3.1.0"],
     },
 )


### PR DESCRIPTION
## Description

Make examples work. The code examples in the examples folder were not fully aligned with some changes, e.g. paths to example data and Python path setup. Additionally, at least the Lasso example requires matplotlib and scikit-learn, which can now be pulled in as optional dependencies.

Issue/s resolved: #529 

## Changes proposed:
- path adaptation (Lasso and KNN examples)
- optional dependencies to run examples

## Type of change

- Bug fix

## Due Diligence

Only example code has been modified.

#### Does this change modify the behaviour of other functions? If so, which?
no

skip ci
