### PR TITLE
Features/880 binop ben bou

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,7 +37,7 @@ These tools only profile the memory used by each process, not the entire functio
 - with `split=None` and `split not None`
 
 Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
-Again, this will only provile the performance on each process. Printing the results with many processes
+Again, this will only profile the performance on each process. Printing the results with many processes
 my be illegible. It may be easiest to save the output of each to a file.
 --->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 - [#868](https://github.com/helmholtz-analytics/heat/pull/868) Fixed an issue in `__binary_op` where data was falsely distributed if a DNDarray has single element.
 
 ## Feature Additions
-### Linear Algebra
-- [#842](https://github.com/helmholtz-analytics/heat/pull/842) New feature: `vdot`
+
+### Arithmetics
+ - - [#887](https://github.com/helmholtz-analytics/heat/pull/887) Binary operations now support operands of equal shapes, equal `split` axes, but different distribution maps.
 
 ### Communication
 - [#868](https://github.com/helmholtz-analytics/heat/pull/868) New `MPICommunication` method `Split`
@@ -21,6 +22,7 @@
 
 ### Linear Algebra
 - [#840](https://github.com/helmholtz-analytics/heat/pull/840) New feature: `vecdot()`
+- [#842](https://github.com/helmholtz-analytics/heat/pull/842) New feature: `vdot`
 - [#846](https://github.com/helmholtz-analytics/heat/pull/846) New features `norm`, `vector_norm`, `matrix_norm`
 ### Logical
 - [#862](https://github.com/helmholtz-analytics/heat/pull/862) New feature `signbit`

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,12 +13,12 @@ pipeline {
                 }
             }
         }
-        
+
         stage ('Test') {
             options {
                 timeout(time: 15, unit: "MINUTES")
             }
-            
+
             steps {
                 withPythonEnv('/home/jenkins/allvenvs/') {
                     sh 'COVERAGE_FILE=report/cov/coverage1 mpirun -n 1 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report1.xml heat/'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,12 @@ pipeline {
                 }
             }
         }
+        
         stage ('Test') {
+            options {
+                timeout(time: 15, unit: "MINUTES")
+            }
+            
             steps {
                 withPythonEnv('/home/jenkins/allvenvs/') {
                     sh 'COVERAGE_FILE=report/cov/coverage1 mpirun -n 1 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report1.xml heat/'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Project Status
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![license: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Downloads](https://pepy.tech/badge/heat)](https://pepy.tech/project/heat)
-[![Mattermost Chat](https://img.shields.io/badge/chat-on%20mattermost-blue.svg)](https://mattermost-haf.fz-juelich.de/signup_user_complete/?id=iqrr6pmxb38fzqffa51qqhcu8w)
 
 Goals
 -----

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -194,11 +194,16 @@ def __binary_op(
         if output_split is not None:
             if t1.lshape[output_split] == 0 or t2.lshape[output_split] == 0:
                 output_lshape[output_split] = 0
-            elif t1.lshape[output_split] == 1:
+            elif t1.shape[output_split] == 1:
                 output_lshape[output_split] = t2.lshape[output_split]
             else:
                 output_lshape[output_split] = t1.lshape[output_split]
-        result = torch.Tensor([], device=output_device).type(promoted_type).expand(output_lshape)
+        result = (
+            torch.Tensor([], device=output_device.torch_device)
+            .type(promoted_type)
+            .expand(output_lshape)
+            .contiguous()
+        )
     else:  # local process is not empty
         result = operation(
             t1.larray.type(promoted_type), t2.larray.type(promoted_type), **fn_kwargs

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -73,6 +73,7 @@ def __binary_op(
         raise TypeError(
             "Only tensors and numeric scalars are supported, but input was {}".format(type(t2))
         )
+    promoted_type = types.result_type(t1, t2).torch_type()
 
     # Make inputs Dndarrays
     if np.isscalar(t1) and np.isscalar(t2):
@@ -163,7 +164,6 @@ def __binary_op(
                 t2.larray[tuple(idx)], is_split=t1.split, copy=False, comm=t2.comm, device=t2.device
             )
 
-    promoted_type = types.result_type(t1, t2).torch_type()
     result = operation(t1.larray.type(promoted_type), t2.larray.type(promoted_type), **fn_kwargs)
     if not isinstance(result, torch.Tensor):
         result = torch.tensor(result, device=output_device.torch_device)

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -112,79 +112,7 @@ def __binary_op(
     # t1 = t1[tuple([None] * (len(output_shape) - t1.ndim))]
     # t2 = t2[tuple([None] * (len(output_shape) - t2.ndim))]
 
-    # determine output params, transform to output shape
-    # if t1.split is not None and t1.shape[t1.split] == output_shape[t1.split]:
-    #     # t1 is "dominant"
-    #     output_split = t1.split
-    #     output_device = t1.device
-    #     output_comm = t1.comm
-    #     if out is None:
-    #         t2 = sanitation.sanitize_distribution(t2, target=t1)
-    #         output_balanced = t1.balance
-    # elif t2.split is not None and t2.shape[t2.split] == output_shape[t2.split]:
-    #     # t2 is "dominant"
-    #     output_split = t2.split
-    #     output_device = t2.device
-    #     output_comm = t2.comm
-    #     if out is None:
-    #         t1 = sanitation.sanitize_distribution(t1, target=t2)
-    #         output_balanced = t2.balance
-    # elif t1.split != t2.split:
-    #     raise NotImplementedError(
-    #         "DNDarrays must have the same split axes, found {} and {}".format(
-    #             t1.split, t2.split
-    #         )
-    #     )
-    # elif t1.split is not None:
-    #     # t1 is split but broadcast -> size==1, only on one rank; t2 is not split
-    #     output_split = t1.split
-    #     output_device = t1.device
-    #     output_comm = t1.comm
-    #     if out is None:
-    #         if t1.lshape[t1.split] == t1.gshape[t1.split]:  # active rank
-    #             t2 = factories.array(
-    #                 t2.larray, is_split=t1.split, copy=False, comm=t1.comm, device=t2.device
-    #             )
-    #         else:  # inactive rank
-    #             idx = [slice(None)] * t1.ndim
-    #             idx[t1.split] = slice(0, 0)
-    #             t2 = factories.array(
-    #                 t2.larray[tuple(idx)],
-    #                 is_split=t1.split,
-    #                 copy=False,
-    #                 comm=t1.comm,
-    #                 device=t2.device,
-    #             )
-    #         output_balanced = t1.balance
-    # elif t2.split is not None:
-    #     # t2 is split but broadcast -> size==1, only on one rank; t1 is not split
-    #     output_split = t2.split
-    #     output_device = t2.device
-    #     output_comm = t2.comm
-    #     if out is None:
-    #         if t2.lshape[t2.split] == t2.gshape[t2.split]:  # active rank
-    #             t1 = factories.array(
-    #                 t1.larray, is_split=t2.split, copy=False, comm=t2.comm, device=t1.device
-    #             )
-    #         else:  # inactive rank
-    #             idx = [slice(None)] * t1.ndim
-    #             idx[t1.split] = slice(0, 0)
-    #             t1 = factories.array(
-    #                 t1.larray[tuple(idx)],
-    #                 is_split=t2.split,
-    #                 copy=False,
-    #                 comm=t2.comm,
-    #                 device=t1.device,
-    #             )
-    #         output_balanced = t2.balance
-    # else:
-    #     # both are not split
-    #     output_split = t1.split
-    #     output_device = t1.device
-    #     output_comm = t1.comm
-    #     output_balanced = t1.balance
-
-    def _get_out_params(target, other=None, map=None):
+    def __get_out_params(target, other=None, map=None):
         if other is not None:
             if out is None:
                 other = sanitation.sanitize_distribution(other, target=target, diff_map=map)
@@ -192,15 +120,15 @@ def __binary_op(
         return target.split, target.device, target.comm, target.balance
 
     if t1.split is not None and t1.shape[t1.split] == output_shape[t1.split]:  # t1 is "dominant"
-        output_split, output_device, output_comm, output_balanced, t2 = _get_out_params(t1, t2)
+        output_split, output_device, output_comm, output_balanced, t2 = __get_out_params(t1, t2)
     elif t2.split is not None and t2.shape[t2.split] == output_shape[t2.split]:  # t2 is "dominant"
-        output_split, output_device, output_comm, output_balanced, t1 = _get_out_params(t2, t1)
+        output_split, output_device, output_comm, output_balanced, t1 = __get_out_params(t2, t1)
     elif t1.split is not None:
         # t1 is split but broadcast -> only on one rank; manipulate lshape_map s.t. this rank has 'full' data
         lmap = t1.lshape_map
         idx = lmap[:, t1.split].nonzero(as_tuple=True)[0]
         lmap[idx.item(), t1.split] = output_shape[t1.split]
-        output_split, output_device, output_comm, output_balanced, t2 = _get_out_params(
+        output_split, output_device, output_comm, output_balanced, t2 = __get_out_params(
             t1, t2, map=lmap
         )
     elif t2.split is not None:
@@ -208,11 +136,11 @@ def __binary_op(
         lmap = t2.lshape_map
         idx = lmap[:, t2.split].nonzero(as_tuple=True)[0]
         lmap[idx.item(), t2.split] = output_shape[t2.split]
-        output_split, output_device, output_comm, output_balanced, t1 = _get_out_params(
-            t2, t1, map=lmap
+        output_split, output_device, output_comm, output_balanced, t1 = __get_out_params(
+            t2, other=t1, map=lmap
         )
     else:  # both are not split
-        output_split, output_device, output_comm, output_balanced = _get_out_params(t1)
+        output_split, output_device, output_comm, output_balanced = __get_out_params(t1)
 
     if out is not None:
         sanitation.sanitize_out(out, output_shape, output_split, output_device, output_comm)
@@ -223,11 +151,6 @@ def __binary_op(
         return out
 
     result = operation(t1.larray.type(promoted_type), t2.larray.type(promoted_type), **fn_kwargs)
-    # if operation is torch.equal:#
-    #     # TODO this is needed because torch.equal wrongly uses binop but is a reduceop
-    #     return result
-    # elif not isinstance(result, torch.Tensor):
-    #     result = torch.tensor(result, device=output_device.torch_device)
 
     return DNDarray(
         result,

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -223,9 +223,11 @@ def __binary_op(
         return out
 
     result = operation(t1.larray.type(promoted_type), t2.larray.type(promoted_type), **fn_kwargs)
-    if not isinstance(result, torch.Tensor):
-        # TODO this is needed because torch.equal wrongly uses binop but is a reduceop
-        result = torch.tensor(result, device=output_device.torch_device)
+    # if operation is torch.equal:#
+    #     # TODO this is needed because torch.equal wrongly uses binop but is a reduceop
+    #     return result
+    # elif not isinstance(result, torch.Tensor):
+    #     result = torch.tensor(result, device=output_device.torch_device)
 
     return DNDarray(
         result,

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -113,9 +113,9 @@ def __binary_op(
 
     def __get_out_params(target, other=None, map=None):
         """
-        Getter for the output parameters of a binop with target.
-        If other is provided, it's distribution will be matched to target or, if provided,
-        redistributed according to map.
+        Getter for the output parameters of a binary operation with target distribution.
+        If `other` is provided, its distribution will be matched to `target` or, if provided,
+        redistributed according to `map`.
 
         Parameters
         ----------
@@ -124,7 +124,7 @@ def __binary_op(
         other : DNDarray
             DNDarray to be adapted
         map : Tensor
-            Lshape-Map other should be matched to. Defaults to target's lshape_map
+            lshape_map `other` should be matched to. Defaults to `target.lshape_map`
 
         Returns
         -------

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -20,8 +20,6 @@ from typing import Callable, Optional, Type, Union, Dict
 __all__ = []
 __BOOLEAN_OPS = [MPI.LAND, MPI.LOR, MPI.BAND, MPI.BOR]
 
-print("debugging")
-
 
 def __binary_op(
     operation: Callable,

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -56,7 +56,7 @@ def __binary_op(
     -------
     If both operands are distributed, they must be distributed along the same dimension, i.e. `t1.split = t2.split`.
 
-    MPI communication is necessary when both operands are distributed along the same dimension, but the distribution maps do not match. I.e.:
+    MPI communication is necessary when both operands are distributed along the same dimension, but the distribution maps do not match. E.g.:
     ```
     a =  ht.ones(10000, split=0)
     b = ht.zeros(10000, split=0)

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -176,10 +176,10 @@ def __binary_op(
             output_balanced = t2.balance
     else:
         # both are not split
-        output_split = None
+        output_split = t1.split
         output_device = t1.device
         output_comm = t1.comm
-        output_balanced = True
+        output_balanced = t1.balance
 
     if out is not None:
         sanitation.sanitize_out(out, output_shape, output_split, output_device, output_comm)
@@ -189,6 +189,8 @@ def __binary_op(
         )
         return out
     result = operation(t1.larray.type(promoted_type), t2.larray.type(promoted_type), **fn_kwargs)
+    if not isinstance(result, torch.Tensor):
+        result = torch.tensor(result, device=output_device.torch_device)
 
     return DNDarray(
         result,

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -108,27 +108,8 @@ def __binary_op(
     # t1 = t1[tuple([None] * (len(output_shape) - t1.ndim))]
     # t2 = t2[tuple([None] * (len(output_shape) - t2.ndim))]
 
-    # if t1.split is not None and t2.split is not None and t1.split != t2.split:
-    #     # if t1 and t2 both split, split has to be the same after (shape)bcast
-    #     raise NotImplementedError(
-    #         "Not implemented for different splittings, found {} and {} after broadcasting".format(
-    #             t1.split, t2.split
-    #         )
-    #     )
-    # elif not t1.comm == t2.comm:
-    #     try:
-    #         raise NotImplementedError(
-    #             "Not implemented for other comms, found {} and {}".format(
-    #                 t1.comm.name, t2.comm.name
-    #             )
-    #         )
-    #     except Exception:
-    #         raise NotImplementedError("Not implemented for other comms")
-
     # determine output params, transform to output shape
-    if (t1.split is not None and t2.split is None) or (
-        t1.split is not None and t1.shape[t1.split] == output_shape[t1.split]
-    ):
+    if t1.split is not None and t1.shape[t1.split] == output_shape[t1.split]:
         # t1 is "dominant"
         output_split = t1.split
         output_device = t1.device
@@ -136,13 +117,69 @@ def __binary_op(
         if out is None:
             t2 = sanitation.sanitize_distribution(t2, target=t1)
             output_balanced = t1.balance
-    else:  # t2 is "dominant"
+    elif t2.split is not None and t2.shape[t2.split] == output_shape[t2.split]:
+        # t2 is "dominant"
         output_split = t2.split
         output_device = t2.device
         output_comm = t2.comm
         if out is None:
             t1 = sanitation.sanitize_distribution(t1, target=t2)
             output_balanced = t2.balance
+    elif t1.split is not None and t2.split is not None:
+        if t1.split != t2.split:
+            raise NotImplementedError(
+                "DNDarrays must have the same split axes, found {} and {}".format(
+                    t1.split, t2.split
+                )
+            )
+    elif t1.split is not None:
+        # t1 is split but broadcast -> size==1, only on one rank; t2 is not split
+        output_split = t1.split
+        output_device = t1.device
+        output_comm = t1.comm
+        if out is None:
+            if t1.lshape[t1.split] == t1.gshape[t1.split]:  # active rank
+                t2 = factories.array(
+                    t2.larray, is_split=t1.split, copy=False, comm=t1.comm, device=t2.device
+                )
+            else:  # inactive rank
+                idx = [slice(None)] * t1.ndim
+                idx[t1.split] = slice(0, 0)
+                t2 = factories.array(
+                    t2.larray[tuple(idx)],
+                    is_split=t1.split,
+                    copy=False,
+                    comm=t1.comm,
+                    device=t2.device,
+                )
+            output_balanced = t1.balance
+    elif t2.split is not None:
+        # t2 is split but broadcast -> size==1, only on one rank; t1 is not split
+        output_split = t2.split
+        output_device = t2.device
+        output_comm = t2.comm
+        if out is None:
+            if t2.lshape[t2.split] == t2.gshape[t2.split]:  # active rank
+                t1 = factories.array(
+                    t1.larray, is_split=t2.split, copy=False, comm=t2.comm, device=t1.device
+                )
+            else:  # inactive rank
+                idx = [slice(None)] * t1.ndim
+                idx[t1.split] = slice(0, 0)
+                t1 = factories.array(
+                    t1.larray[tuple(idx)],
+                    is_split=t2.split,
+                    copy=False,
+                    comm=t2.comm,
+                    device=t1.device,
+                )
+            output_balanced = t2.balance
+    else:
+        # both are not split
+        output_split = None
+        output_device = t1.device
+        output_comm = t1.comm
+        output_balanced = True
 
     if out is not None:
         sanitation.sanitize_out(out, output_shape, output_split, output_device, output_comm)
@@ -151,107 +188,7 @@ def __binary_op(
             t1.larray.type(promoted_type), t2.larray.type(promoted_type), **fn_kwargs
         )
         return out
-
-    # if output_split is not None and t1.shape[output_split] <= 1 and output_shape[output_split] > 1:
-    #     # broadcasting in split-dimension:
-    #     # move full array to every rank; no redistribution because size is only one
-    #     t1 = t1.resplit(None)
-    #     output_split = t2.split
-    #     output_balanced = t2.balanced
-    # elif (
-    #     output_split is not None and t2.shape[output_split] <= 1 and output_shape[output_split] > 1
-    # ):
-    #     # broadcasting in split-dimension:
-    #     # move full array to every rank; no redistribution because size is only one
-    #     t2 = t2.resplit(None)
-    # elif (
-    #     t1.is_distributed() and t2.is_distributed() and not (t1.is_balanced() and t2.is_balanced())
-    # ):
-    #     # Equalize t1 and t2 distribution
-    #     if out is None:  # redistribute to match t1
-    #         t2_map = t2.lshape_map
-    #         target_map = t2_map.clone()
-    #         target_map[:, t2.split] = t1.lshape_map[:, t2.split]
-    #         if not (t2_map[:, t2.split] == target_map[:, t2.split]).all():
-    #             t2 = t2.redistribute(
-    #                 lshape_map=t2_map, target_map=target_map
-    #             )  # OUT-OF-PLACE binops should not alter their arguments
-    #     else:  # redistribute to match out
-    #         sanitation.sanitize_out(out, output_shape, output_split, output_device)
-    #         target_map = out.lshape_map
-    #         t1_map = t1.lshape_map
-    #         t1_target_map = t1_map.clone()
-    #         t2_map = t2.lshape_map
-    #         t2_target_map = t2_map.clone()
-    #         t1_target_map[:, t1.split] = target_map[:, t1.split]
-    #         t2_target_map[:, t2.split] = target_map[:, t2.split]
-    #         if not (t1_map[:, t1.split] == t1_target_map[:, t1.split]).all():
-    #             t1 = t1.redistribute(
-    #                 lshape_map=t1_map, target_map=t1_target_map
-    #             )  # OUT-OF-PLACE binops should not alter their arguments
-    #         if not (t2_map[:, t2.split] == t2_target_map[:, t2.split]).all():
-    #             t2 = t2.redistribute(
-    #                 lshape_map=t2_map, target_map=t2_target_map
-    #             )  # OUT-OF-PLACE binops should not alter their arguments
-    # elif not t1.is_distributed() and t2.is_distributed():
-    #     # t1 is not distributed -> no redistribution needed; take local slice
-    #     if t2.is_balanced():
-    #         t1 = factories.array(t1, split=t2.split, copy=False, comm=t1.comm, device=t1.device)
-    #     else:
-    #         idx = [slice(None)] * t1.ndim
-    #         lshapes = t2.lshape_map[:, t2.split]
-    #         idx[t2.split] = slice(lshapes[: t1.comm.rank].sum(), lshapes[: t1.comm.rank + 1].sum())
-    #         t1 = factories.array(
-    #             t1.larray[tuple(idx)], is_split=t2.split, copy=False, comm=t1.comm, device=t1.device
-    #         )
-    # elif t1.is_distributed() and not t2.is_distributed():
-    #     # t2 is not distributed -> no redistribution needed; take local slice
-    #     if t1.is_balanced():
-    #         t2 = factories.array(t2, split=t1.split, copy=False, comm=t2.comm, device=t2.device)
-    #     else:
-    #         idx = [slice(None)] * t2.ndim
-    #         lshapes = t1.lshape_map[:, t1.split]
-    #         idx[t1.split] = slice(lshapes[: t2.comm.rank].sum(), lshapes[: t2.comm.rank + 1].sum())
-    #         t2 = factories.array(
-    #             t2.larray[tuple(idx)], is_split=t1.split, copy=False, comm=t2.comm, device=t2.device
-    #         )
-
-    # if False:#t1.lnumel == 0 or t2.lnumel == 0:  # local process is empty
-    #     output_lshape = list(output_shape)
-    #     if output_split is not None:  # determine lshape in split dimension
-    #         if t1.lshape[output_split] == t2.lshape[output_split]:
-    #             # if both are the same
-    #             output_lshape[output_split] = t1.lshape[output_split]
-    #         elif t1.lshape[output_split] == 0 or t2.lshape[output_split] == 0:
-    #             # if one has local size zero
-    #             output_lshape[output_split] = 0
-    #         elif t1.split is None or t1.shape[output_split] == 1:
-    #             # if t1 is not split or broadcast along split-dimension -> choose t2
-    #             output_lshape[output_split] = t2.lshape[output_split]
-    #         elif t2.split is None or t2.shape[output_split] == 1:
-    #             # if t2 is not split or broadcast along split-dimension -> choose t1
-    #             output_lshape[output_split] = t1.lshape[output_split]
-    #         else:  # impossible
-    #             pass
-    #     output_lshape = tuple(output_lshape)
-    #     result = (
-    #         torch.Tensor([], device=output_device.torch_device)
-    #         .type(promoted_type)
-    #         .view(output_lshape)
-    #         .contiguous()
-    #     )
-    # else:  # local process is not empty
     result = operation(t1.larray.type(promoted_type), t2.larray.type(promoted_type), **fn_kwargs)
-    if not isinstance(result, torch.Tensor):
-        result = torch.tensor(result, device=output_device.torch_device)
-
-    # if out is not None:
-    #     sanitation.sanitize_out(out, output_shape, output_split, output_device)
-    #     out_dtype = out.dtype
-    #     out.larray = result  # "out: Output buffer in which the result is placed" is this correct???
-    #     out._DNDarray__comm = output_comm
-    #     out = out.astype(out_dtype)
-    #     return out
 
     return DNDarray(
         result,

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -112,8 +112,10 @@ def __binary_op(
     if t1.is_distributed() and t2.is_distributed():
         if t1.shape[t1.split] == 1 and t2.shape[t2.split] != 1:
             t1 = t1.resplit(None)
+            t1.larray = t1.larray.expand(output_shape)
         elif t1.shape[t1.split] != 1 and t2.shape[t2.split] == 1:
             t2 = t2.resplit(None)
+            t2.larray = t2.larray.expand(output_shape)
     output_split = t1.split if t1.split is not None else t2.split
     output_balanced = t1.balanced if t1.split is not None else t2.balanced
     output_device = t1.device

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -108,6 +108,12 @@ def __binary_op(
     if t1.split is not None and t2.split is not None and t1.split != t2.split:
         # if t1 and t2 both split, split has to be the same after (shape)bcast
         raise NotImplementedError("Not implemented for other splittings")
+    # No broadcasting should happen in the split-dimension, would not work with redistribution
+    if t1.is_distributed() and t2.is_distributed():
+        if t1.shape[t1.split] == 1 and t2.shape[t2.split] != 1:
+            t1 = t1.resplit(None)
+        elif t1.shape[t1.split] != 1 and t2.shape[t2.split] == 1:
+            t2 = t2.resplit(None)
     output_split = t1.split if t1.split is not None else t2.split
     output_balanced = t1.balanced if t1.split is not None else t2.balanced
     output_device = t1.device

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -101,12 +101,12 @@ def __binary_op(
     output_shape = stride_tricks.broadcast_shape(t1.shape, t2.shape)
     # Broadcasting allows additional empty dimensions on the left side
     # TODO simplify this once newaxis-indexing is supported to get rid of the loops
-    # while len(t1.shape) < len(output_shape):
-    #     t1 = t1.expand_dims(axis=0)
-    # while len(t2.shape) < len(output_shape):
-    #     t2 = t2.expand_dims(axis=0)
-    t1 = t1[tuple([None] * (len(output_shape) - t1.ndim))]
-    t2 = t2[tuple([None] * (len(output_shape) - t2.ndim))]
+    while len(t1.shape) < len(output_shape):
+        t1 = t1.expand_dims(axis=0)
+    while len(t2.shape) < len(output_shape):
+        t2 = t2.expand_dims(axis=0)
+    # t1 = t1[tuple([None] * (len(output_shape) - t1.ndim))]
+    # t2 = t2[tuple([None] * (len(output_shape) - t2.ndim))]
 
     # if t1.split is not None and t2.split is not None and t1.split != t2.split:
     #     # if t1 and t2 both split, split has to be the same after (shape)bcast

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -190,8 +190,12 @@ def __binary_op(
             t2 = factories.array(
                 t2.larray[tuple(idx)], is_split=t1.split, copy=False, comm=t2.comm, device=t2.device
             )
-
-    result = operation(t1.larray.type(promoted_type), t2.larray.type(promoted_type), **fn_kwargs)
+    if t1.lnumel == 0:
+        result = t1.larray.type(promoted_type).clone()
+    else:
+        result = operation(
+            t1.larray.type(promoted_type), t2.larray.type(promoted_type), **fn_kwargs
+        )
     if not isinstance(result, torch.Tensor):
         result = torch.tensor(result, device=output_device.torch_device)
 

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -160,7 +160,7 @@ def __binary_op(
             idx = [slice(None)] * t2.ndim
             lshapes = t1.lshape_map[:, t1.split]
             idx[t1.split] = slice(lshapes[: t2.comm.rank].sum(), lshapes[: t2.comm.rank + 1].sum())
-            t1 = factories.array(
+            t2 = factories.array(
                 t2.larray[tuple(idx)], is_split=t1.split, copy=False, comm=t2.comm, device=t2.device
             )
 

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -116,8 +116,8 @@ def __binary_op(
         if other is not None:
             if out is None:
                 other = sanitation.sanitize_distribution(other, target=target, diff_map=map)
-            return target.split, target.device, target.comm, target.balance, other
-        return target.split, target.device, target.comm, target.balance
+            return target.split, target.device, target.comm, target.balanced, other
+        return target.split, target.device, target.comm, target.balanced
 
     if t1.split is not None and t1.shape[t1.split] == output_shape[t1.split]:  # t1 is "dominant"
         output_split, output_device, output_comm, output_balanced, t2 = __get_out_params(t1, t2)

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -126,14 +126,17 @@ def __binary_op(
     #         raise NotImplementedError("Not implemented for other comms")
 
     # determine output params, transform to output shape
-    if t1.split is not None and t1.shape[t1.split] == output_shape[t1.split]:
+    if (t1.split is not None and t2.split is None) or (
+        t1.split is not None and t1.shape[t1.split] == output_shape[t1.split]
+    ):
+        # t1 is "dominant"
         output_split = t1.split
         output_device = t1.device
         output_comm = t1.comm
         if out is None:
             t2 = sanitation.sanitize_distribution(t2, target=t1)
             output_balanced = t1.balance
-    else:
+    else:  # t2 is "dominant"
         output_split = t2.split
         output_device = t2.device
         output_comm = t2.comm

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -51,6 +51,18 @@ def __binary_op(
     -------
     result: ht.DNDarray
         A DNDarray containing the results of element-wise operation.
+
+    Warning
+    -------
+    If both operands are distributed, they must be distributed along the same dimension, i.e. `t1.split = t2.split`.
+
+    MPI communication is necessary when both operands are distributed along the same dimension, but the distribution maps do not match. I.e.:
+    ```
+    a =  ht.ones(10000, split=0)
+    b = ht.zeros(10000, split=0)
+    c = a[:-1] + b[1:]
+    ```
+    In such cases, one of the operands is redistributed IN PLACE to match the distribution map of the other operand.
     """
     promoted_type = types.result_type(t1, t2).torch_type()
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -753,7 +753,6 @@ class DNDarray:
             key = kst + slices + kend
 
         self_proxy = self.__torch_proxy__()
-
         # None and newaxis indexing
         for i in range(len(key))[::-1]:
             if self.___key_adds_dimension(key, i, self_proxy):
@@ -761,6 +760,7 @@ class DNDarray:
                 key[i] = slice(None)
 
         key = tuple(key)
+        self_proxy = self.__torch_proxy__()
         # assess final global shape
         gout_full = list(self_proxy[key].shape)
 
@@ -970,7 +970,7 @@ class DNDarray:
 
     @staticmethod
     def ___key_adds_dimension(key: any, axis: int, self_proxy: torch.Tensor) -> bool:
-        # determine if the key gets a singular item
+        # determine if the key adds a new dimension
         zeros = tuple([0] * (self_proxy.ndim - 1))
         return self_proxy[(*zeros[:axis], key[axis], *zeros[axis:])].ndim == 2
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -962,13 +962,13 @@ class DNDarray:
     @staticmethod
     def __is_key_singular(key: any, axis: int, self_proxy: torch.Tensor) -> bool:
         # determine if the key gets a singular item
-        zeros = tuple([0] * (self_proxy.ndim - 1))
+        zeros = (0,) * (self_proxy.ndim - 1)
         return self_proxy[(*zeros[:axis], key[axis], *zeros[axis:])].ndim == 0
 
     @staticmethod
     def __key_adds_dimension(key: any, axis: int, self_proxy: torch.Tensor) -> bool:
         # determine if the key adds a new dimension
-        zeros = tuple([0] * (self_proxy.ndim - 1))
+        zeros = (0,) * (self_proxy.ndim - 1)
         return self_proxy[(*zeros[:axis], key[axis], *zeros[axis:])].ndim == 2
 
     def item(self):

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -709,7 +709,7 @@ class DNDarray:
             """ this loop handles all other cases. DNDarrays which make it to here refer to
                 advanced indexing slices, as do the torch tensors. Both DNDaarrys and torch.Tensors
                 are cast into lists here by PyTorch. lists mean advanced indexing will be used"""
-            h = [slice(None, None, None)] * self.ndim
+            h = [slice(None, None, None)] * max(self.ndim, 1)
             if isinstance(key, DNDarray):
                 key = manipulations.resplit(key)
                 if key.larray.dtype in [torch.bool, torch.uint8]:
@@ -755,21 +755,12 @@ class DNDarray:
             key = key + [slice(None)] * (self.ndim - len(key))
 
         self_proxy = self.__torch_proxy__()
-        # None and newaxis indexing
-        # expand = []
         for i in range(len(key)):
             if self.__key_adds_dimension(key, i, self_proxy):
-                # self = self.expand_dims(i)
                 key[i] = slice(None)
-                # expand.append(i - len(expand))
                 return self.expand_dims(i)[tuple(key)]
-        # for dim in expand:
-        #     self = self.expand_dims(dim)
-        # if len(expand):
-        #     return self[tuple(key)]
 
         key = tuple(key)
-        self_proxy = self.__torch_proxy__()
         # assess final global shape
         gout_full = list(self_proxy[key].shape)
 

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 import warnings
 
-from typing import List, Callable, Union, Optional, Tuple, Literal
+from typing import List, Callable, Union, Optional, Tuple
 
 from torch._C import Value
 
@@ -780,7 +780,7 @@ def matrix_norm(
     x: DNDarray,
     axis: Optional[Tuple[int, int]] = None,
     keepdims: bool = False,
-    ord: Optional[Union[int, Literal["fro", "nuc"]]] = None,
+    ord: Optional[Union[int, str]] = None,
 ) -> DNDarray:
     """
     Computes the matrix norm of an array.
@@ -908,7 +908,7 @@ def norm(
     x: DNDarray,
     axis: Optional[Union[int, Tuple[int, int]]] = None,
     keepdims: bool = False,
-    ord: Optional[Union[int, float, Literal["fro", "nuc"]]] = None,
+    ord: Optional[Union[int, float, str]] = None,
 ) -> DNDarray:
     """
     Return the vector or matrix norm of an array.

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -2955,8 +2955,9 @@ def stack(
 
     target = arrays[0]
     try:
-        # arrays[1:] = sanitation.sanitize_distribution(*arrays[1:], target=target) # error in unpacking
-        arrays = sanitation.sanitize_distribution(*arrays, target=target)
+        arrays = sanitation.sanitize_distribution(
+            *arrays, target=target
+        )  # also checks target again
     except NotImplementedError as e:  # transform split axis error to ValueError
         raise ValueError(e)
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -2891,7 +2891,7 @@ def stack(
     ValueError
         If the `DNDarray`s are of different shapes, or if they are split along different axes (`split` attribute).
     RuntimeError
-        If the `DNDarrays` reside of different devices, or if they are unevenly distributed across ranks (method `is_balanced()` returns `False`)
+        If the `DNDarrays` reside of different devices.
 
     Notes
     -----
@@ -2949,83 +2949,51 @@ def stack(
     [2/2]          [18, 38],
     [2/2]          [19, 39]]])
     """
-    # sanitation
-    sanitation.sanitize_sequence(arrays)
-
+    arrays = sanitation.sanitize_sequence(arrays)
     if len(arrays) < 2:
         raise ValueError("stack expects a sequence of at least 2 DNDarrays")
 
-    for i, array in enumerate(arrays):
-        sanitation.sanitize_in(array)
+    target = arrays[0]
+    try:
+        # arrays[1:] = sanitation.sanitize_distribution(*arrays[1:], target=target) # error in unpacking
+        arrays = sanitation.sanitize_distribution(*arrays, target=target)
+    except NotImplementedError as e:  # transform split axis error to ValueError
+        raise ValueError(e)
 
-    arrays_metadata = list(
-        [array.gshape, array.split, array.device, array.balanced] for array in arrays
-    )
-    num_arrays = len(arrays)
-    # metadata must be identical for all arrays
-    if arrays_metadata.count(arrays_metadata[0]) != num_arrays:
-        shapes = list(array.gshape for array in arrays)
-        if shapes.count(shapes[0]) != num_arrays:
-            raise ValueError(
-                "All DNDarrays in sequence must have the same shape, got shapes {}".format(shapes)
-            )
-        splits = list(array.split for array in arrays)
-        if splits.count(splits[0]) != num_arrays:
-            raise ValueError(
-                "All DNDarrays in sequence must have the same split axis, got splits {}"
-                "Check out the heat.resplit() documentation.".format(splits)
-            )
-        devices = list(array.device for array in arrays)
-        if devices.count(devices[0]) != num_arrays:
-            raise RuntimeError(
-                "DNDarrays in sequence must reside on the same device, got devices {} {} {}".format(
-                    devices, devices[0].device_id, devices[1].device_id
-                )
-            )
-    else:
-        array_shape, array_split, array_device, array_balanced = arrays_metadata[0][:4]
-        # extract torch tensors
-        t_arrays = list(array.larray for array in arrays)
-        # output dtype
-        t_dtypes = list(t_array.dtype for t_array in t_arrays)
-        t_array_dtype = t_dtypes[0]
-        if t_dtypes.count(t_dtypes[0]) != num_arrays:
-            for d in range(1, len(t_dtypes)):
-                t_array_dtype = (
-                    t_array_dtype
-                    if t_array_dtype is t_dtypes[d]
-                    else torch.promote_types(t_array_dtype, t_dtypes[d])
-                )
-            t_arrays = list(t_array.type(t_array_dtype) for t_array in t_arrays)
-        array_dtype = types.canonical_heat_type(t_array_dtype)
-
-    # sanitize axis
-    axis = stride_tricks.sanitize_axis(array_shape + (num_arrays,), axis)
+    # extract torch tensors
+    t_arrays = list(array.larray for array in arrays)
 
     # output shape and split
-    stacked_shape = array_shape[:axis] + (num_arrays,) + array_shape[axis:]
-    if array_split is not None:
-        stacked_split = array_split + 1 if axis <= array_split else array_split
+    axis = stride_tricks.sanitize_axis(target.gshape + (len(arrays),), axis)
+    stacked_shape = target.gshape[:axis] + (len(arrays),) + target.gshape[axis:]
+    if target.split is not None:
+        stacked_split = target.split + 1 if axis <= target.split else target.split
     else:
         stacked_split = None
 
     # stack locally
-    t_stacked = torch.stack(t_arrays, dim=axis)
+    try:
+        t_stacked = torch.stack(t_arrays, dim=axis)
+        result_dtype = types.canonical_heat_type(t_stacked.dtype)
+    except Exception as e:
+        if "size" in e.args[0] or "shape" in e.args[0]:
+            raise ValueError(e)
+        raise e
 
     # return stacked DNDarrays
     if out is not None:
-        sanitation.sanitize_out(out, stacked_shape, stacked_split, array_device)
+        sanitation.sanitize_out(out, stacked_shape, stacked_split, target.device)
         out.larray = t_stacked.type(out.larray.dtype)
         return out
 
     stacked = DNDarray(
         t_stacked,
         gshape=stacked_shape,
-        dtype=array_dtype,
+        dtype=result_dtype,
         split=stacked_split,
-        device=array_device,
-        comm=arrays[0].comm,
-        balanced=array_balanced,
+        device=target.device,
+        comm=target.comm,
+        balanced=target.balanced,
     )
     return stacked
 

--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -101,15 +101,6 @@ def equal(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> boo
     >>> ht.equal(x, 3.0)
     False
     """
-    # result_tensor = _operations.__binary_op(torch.equal, x, y)
-    #
-    # if result_tensor.larray.numel() == 1:
-    #     result_value = result_tensor.larray.item()
-    # else:
-    #     result_value = True
-    #
-    # return result_tensor.comm.allreduce(result_value, MPI.LAND)
-
     if np.isscalar(x) and np.isscalar(y):
         x = factories.array(x)
         y = factories.array(y)

--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -136,7 +136,7 @@ def equal(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> boo
         if x.split is None and y.split is None:
             pass
         elif x.split is None and y.split is not None:
-            if y.is_balanced():
+            if y.is_balanced(force_check=True):
                 x = factories.array(x, split=y.split, copy=False, comm=x.comm, device=x.device)
             else:
                 target_map = y.lshape_map
@@ -149,7 +149,7 @@ def equal(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> boo
                     x.larray[tuple(idx)], is_split=y.split, copy=False, comm=x.comm, device=x.device
                 )
         elif x.split is not None and y.split is None:
-            if x.is_balanced():
+            if x.is_balanced(force_check=True):
                 y = factories.array(y, split=x.split, copy=False, comm=y.comm, device=y.device)
             else:
                 target_map = x.lshape_map
@@ -165,7 +165,7 @@ def equal(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> boo
             raise ValueError(
                 "DNDarrays must have the same split axes, found {} and {}".format(x.split, y.split)
             )
-        elif not (x.is_balanced() and y.is_balanced()):
+        elif not (x.is_balanced(force_check=True) and y.is_balanced(force_check=True)):
             x_lmap = x.lshape_map
             y_lmap = y.lshape_map
             if not torch.equal(x_lmap, y_lmap):

--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -136,7 +136,7 @@ def equal(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> boo
         if x.split is None and y.split is None:
             pass
         elif x.split is None and y.split is not None:
-            if y.is_balanced(force_check=True):
+            if y.is_balanced(force_check=False):
                 x = factories.array(x, split=y.split, copy=False, comm=x.comm, device=x.device)
             else:
                 target_map = y.lshape_map
@@ -149,7 +149,7 @@ def equal(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> boo
                     x.larray[tuple(idx)], is_split=y.split, copy=False, comm=x.comm, device=x.device
                 )
         elif x.split is not None and y.split is None:
-            if x.is_balanced(force_check=True):
+            if x.is_balanced(force_check=False):
                 y = factories.array(y, split=x.split, copy=False, comm=y.comm, device=y.device)
             else:
                 target_map = x.lshape_map
@@ -165,7 +165,7 @@ def equal(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> boo
             raise ValueError(
                 "DNDarrays must have the same split axes, found {} and {}".format(x.split, y.split)
             )
-        elif not (x.is_balanced(force_check=True) and y.is_balanced(force_check=True)):
+        elif not (x.is_balanced(force_check=False) and y.is_balanced(force_check=False)):
             x_lmap = x.lshape_map
             y_lmap = y.lshape_map
             if not torch.equal(x_lmap, y_lmap):

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -76,7 +76,7 @@ def sanitize_distribution(
     elif target_split is not None:
         target_map = target.lshape_map
         target_size = target.shape[target_split]
-        target_balanced = target.is_balanced(force_check=True)
+        target_balanced = target.is_balanced(force_check=False)
 
     for arg in args:
         sanitize_in(arg)
@@ -137,7 +137,7 @@ def sanitize_distribution(
         elif not (
             # False
             target_balanced
-            and arg.is_balanced(force_check=True)
+            and arg.is_balanced(force_check=False)
         ):  # Split axes are the same and atleast one is not balanced
             current_map = arg.lshape_map
             out_map = current_map.clone()

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -114,7 +114,9 @@ def sanitize_distribution(*args: DNDarray, target: DNDarray):
                     target_split, arg.split
                 )
             )
-        else:  # Split axes are the same
+        elif not (
+            target.is_balanced() and arg.is_balanced()
+        ):  # Split axes are the same and atleast one is not balanced
             current_map = arg.lshape_map
             out_map = current_map.clone()
             out_map[:, target_split] = target_map[:, target_split]
@@ -122,6 +124,8 @@ def sanitize_distribution(*args: DNDarray, target: DNDarray):
                 out.append(arg.redistribute(lshape_map=current_map, target_map=out_map))
             else:
                 out.append(arg)
+        else:  # both are balanced
+            out.append(arg)
     if len(out) == 1:
         return out[0]
     return tuple(out)

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -32,9 +32,9 @@ def sanitize_distribution(
     *args: DNDarray, target: DNDarray, diff_map: torch.Tensor = None
 ) -> Union[DNDarray, Tuple(DNDarray)]:
     """
-    Distribute every arg according to target.lshape_map or, if provided, diff_map.
+    Distribute every `arg` according to `target.lshape_map` or, if provided, `diff_map`.
     After this sanitation, the lshapes are compatible along the split dimension.
-    Args can contain non-distributed DNDarrays, they will be split afterwards.
+    `Args` can contain non-distributed DNDarrays, they will be split afterwards, if `target` is split.
 
     Parameters
     ----------

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -311,13 +311,13 @@ def sanitize_out(
     count_split = int(out.split is not None) + int(output_split is not None)
     if count_split == 1:
         raise ValueError(
-            "Split axis of output buffer is inconsistent with split semantics (see documentation)."
+            "Split axis of output buffer is inconsistent with split semantics for this operation."
         )
     elif count_split == 2:
         if out.shape[out.split] > 1:  # split axis is not squeezed out
             if out_proxy.names.index("split") != check_proxy.names.index("split"):
                 raise ValueError(
-                    "Split axis of output buffer is inconsistent with split semantics (see documentation)."
+                    "Split axis of output buffer is inconsistent with split semantics for this operation."
                 )
         else:  # split axis is squeezed out
             num_dim_before_split = len(
@@ -328,7 +328,7 @@ def sanitize_out(
             )
             if num_dim_before_split != check_num_dim_before_split:
                 raise ValueError(
-                    "Split axis of output buffer is inconsistent with split semantics (see documentation)."
+                    "Split axis of output buffer is inconsistent with split semantics for this operation."
                 )
     if out.device is not output_device:
         raise ValueError(

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -266,14 +266,14 @@ def sanitize_out(
 
     out_proxy = out.__torch_proxy__()
     out_proxy.names = [
-        "_{}".format(i) if (out.split is not None and i != out.split) else "split"
+        "split" if (out.split is not None and i == out.split) else "_{}".format(i)
         for i in range(out_proxy.ndim)
     ]
     out_proxy = out_proxy.squeeze()
 
     check_proxy = torch.ones(1).expand(output_shape)
     check_proxy.names = [
-        "_{}".format(i) if (output_split is not None and i != output_split) else "split"
+        "split" if (output_split is not None and i == output_split) else "_{}".format(i)
         for i in range(check_proxy.ndim)
     ]
     check_proxy = check_proxy.squeeze()

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -42,7 +42,7 @@ def sanitize_distribution(
         Dndarrays to be distributed
 
     target : DNDarray
-        Dndarrays determining the distribution
+        Dndarray used to sanitize the metadata and to, if diff_map is not given, determine the resulting distribution.
 
     diff_map : torch.Tensor (optional)
         Different lshape_map. Overwrites the distribution of the target array.
@@ -65,7 +65,7 @@ def sanitize_distribution(
         sanitize_in_tensor(diff_map)
         target_map = diff_map
         target_size = target_map[:, target_split].sum().item()
-    else:
+    elif target_split is not None:
         target_map = target.lshape_map
         target_size = target.shape[target_split]
 

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -17,6 +17,7 @@ from . import types
 
 
 __all__ = [
+    "sanitize_distribution",
     "sanitize_in",
     "sanitize_infinity",
     "sanitize_in_tensor",
@@ -27,7 +28,7 @@ __all__ = [
 ]
 
 
-def sanitize_distribution(*args: DNDarray, target: DNDarray):
+def sanitize_distribution(*args: DNDarray, target: DNDarray) -> Union[DNDarray, Tuple(DNDarray)]:
     """
     Make every arg have the same distribution (along split-axis) as the target,
     such that after this sanitation, the lshapes are compatible wrt split-dimension.

--- a/heat/core/sanitation.py
+++ b/heat/core/sanitation.py
@@ -109,7 +109,7 @@ def sanitize_distribution(*args: DNDarray, target: DNDarray):
                     )
                 )
         elif arg.split != target_split:
-            raise ValueError(
+            raise NotImplementedError(
                 "DNDarrays must have the same split axes, found {} and {}".format(
                     target_split, arg.split
                 )

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -11,7 +11,8 @@ from typing import Tuple, Union
 
 def broadcast_shape(shape_a: Tuple[int, ...], shape_b: Tuple[int, ...]) -> Tuple[int, ...]:
     """
-    Infers, if possible, the broadcast output shape of two operands a and b.
+    Infers, if possible, the broadcast output shape of two operands a and b. Inspired by stackoverflow post:
+    https://stackoverflow.com/questions/24743753/test-if-an-array-is-broadcastable-to-a-shape
 
     Parameters
     ----------
@@ -41,7 +42,20 @@ def broadcast_shape(shape_a: Tuple[int, ...], shape_b: Tuple[int, ...]) -> Tuple
         "operands could not be broadcast, input shapes {} {}".format(shape_a, shape_b)
     ValueError: operands could not be broadcast, input shapes (2, 1) (8, 4, 3)
     """
-    return tuple(torch.broadcast_shapes(shape_a, shape_b))
+    return np.broadcast_shapes(shape_a, shape_b)
+    it = itertools.zip_longest(shape_a[::-1], shape_b[::-1], fillvalue=1)
+    resulting_shape = max(len(shape_a), len(shape_b)) * [None]
+    for i, (a, b) in enumerate(it):
+        if a == 0 or b == 0:
+            resulting_shape[i] = 0
+        elif a == 1 or b == 1 or a == b:
+            resulting_shape[i] = max(a, b)
+        else:
+            raise ValueError(
+                "operands could not be broadcast, input shapes {} {}".format(shape_a, shape_b)
+            )
+
+    return tuple(resulting_shape[::-1])
 
 
 def sanitize_axis(

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -4,14 +4,14 @@ A collection of functions used for inferring or correction things before major c
 
 import itertools
 import numpy as np
+import torch
 
 from typing import Tuple, Union
 
 
 def broadcast_shape(shape_a: Tuple[int, ...], shape_b: Tuple[int, ...]) -> Tuple[int, ...]:
     """
-    Infers, if possible, the broadcast output shape of two operands a and b. Inspired by stackoverflow post:
-    https://stackoverflow.com/questions/24743753/test-if-an-array-is-broadcastable-to-a-shape
+    Infers, if possible, the broadcast output shape of two operands a and b.
 
     Parameters
     ----------
@@ -41,17 +41,7 @@ def broadcast_shape(shape_a: Tuple[int, ...], shape_b: Tuple[int, ...]) -> Tuple
         "operands could not be broadcast, input shapes {} {}".format(shape_a, shape_b)
     ValueError: operands could not be broadcast, input shapes (2, 1) (8, 4, 3)
     """
-    it = itertools.zip_longest(shape_a[::-1], shape_b[::-1], fillvalue=1)
-    resulting_shape = max(len(shape_a), len(shape_b)) * [None]
-    for i, (a, b) in enumerate(it):
-        if a == 1 or b == 1 or a == b:
-            resulting_shape[i] = max(a, b)
-        else:
-            raise ValueError(
-                "operands could not be broadcast, input shapes {} {}".format(shape_a, shape_b)
-            )
-
-    return tuple(resulting_shape[::-1])
+    return tuple(torch.broadcast_shapes(shape_a, shape_b))
 
 
 def sanitize_axis(

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -53,6 +53,30 @@ class TestArithmetics(TestCase):
         self.assertTrue((c == 1).all())
         self.assertTrue(c.lshape == a[:-1].lshape)
 
+        c = a[1:-1] + b[1:-1]  # test unbalanced
+        self.assertTrue((c == 1).all())
+        self.assertTrue(c.lshape == a[1:-1].lshape)
+
+        # test one unsplit
+        a = ht.ones(10, split=None)
+        b = ht.zeros(10, split=0)
+        c = a[:-1] + b[1:]
+        self.assertTrue((c == 1).all())
+        self.assertEqual(c.lshape, b[1:].lshape)
+        c = b[:-1] + a[1:]
+        self.assertTrue((c == 1).all())
+        self.assertEqual(c.lshape, b[:-1].lshape)
+
+        # broadcast in split dimension
+        a = ht.ones((1, 10), split=0)
+        b = ht.zeros((2, 10), split=0)
+        c = a + b
+        self.assertTrue((c == 1).all())
+        self.assertTrue(c.lshape == b.lshape)
+        c = b + a
+        self.assertTrue((c == 1).all())
+        self.assertTrue(c.lshape == b.lshape)
+
         with self.assertRaises(ValueError):
             ht.add(self.a_tensor, self.another_vector)
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -246,16 +246,17 @@ class TestArithmetics(TestCase):
     def test_diff(self):
         ht_array = ht.random.rand(20, 20, 20, split=None)
         arb_slice = [0] * 3
-        for dim in range(0, 3):  # loop over 3 dimensions
+        for dim in range(3):  # loop over 3 dimensions
             arb_slice[dim] = slice(None)
-            tup_arb = tuple(arb_slice)
-            np_array = ht_array[tup_arb].numpy()
             for ax in range(dim + 1):  # loop over the possible axis values
                 for sp in range(dim + 1):  # loop over the possible split values
-                    lp_array = ht.manipulations.resplit(ht_array[tup_arb], sp)
                     # loop to 3 for the number of times to do the diff
                     for nl in range(1, 4):
                         # only generating the number once and then
+                        tup_arb = tuple(arb_slice)
+                        lp_array = ht.manipulations.resplit(ht_array[tup_arb], sp)
+                        np_array = ht_array[tup_arb].numpy()
+
                         ht_diff = ht.diff(lp_array, n=nl, axis=ax)
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
 
@@ -268,11 +269,10 @@ class TestArithmetics(TestCase):
                         ht_append = ht.ones(
                             append_shape, dtype=lp_array.dtype, split=lp_array.split
                         )
-
                         ht_diff_pend = ht.diff(lp_array, n=nl, axis=ax, prepend=0, append=ht_append)
-                        np_append = np.ones(append_shape, dtype=lp_array.larray.numpy().dtype)
                         np_diff_pend = ht.array(
-                            np.diff(np_array, n=nl, axis=ax, prepend=0, append=np_append)
+                            np.diff(np_array, n=nl, axis=ax, prepend=0, append=ht_append.numpy()),
+                            dtype=ht_diff_pend.dtype,
                         )
                         self.assertTrue(ht.equal(ht_diff_pend, np_diff_pend))
                         self.assertEqual(ht_diff_pend.split, sp)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -246,17 +246,16 @@ class TestArithmetics(TestCase):
     def test_diff(self):
         ht_array = ht.random.rand(20, 20, 20, split=None)
         arb_slice = [0] * 3
-        for dim in range(3):  # loop over 3 dimensions
+        for dim in range(0, 3):  # loop over 3 dimensions
             arb_slice[dim] = slice(None)
+            tup_arb = tuple(arb_slice)
+            np_array = ht_array[tup_arb].numpy()
             for ax in range(dim + 1):  # loop over the possible axis values
                 for sp in range(dim + 1):  # loop over the possible split values
+                    lp_array = ht.manipulations.resplit(ht_array[tup_arb], sp)
                     # loop to 3 for the number of times to do the diff
                     for nl in range(1, 4):
                         # only generating the number once and then
-                        tup_arb = tuple(arb_slice)
-                        lp_array = ht.manipulations.resplit(ht_array[tup_arb], sp)
-                        np_array = ht_array[tup_arb].numpy()
-
                         ht_diff = ht.diff(lp_array, n=nl, axis=ax)
                         np_diff = ht.array(np.diff(np_array, n=nl, axis=ax))
 
@@ -269,10 +268,11 @@ class TestArithmetics(TestCase):
                         ht_append = ht.ones(
                             append_shape, dtype=lp_array.dtype, split=lp_array.split
                         )
+
                         ht_diff_pend = ht.diff(lp_array, n=nl, axis=ax, prepend=0, append=ht_append)
+                        np_append = np.ones(append_shape, dtype=lp_array.larray.numpy().dtype)
                         np_diff_pend = ht.array(
-                            np.diff(np_array, n=nl, axis=ax, prepend=0, append=ht_append.numpy()),
-                            dtype=ht_diff_pend.dtype,
+                            np.diff(np_array, n=nl, axis=ax, prepend=0, append=np_append)
                         )
                         self.assertTrue(ht.equal(ht_diff_pend, np_diff_pend))
                         self.assertEqual(ht_diff_pend.split, sp)

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -45,6 +45,13 @@ class TestArithmetics(TestCase):
             else:
                 self.assertEqual(c.larray.size()[0], 0)
 
+        # test with differently distributed DNDarrays
+        a = ht.ones(10, split=0)
+        b = ht.zeros(10, split=0)
+        c = a[:-1] + b[1:]
+        self.assertTrue((c == 1).all())
+        self.assertTrue(c.lshape == a[:-1].lshape)
+
         with self.assertRaises(ValueError):
             ht.add(self.a_tensor, self.another_vector)
         with self.assertRaises(TypeError):

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -1413,6 +1413,19 @@ class TestDNDarray(TestCase):
                 setting = ht.zeros((8, 8), split=1)
                 x[1:-1, 1:-1] = setting
 
+        for split in [None, 0, 1, 2]:
+            for new_dim in [0, 1, 2]:
+                for add in [np.newaxis, None]:
+                    arr = ht.ones((4, 3, 2), split=split, dtype=ht.int32)
+                    check = torch.ones((4, 3, 2), dtype=torch.int32)
+                    idx = [slice(None), slice(None), slice(None)]
+                    idx[new_dim] = add
+                    idx = tuple(idx)
+                    arr = arr[idx]
+                    check = check[idx]
+                    self.assertTrue(arr.shape == check.shape)
+                    self.assertTrue(arr.lshape[new_dim] == 1)
+
     def test_size_gnumel(self):
         a = ht.zeros((10, 10, 10), split=None)
         self.assertEqual(a.size, 10 * 10 * 10)

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -3245,7 +3245,7 @@ class TestManipulations(TestCase):
         with self.assertRaises(ValueError):
             ht.stack((ht_a_split, ht_b_wrong_split, ht_c_split))
         with self.assertRaises(ValueError):
-            ht.stack((ht_a_split, ht_b, ht_c_split))
+            ht.stack((ht_a_split, ht_b.resplit(1), ht_c_split))
         out_wrong_type = torch.empty((3, 5, 4), dtype=torch.float32)
         with self.assertRaises(TypeError):
             ht.stack((ht_a_split, ht_b_split, ht_c_split), out=out_wrong_type)

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -77,3 +77,14 @@ class TestOperations(TestCase):
             ht.bitwise_or(
                 ht.ones((1, 2), dtype=ht.int32, split=0), ht.ones((1, 2), dtype=ht.int32, split=1)
             )
+
+        a = ht.ones((4, 4), split=None)
+        b = ht.zeros((4, 4), split=0)
+        self.assertTrue(ht.equal(a * b, b))
+        self.assertTrue(ht.equal(b * a, b))
+        self.assertTrue(ht.equal(a[0] * b[0], b[0]))
+        self.assertTrue(ht.equal(b[0] * a[0], b[0]))
+        self.assertTrue(ht.equal(a * b[0:1], b))
+        self.assertTrue(ht.equal(b[0:1] * a, b))
+        self.assertTrue(ht.equal(a[0:1] * b, b))
+        self.assertTrue(ht.equal(b * a[0:1], b))

--- a/heat/core/tests/test_operations.py
+++ b/heat/core/tests/test_operations.py
@@ -64,7 +64,7 @@ class TestOperations(TestCase):
         self.assertEqual(result.shape, (1, 2))
 
         # broadcast with unequal dimensions and two splitted tensors
-        left_tensor = ht.ones((4, 1, 3, 1, 2), split=0, dtype=torch.uint8)
+        left_tensor = ht.ones((4, 1, 3, 1, 2), split=2, dtype=torch.uint8)
         right_tensor = ht.ones((1, 3, 1), split=0, dtype=torch.uint8)
         result = left_tensor & right_tensor
         self.assertEqual(result.shape, (4, 1, 3, 3, 2))

--- a/heat/core/tests/test_relational.py
+++ b/heat/core/tests/test_relational.py
@@ -43,7 +43,13 @@ class TestRelational(TestCase):
         self.assertTrue(ht.equal(self.a_tensor, self.a_tensor))
         self.assertFalse(ht.equal(self.a_tensor, self.another_tensor))
         self.assertFalse(ht.equal(self.a_tensor, self.a_scalar))
+        self.assertFalse(ht.equal(self.a_scalar, self.a_tensor))
+        self.assertFalse(ht.equal(self.a_scalar, self.a_tensor[0, 0]))
+        self.assertFalse(ht.equal(self.a_tensor[0, 0], self.a_scalar))
         self.assertFalse(ht.equal(self.another_tensor, self.a_scalar))
+        self.assertTrue(ht.equal(self.split_ones_tensor[:, 0], self.split_ones_tensor[:, 1]))
+        self.assertFalse(ht.equal(self.a_tensor, self.a_split_tensor))
+        self.assertFalse(ht.equal(self.a_split_tensor, self.a_tensor))
 
     def test_ge(self):
         result = ht.uint8([[False, True], [True, True]])

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -1053,7 +1053,7 @@ class TestStatistics(TestCase):
         with self.assertRaises(TypeError):
             ht.minimum(random_volume_1, random_volume_3)
         random_volume_3 = np.array(7.2)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             ht.minimum(random_volume_3, random_volume_1)
         random_volume_3 = ht.random.randn(6, 3, 3, split=1)
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
## Description

Issue/s resolved: #880

## Changes proposed:
- Add `None` / `newaxis` indexing to `getitem`
- Fix the `ht.equal` Method. Previously it used the `binop` interface, which was wrong because it isn't a `binop`
- Make the `stack` function compatible to not balanced arrays
- 
- check lshape-map before binop instead of after try...except because not all processes necessarily fail so synchronization is necessary anyway
- redistribute OUT-OF-PLACE - binops should not alter their arguments
- add support for unbalanced array when the other one is not split
- check arrays for having the same split axis AFTER (shape)broadcasting added empty dimensions (?)
- restructure input sanitation; reduce nested ifs

## Type of change
- New feature (breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
--->


## Performance
Checks lshape-maps inside every binop between distributed dndarrays -> more communication
Redistributes out-of-place -> more memory

If the dndarrays are balanced (i.e. the features of this PR are not used) the introduced overhead is small.
Binops between two balanced dndarrays of shape `(30,100,100)` with 24 MPI-processes spend >90% of the runtime in the respective torch functions:
```
         53713 function calls (53203 primitive calls) in 1.866 seconds

   Ordered by: internal time
   List reduced from 51 to 30 due to restriction <30>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      100    0.378    0.004    0.378    0.004 {built-in method mul}
      100    0.375    0.004    0.375    0.004 {built-in method add}
      100    0.375    0.004    0.375    0.004 {built-in method true_divide}
      100    0.370    0.004    0.370    0.004 {built-in method sub}
      100    0.286    0.003    0.286    0.003 {built-in method eq}
      500    0.017    0.000    1.858    0.004 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/_operations.py:24(__binary_op)
      500    0.008    0.000    0.008    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/dndarray.py:63(__init__)
      500    0.007    0.000    0.009    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/stride_tricks.py:12(broadcast_shape)
      500    0.006    0.000    0.009    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/sanitation.py:31(sanitize_distribution)
 1000/500    0.005    0.000    0.007    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/types.py:889(result_type_rec)
     2500    0.005    0.000    0.010    0.000 /p/software/juwels/stages/2020/software/SciPy-Stack/2020-gcccoremkl-9.3.0-2020.2.254-Python-3.8.5/lib/python3.8/site-packages/numpy-1.19.1-py3.8-linux-x86_64.egg/numpy/core/numeric.py:1816(isscalar)
      100    0.004    0.000    1.866    0.019 profile-binop.py:10(test_function)
     8500    0.003    0.000    0.005    0.000 {built-in method builtins.isinstance}
     1500    0.003    0.000    0.004    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/types.py:495(canonical_heat_type)
     1000    0.002    0.000    0.002    0.000 {method 'type' of 'torch._C._TensorBase' objects}
      500    0.002    0.000    0.012    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/_operations.py:114(__get_out_params)
      500    0.002    0.000    0.005    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/types.py:565(heat_type_of)
     2500    0.001    0.000    0.001    0.000 {built-in method _abc._abc_instancecheck}
     1500    0.001    0.000    0.001    0.000 {built-in method builtins.issubclass}
     2000    0.001    0.000    0.001    0.000 {built-in method builtins.max}
     1000    0.001    0.000    0.001    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/dndarray.py:941(is_balanced)
      500    0.001    0.000    0.008    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/types.py:868(result_type)
     2500    0.001    0.000    0.002    0.000 /p/software/juwels/stages/2020/software/Python/3.8.5-GCCcore-9.3.0/lib/python3.8/abc.py:96(__instancecheck__)
      100    0.001    0.000    0.301    0.003 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/relational.py:35(eq)
     5000    0.001    0.000    0.001    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/dndarray.py:293(shape)
      500    0.001    0.000    0.001    0.000 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/dndarray.py:279(lshape_map)
     5500    0.001    0.000    0.001    0.000 {built-in method builtins.len}
      100    0.001    0.000    0.385    0.004 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/arithmetics.py:904(sub)
      100    0.001    0.000    0.390    0.004 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/arithmetics.py:63(add)
      100    0.001    0.000    0.390    0.004 /p/project/cslts/local/juwels/HeAT/binop_Branch/lib/python3.8/site-packages/heat/core/arithmetics.py:430(div)
```


## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
yes, every function using binops,

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->

