### PR TITLE
ht.diff edge case only one element along `axis`

### DIFF
--- a/heat/core/arithmetics.py
+++ b/heat/core/arithmetics.py
@@ -378,6 +378,19 @@ def diff(
             ret = ret[tuple(axis_slice)] - ret[tuple(axis_slice_end)]
         return ret
 
+    if a.shape[axis] == 1:
+        ret_lshape = list(a.lshape)
+        ret_lshape[axis] = 0
+        ret = torch.empty(ret_lshape, dtype=a.larray.dtype, device=a.larray.device)
+        if a.split != axis:
+            ret_gshape = ret_lshape
+            ret_gshape[a.split] = a.gshape[a.split]
+            return DNDarray(ret, tuple(ret_gshape), a.dtype, a.split, a.device, a.comm, a.balanced)
+
+        return DNDarray(
+            ret, tuple(ret_lshape), a.dtype, split=None, device=a.device, comm=a.comm, balanced=True
+        )
+
     size = a.comm.size
     rank = a.comm.rank
     ret = a.copy()

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -246,17 +246,16 @@ class TestArithmetics(TestCase):
     def test_diff(self):
         ht_array = ht.random.rand(20, 20, 20, split=None)
         arb_slice = [0] * 3
-        for dim in range(3):  # loop over 3 dimensions
+        for dim in range(0, 3):  # loop over 3 dimensions
             arb_slice[dim] = slice(None)
+            tup_arb = tuple(arb_slice)
+            np_array = ht_array[tup_arb].numpy()
             for ax in range(dim + 1):  # loop over the possible axis values
                 for sp in range(dim + 1):  # loop over the possible split values
+                    lp_array = ht.manipulations.resplit(ht_array[tup_arb], sp)
                     # loop to 3 for the number of times to do the diff
                     for nl in range(1, 4):
                         # only generating the number once and then
-                        tup_arb = tuple(arb_slice)
-                        lp_array = ht.manipulations.resplit(ht_array[tup_arb], sp)
-                        np_array = ht_array[tup_arb].numpy()
-
                         ht_diff = ht.diff(lp_array, n=nl, axis=ax)
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
 
@@ -269,10 +268,11 @@ class TestArithmetics(TestCase):
                         ht_append = ht.ones(
                             append_shape, dtype=lp_array.dtype, split=lp_array.split
                         )
+
                         ht_diff_pend = ht.diff(lp_array, n=nl, axis=ax, prepend=0, append=ht_append)
+                        np_append = np.ones(append_shape, dtype=lp_array.larray.numpy().dtype)
                         np_diff_pend = ht.array(
-                            np.diff(np_array, n=nl, axis=ax, prepend=0, append=ht_append.numpy()),
-                            dtype=ht_diff_pend.dtype,
+                            np.diff(np_array, n=nl, axis=ax, prepend=0, append=np_append)
                         )
                         self.assertTrue(ht.equal(ht_diff_pend, np_diff_pend))
                         self.assertEqual(ht_diff_pend.split, sp)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Implemented solution for `ht.diff` edge case where  `diff` is calculated along a size-1 axis of a distributed DNDarray.

Issue/s resolved: #753 

## Changes proposed:
- Return empty DNDarray with correct shapes
- modify tests
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
--->
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence

- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
