### PR TITLE
Examples/fix knn

### DIFF
--- a/examples/classification/demo_knn.py
+++ b/examples/classification/demo_knn.py
@@ -138,7 +138,8 @@ def verify_algorithm(x, y, split_number, split_size, k, seed=None):
 
     for split_index in range(split_number):
         fold_x, fold_y, verification_x, verification_y = create_fold(x, y, split_size, seed)
-        classifier = KNeighborsClassifier(fold_x, fold_y, k)
+        classifier = KNeighborsClassifier(k)
+        classifier.fit(fold_x, fold_y)
         result_y = classifier.predict(verification_x)
         accuracies.append(calculate_accuracy(result_y, verification_y).item())
     return accuracies

--- a/examples/classification/demo_knn.py
+++ b/examples/classification/demo_knn.py
@@ -95,10 +95,10 @@ def create_fold(dataset_x, dataset_y, size, seed=None):
     data_indices = ht.array(indices[0:size], split=0)
     verification_indices = ht.array(indices[size:], split=0)
 
-    fold_x = ht.array(dataset_x[data_indices], is_split=0)
-    fold_y = ht.array(dataset_y[data_indices], is_split=0)
-    verification_y = ht.array(dataset_y[verification_indices], is_split=0)
-    verification_x = ht.array(dataset_x[verification_indices], is_split=0)
+    fold_x = dataset_x[data_indices]
+    fold_y = dataset_y[data_indices]
+    verification_y = dataset_y[verification_indices]
+    verification_x = dataset_x[verification_indices]
 
     # Balance arrays
     fold_x.balance_()

--- a/examples/classification/demo_knn.py
+++ b/examples/classification/demo_knn.py
@@ -145,4 +145,4 @@ def verify_algorithm(x, y, split_number, split_size, k, seed=None):
     return accuracies
 
 
-print(verify_algorithm(X, Y, 1, 30, 5, 1))
+print("Accuracy: {}".format(verify_algorithm(X, Y, 1, 30, 5, 1)))


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

The [knn demo](https://github.com/helmholtz-analytics/heat/blob/master/examples/classification/demo_knn.py) stopped working at some unspecified time.

Here's  a version that runs. However, it returns a different accuracy depending on the number of MPI processes I run it on: 

```
(heat-dev3.8) Claudias-MBP:heat c.comito$ mpirun --tag-output --use-hwthread-cpus -n 1 python demo_knn.py 
[1,0]<stdout>:Accuracy: [0.9333333373069763]
(heat-dev3.8) Claudias-MBP:heat c.comito$ mpirun --tag-output --use-hwthread-cpus -n 2 python demo_knn.py 
[1,0]<stdout>:Accuracy: [0.5333333611488342]
[1,1]<stdout>:Accuracy: [0.5333333611488342]
(heat-dev3.8) Claudias-MBP:heat c.comito$ mpirun --tag-output --use-hwthread-cpus -n 3 python demo_knn.py 
[1,1]<stdout>:Accuracy: [0.9833333492279053]
[1,0]<stdout>:Accuracy: [0.9833333492279053]
[1,2]<stdout>:Accuracy: [0.9833333492279053]
(heat-dev3.8) Claudias-MBP:heat c.comito$ mpirun --tag-output --use-hwthread-cpus -n 4 python demo_knn.py 
[1,0]<stdout>:Accuracy: [0.7666666507720947]
[1,1]<stdout>:Accuracy: [0.7666666507720947]
[1,2]<stdout>:Accuracy: [0.7666666507720947]
[1,3]<stdout>:Accuracy: [0.7666666507720947]
```

~~Help would be great @mtar @coquelin77 @Inzlinger ~~

EDIT Feb 8.: The unstable accuracy is due to a `getitem` call within `KNearestNeighbours.predict()`, where the indices are distributed and not ordered, see #914. Since it's not a specific `knn`  problem, this PR is ready for review.


Issue/s resolved: #

## Changes proposed:
- update demo script
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue)
- Documentation update
- 
## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measuremens can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
N.A. 
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only provile the performance on each process. Printing the results with many processes
my be illegible. It may be easiest to save the output of each to a file.
--->

N.A.
## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
