### PR TITLE
Features/537 better inclusion of license file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [#867](https://github.com/helmholtz-analytics/heat/pull/867) Upgraded to support torch 1.9.0
 - [#876](https://github.com/helmholtz-analytics/heat/pull/876) Make examples work (Lasso and kNN)
+- [#894](https://github.com/helmholtz-analytics/heat/pull/894) Change inclusion of license file
 
 ## Bug Fixes
 - [#826](https://github.com/helmholtz-analytics/heat/pull/826) Fixed `__setitem__` handling of distributed `DNDarray` values which have a different shape in the split dimension

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Project Status
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![license: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Downloads](https://pepy.tech/badge/heat)](https://pepy.tech/project/heat)
-[![Mattermost Chat](https://img.shields.io/badge/chat-on%20mattermost-blue.svg)](https://mattermost-haf.fz-juelich.de/signup_user_complete/?id=iqrr6pmxb38fzqffa51qqhcu8w)
 
 Goals
 -----

--- a/examples/classification/demo_knn.py
+++ b/examples/classification/demo_knn.py
@@ -2,15 +2,17 @@ import sys
 import os
 import random
 
-# Fix python path if run from terminal
-curdir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.abspath(os.path.join(curdir, "../../")))
-
 import heat as ht
 from heat.classification.kneighborsclassifier import KNeighborsClassifier
 
+import pkg_resources
+
 # Load dataset from hdf5 file
-X = ht.load_hdf5("../../heat/datasets/iris.h5", dataset="data", split=0)
+iris_path = pkg_resources.resource_filename(
+    pkg_resources.Requirement.parse("heat"), "heat/datasets/iris.h5"
+)
+
+X = ht.load_hdf5(iris_path, dataset="data", split=0)
 
 # Generate keys for the iris.h5 dataset
 keys = []

--- a/examples/lasso/demo.py
+++ b/examples/lasso/demo.py
@@ -3,22 +3,25 @@ import torch
 import sys
 import os
 
-# Fix python path if run from terminal
-curdir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.abspath(os.path.join(curdir, "../../")))
-
 import heat as ht
 from matplotlib import pyplot as plt
 from sklearn import datasets
 import heat.regression.lasso as lasso
+
 import plotfkt
+
+import pkg_resources
 
 # read scikit diabetes data set
 diabetes = datasets.load_diabetes()
 
 # load diabetes dataset from hdf5 file
-X = ht.load_hdf5("../../heat/datasets/diabetes.h5", dataset="x", split=0)
-y = ht.load_hdf5("../../heat/datasets/diabetes.h5", dataset="y", split=0)
+diabetes_path = pkg_resources.resource_filename(
+    pkg_resources.Requirement.parse("heat"), "heat/datasets/diabetes.h5"
+)
+
+X = ht.load_hdf5(diabetes_path, dataset="x", split=0)
+y = ht.load_hdf5(diabetes_path, dataset="y", split=0)
 
 # normalize dataset #DoTO this goes into the lasso fit routine soon as issue #106 is solved
 X = X / ht.sqrt((ht.mean(X ** 2, axis=0)))

--- a/heat/datasets/__init__.py
+++ b/heat/datasets/__init__.py
@@ -1,0 +1,3 @@
+"""
+Make heat.datasets available as a module.
+"""

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open("./heat/core/version.py") as handle:
 setup(
     name="heat",
     packages=find_packages(exclude=("*tests*", "*benchmarks*")),
+    package_data={"heat.datasets": ["*.csv", "*.h5", "*.nc"]},
     version=__version__,
     description="A framework for high-performance data analytics and machine learning.",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ with open("./heat/core/version.py") as handle:
 setup(
     name="heat",
     packages=find_packages(exclude=("*tests*", "*benchmarks*")),
-    data_files=["README.md", "LICENSE"],
     version=__version__,
     description="A framework for high-performance data analytics and machine learning.",
     long_description=long_description,


### PR DESCRIPTION
## Description

This PR changes several two aspects of installing and using HeAT. 

1. get rid of README.md and LICENSE files in the install root / PREFIX
2. make the already packaged data sets available as a package resource

Issue/s resolved: #537 

## Changes proposed:
- 

## Type of change
- Bug fix
- New feature

## Memory requirements
n/a

## Performance
n/a

## Due Diligence
- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
