### PR TITLE
conjugate method in DNDarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### DNDarray
 - [#856](https://github.com/helmholtz-analytics/heat/pull/856) New `DNDarray` method `__torch_proxy__`
+- [#885](https://github.com/helmholtz-analytics/heat/pull/885) New `DNDarray` method `conj`
 
 ### Linear Algebra
 - [#840](https://github.com/helmholtz-analytics/heat/pull/840) New feature: `vecdot()`

--- a/heat/core/complex_math.py
+++ b/heat/core/complex_math.py
@@ -65,6 +65,10 @@ def conjugate(x: DNDarray, out: Optional[DNDarray] = None) -> DNDarray:
 # alias
 conj = conjugate
 
+# DNDarray method
+DNDarray.conj = lambda self, out=None: conjugate(self, out)
+DNDarray.conj.__doc__ = conjugate.__doc__
+
 
 def imag(x: DNDarray) -> DNDarray:
     """

--- a/heat/core/tests/test_complex_math.py
+++ b/heat/core/tests/test_complex_math.py
@@ -137,6 +137,14 @@ class TestComplex(TestCase):
         self.assertEqual(conj.shape, (4, 4))
         self.assertTrue(ht.equal(conj, res))
 
+        # DNDarray method
+        a = ht.array([1 + 1j, 1 - 1j])
+        conj = a.conj()
+        res = ht.array([1 - 1j, 1 + 1j])
+
+        self.assertIs(conj.device, self.device)
+        self.assertTrue(ht.equal(conj, res))
+
     def test_imag(self):
         a = ht.array([1.0, 1.0j, 1 + 1j, -2 + 2j, 3 - 3j])
         imag = ht.imag(a)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Adds `conj` to `DNDarray` to match the NumPy/PyTorch API

## Changes proposed:
- DNDarray method `conj`

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Enhancement/feature

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measuremens can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
N/A :smiley: 
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only provile the performance on each process. Printing the results with many processes
my be illegible. It may be easiest to save the output of each to a file.
--->
N/A :smiley: 

## Due Diligence
- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no