### PR TITLE
Feature/844 cross axisa axisb

### DIFF
--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -146,17 +146,8 @@ def cross(
 
         axisc = stride_tricks.sanitize_axis(x1.shape, axisc)
 
-        if axisc != axisa:
-            x1_permute_axes = list(range(len(x1.shape)))
-            x1_permute_axes.remove(axisa)
-            x1_permute_axes = x1_permute_axes[:axisc] + [axisa] + x1_permute_axes[axisc:]
-            x1 = x1.transpose(x1_permute_axes)
-
-        if axisc != axisb:
-            x2_permute_axes = list(range(len(x2.shape)))
-            x2_permute_axes.remove(axisb)
-            x2_permute_axes = x2_permute_axes[:axisc] + [axisb] + x2_permute_axes[axisc:]
-            x2 = x2.transpose(x2_permute_axes)
+        x1 = manipulations.swapaxes(x1, axisa, axisc)
+        x2 = manipulations.swapaxes(x2, axisb, axisc)
 
         axis = axisc
 

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -159,6 +159,7 @@ def cross(
         raise ValueError("'a' and 'b' must have the same split, {} != {}".format(a.split, b.split))
 
     if not (a.is_balanced and b.is_balanced):
+        # TODO: replace with sanitize_redistribute after #888 is merged
         b = manipulations.redistribute(b, b.lshape_map, a.lshape_map)
 
     promoted = torch.promote_types(a.larray.dtype, b.larray.dtype)

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -106,6 +106,7 @@ def cross(
         # 2d -> 3d vector
         if x1.shape[axisa] == 2:
             shape = tuple(1 if i == axisa else j for i, j in enumerate(x1.shape))
+            # TODO test: writing into a larger zeros array might be more efficient than concatenating
             x1 = manipulations.concatenate(
                 [x1, factories.zeros(shape, dtype=x1.dtype, device=x1.device)], axis=axisa
             )
@@ -120,15 +121,17 @@ def cross(
 
         axisc = stride_tricks.sanitize_axis(x1.shape, axisc)
 
-        x1_permute_axes = list(range(len(x1.shape)))
-        x1_permute_axes.remove(axisa)
-        x1_permute_axes = x1_permute_axes[:axisc] + [axisa] + x1_permute_axes[axisc:]
-        x1 = x1.transpose(x1_permute_axes)
+        if axisc != axisa:
+            x1_permute_axes = list(range(len(x1.shape)))
+            x1_permute_axes.remove(axisa)
+            x1_permute_axes = x1_permute_axes[:axisc] + [axisa] + x1_permute_axes[axisc:]
+            x1 = x1.transpose(x1_permute_axes)
 
-        x2_permute_axes = list(range(len(x2.shape)))
-        x2_permute_axes.remove(axisb)
-        x2_permute_axes = x2_permute_axes[:axisc] + [axisb] + x2_permute_axes[axisc:]
-        x2 = x2.transpose(x2_permute_axes)
+        if axisc != axisb:
+            x2_permute_axes = list(range(len(x2.shape)))
+            x2_permute_axes.remove(axisb)
+            x2_permute_axes = x2_permute_axes[:axisc] + [axisb] + x2_permute_axes[axisc:]
+            x2 = x2.transpose(x2_permute_axes)
 
         axis = axisc
 

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -42,7 +42,9 @@ __all__ = [
 ]
 
 
-def cross(x1: DNDarray, x2: DNDarray, axis: int = -1) -> DNDarray:
+def cross(
+    x1: DNDarray, x2: DNDarray, axisa: int = -1, axisb: int = -1, axisc: int = -1, axis: int = -1
+) -> DNDarray:
     """
     Returns the cross product. 2D vectors will we converted to 3D.
 
@@ -52,8 +54,15 @@ def cross(x1: DNDarray, x2: DNDarray, axis: int = -1) -> DNDarray:
         First input array.
     x2 : DNDarray
         Second input array. Must have the same shape as 'x1'.
+    axisa: int
+        Axis of `x1` that defines the vector(s). By default, the last axis.
+    axisb: int
+        Axis of `x2` that defines the vector(s). By default, the last axis.
+    axisc: int
+        Axis of the output containing the cross product vector(s). By default, the last axis.
     axis : int
-        Axis that defines the vectors for which to compute the cross product. Default: -1
+        Axis that defines the vectors for which to compute the cross product. Overrides `axisa`, `axisb` and `axisc`. Default: -1
+
 
     Raises
     ------
@@ -73,6 +82,9 @@ def cross(x1: DNDarray, x2: DNDarray, axis: int = -1) -> DNDarray:
     """
     sanitation.sanitize_in(x1)
     sanitation.sanitize_in(x2)
+
+    if not axis == -1 or torch.unique(torch.tensor([axisa, axisb, axisc, axis])).numel() == 1:
+        axis = stride_tricks.sanitize_axis(x1.shape, axis)
 
     # 2d -> 3d vector
     if x1.shape[axis] == 2:
@@ -102,13 +114,14 @@ def cross(x1: DNDarray, x2: DNDarray, axis: int = -1) -> DNDarray:
     if x1.comm != x2.comm:  # pragma: no cover
         raise ValueError("'x1' and 'x2' must have the same comm, {} != {}".format(x1.comm, x2.comm))
 
-    if not isinstance(axis, int):
-        try:
-            axis = int(axis)
-        except Exception:
-            raise TypeError("'axis' must be an integer.")
+    # TODO remove this
+    # if not isinstance(axis, int):
+    #     try:
+    #         axis = int(axis)
+    #     except Exception:
+    #         raise TypeError("'axis' must be an integer.")
 
-    axis = stride_tricks.sanitize_axis(x1.shape, axis)
+    # axis = stride_tricks.sanitize_axis(x1.shape, axis)
 
     if x1.split == axis:
         raise ValueError(

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -134,7 +134,6 @@ def cross(
         if x1.shape[axisa] == 2:
             x1_2d = True
             shape = tuple(1 if i == axisa else j for i, j in enumerate(x1.shape))
-            # TODO test: writing into a larger zeros array might be more efficient than concatenating
             x1 = manipulations.concatenate(
                 [x1, factories.zeros(shape, dtype=x1.dtype, device=x1.device)], axis=axisa
             )

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -146,8 +146,11 @@ def cross(
 
         axisc = stride_tricks.sanitize_axis(x1.shape, axisc)
 
-        x1 = manipulations.swapaxes(x1, axisa, axisc)
-        x2 = manipulations.swapaxes(x2, axisb, axisc)
+        if axisc != axisa:
+            x1 = manipulations.moveaxis(x1, axisa, axisc)
+
+        if axisc != axisb:
+            x2 = manipulations.moveaxis(x2, axisb, axisc)
 
         axis = axisc
 

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -75,6 +75,9 @@ class TestLinalgBasics(TestCase):
         np_cross_z_comp = np.cross(np_a[:, :-1, :], np_b[:-1, :, :], axisa=1, axisb=0)
         self.assert_array_equal(cross_z_comp, np_cross_z_comp)
 
+        a_wrong_split = ht.array(np_a[:, :-1, :], split=2)
+        with self.assertRaises(ValueError):
+            ht.cross(a_wrong_split, b, axisa=1, axisb=0)
         with self.assertRaises(ValueError):
             ht.cross(ht.eye(3), ht.eye(4))
         with self.assertRaises(ValueError):

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -47,18 +47,18 @@ class TestLinalgBasics(TestCase):
 
         # test axisa, axisb, axisc
         np.random.seed(42)
-        np_a = np.random.randn(40, 3, 50).astype(np.float32)
-        np_b = np.random.randn(3, 40, 50).astype(np.float32)
+        np_a = np.random.randn(40, 3, 50)
+        np_b = np.random.randn(3, 40, 50)
         np_cross = np.cross(np_a, np_b, axisa=1, axisb=0)
 
         a = ht.array(np_a, split=0)
         b = ht.array(np_b, split=1)
         cross = ht.cross(a, b, axisa=1, axisb=0)
-        self.assertTrue((cross.numpy() == np_cross).all())
+        self.assert_array_equal(cross, np_cross)
 
         cross_axisc = ht.cross(a, b, axisa=1, axisb=0, axisc=1)
         np_cross_axisc = np.cross(np_a, np_b, axisa=1, axisb=0, axisc=1)
-        self.assertTrue((cross_axisc.numpy() == np_cross_axisc).all())
+        self.assert_array_equal(cross_axisc, np_cross_axisc)
 
         with self.assertRaises(ValueError):
             ht.cross(ht.eye(3), ht.eye(4))

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -60,6 +60,21 @@ class TestLinalgBasics(TestCase):
         np_cross_axisc = np.cross(np_a, np_b, axisa=1, axisb=0, axisc=1)
         self.assert_array_equal(cross_axisc, np_cross_axisc)
 
+        # test vector axes with 2 elements
+        b_2d = ht.array(np_b[:-1, :, :], split=1)
+        cross_3d_2d = ht.cross(a, b_2d, axisa=1, axisb=0)
+        np_cross_3d_2d = np.cross(np_a, np_b[:-1, :, :], axisa=1, axisb=0)
+        self.assert_array_equal(cross_3d_2d, np_cross_3d_2d)
+
+        a_2d = ht.array(np_a[:, :-1, :], split=0)
+        cross_2d_3d = ht.cross(a_2d, b, axisa=1, axisb=0)
+        np_cross_2d_3d = np.cross(np_a[:, :-1, :], np_b, axisa=1, axisb=0)
+        self.assert_array_equal(cross_2d_3d, np_cross_2d_3d)
+
+        cross_z_comp = ht.cross(a_2d, b_2d, axisa=1, axisb=0)
+        np_cross_z_comp = np.cross(np_a[:, :-1, :], np_b[:-1, :, :], axisa=1, axisb=0)
+        self.assert_array_equal(cross_z_comp, np_cross_z_comp)
+
         with self.assertRaises(ValueError):
             ht.cross(ht.eye(3), ht.eye(4))
         with self.assertRaises(ValueError):

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -45,6 +45,21 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(cross.device, a.device)
         self.assertTrue(ht.equal(cross, ht.array([[0, 0, -1], [-1, 0, 0], [0, -1, 0]])))
 
+        # test axisa, axisb, axisc
+        np.random.seed(42)
+        np_a = np.random.randn(40, 3, 50)
+        np_b = np.random.randn(3, 40, 50)
+        np_cross = np.cross(np_a, np_b, axisa=1, axisb=0)
+
+        a = ht.array(np_a, split=0)
+        b = ht.array(np_b, split=1)
+        cross = ht.cross(a, b, axisa=1, axisb=0)
+        self.assertTrue((cross.numpy() == np_cross).all())
+
+        cross_axisc = ht.cross(a, b, axisa=1, axisb=0, axisc=1)
+        np_cross_axisc = np.cross(np_a, np_b, axisa=1, axisb=0, axisc=1)
+        self.assertTrue((cross_axisc.numpy() == np_cross_axisc).all())
+
         with self.assertRaises(ValueError):
             ht.cross(ht.eye(3), ht.eye(4))
         with self.assertRaises(ValueError):

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -47,8 +47,8 @@ class TestLinalgBasics(TestCase):
 
         # test axisa, axisb, axisc
         np.random.seed(42)
-        np_a = np.random.randn(40, 3, 50)
-        np_b = np.random.randn(3, 40, 50)
+        np_a = np.random.randn(40, 3, 50).astype(np.float32)
+        np_b = np.random.randn(3, 40, 50).astype(np.float32)
         np_cross = np.cross(np_a, np_b, axisa=1, axisb=0)
 
         a = ht.array(np_a, split=0)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Introducing changes to accomodate numpy's `axisa`, `axisb`, `axisc` into @mtar 's `ht.cross` implementation.

Still TODO: documentation update, expand on tests, memory/performance checks.
 
Issue/s resolved: #

## Changes proposed:
-
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- New feature (non-breaking change which adds functionality)
## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measuremens can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only provile the performance on each process. Printing the results with many processes
my be illegible. It may be easiest to save the output of each to a file.
--->


## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->

