### PR TITLE
Debugging branch for #902

### DIFF
--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -103,9 +103,9 @@ def __binary_op(
     sanitation.sanitize_in(t2)
 
     # Make inputs have the same dimensionality
-    print("debugging: ON RANK ", t1.rank, " BEFORE BROADCAST_SHAPE")
+    print("debugging: ON RANK ", t1.comm.rank, " BEFORE BROADCAST_SHAPE")
     output_shape = stride_tricks.broadcast_shape(t1.shape, t2.shape)
-    print("debugging: ON RANK ", t1.rank, " AFTER BROADCAST_SHAPE")
+    print("debugging: ON RANK ", t1.comm.rank, " AFTER BROADCAST_SHAPE")
     # Broadcasting allows additional empty dimensions on the left side
     # TODO simplify this once newaxis-indexing is supported to get rid of the loops
     while len(t1.shape) < len(output_shape):

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -103,9 +103,9 @@ def __binary_op(
     sanitation.sanitize_in(t2)
 
     # Make inputs have the same dimensionality
-    print("debugging: ON RANK ", t1.comm.rank, " BEFORE BROADCAST_SHAPE")
+    print("debugging: ON RANK ", t1.comm.rank, " BEFORE BROADCAST_SHAPE", t1.shape, t2.shape)
     output_shape = stride_tricks.broadcast_shape(t1.shape, t2.shape)
-    print("debugging: ON RANK ", t1.comm.rank, " AFTER BROADCAST_SHAPE")
+    print("debugging: ON RANK ", t1.comm.rank, " AFTER BROADCAST_SHAPE", output_shape)
     # Broadcasting allows additional empty dimensions on the left side
     # TODO simplify this once newaxis-indexing is supported to get rid of the loops
     while len(t1.shape) < len(output_shape):

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -68,6 +68,7 @@ def __binary_op(
     2) no (shape)-broadcasting in the split dimension if not necessary
     3) t1 is preferred to t2
     """
+    print("DEBUGGING: type(t1), type(t2) = {}, {}".format(type(t1), type(t2)))
     # Check inputs
     if not np.isscalar(t1) and not isinstance(t1, DNDarray):
         raise TypeError(
@@ -102,7 +103,9 @@ def __binary_op(
     sanitation.sanitize_in(t2)
 
     # Make inputs have the same dimensionality
+    print("debugging: ON RANK ", t1.rank, " BEFORE BROADCAST_SHAPE")
     output_shape = stride_tricks.broadcast_shape(t1.shape, t2.shape)
+    print("debugging: ON RANK ", t1.rank, " AFTER BROADCAST_SHAPE")
     # Broadcasting allows additional empty dimensions on the left side
     # TODO simplify this once newaxis-indexing is supported to get rid of the loops
     while len(t1.shape) < len(output_shape):

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -68,7 +68,6 @@ def __binary_op(
     2) no (shape)-broadcasting in the split dimension if not necessary
     3) t1 is preferred to t2
     """
-    print("DEBUGGING: type(t1), type(t2) = {}, {}".format(type(t1), type(t2)))
     # Check inputs
     if not np.isscalar(t1) and not isinstance(t1, DNDarray):
         raise TypeError(
@@ -103,9 +102,7 @@ def __binary_op(
     sanitation.sanitize_in(t2)
 
     # Make inputs have the same dimensionality
-    print("debugging: ON RANK ", t1.comm.rank, " BEFORE BROADCAST_SHAPE", t1.shape, t2.shape)
     output_shape = stride_tricks.broadcast_shape(t1.shape, t2.shape)
-    print("debugging: ON RANK ", t1.comm.rank, " AFTER BROADCAST_SHAPE", output_shape)
     # Broadcasting allows additional empty dimensions on the left side
     # TODO simplify this once newaxis-indexing is supported to get rid of the loops
     while len(t1.shape) < len(output_shape):

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -48,7 +48,7 @@ def broadcast_shape(shape_a: Tuple[int, ...], shape_b: Tuple[int, ...]) -> Tuple
         it = itertools.zip_longest(shape_a[::-1], shape_b[::-1], fillvalue=1)
         resulting_shape = max(len(shape_a), len(shape_b)) * [None]
         for i, (a, b) in enumerate(it):
-            if a == 0 or b == 0:
+            if a == 0 and b == 1 or b == 0 and a == 1:
                 resulting_shape[i] = 0
             elif a == 1 or b == 1 or a == b:
                 resulting_shape[i] = max(a, b)

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -1,5 +1,5 @@
 """
-A collection of functions used for inferring or correction things before major computation
+A collection of functions used for inferring or correcting things before major computation
 """
 
 import itertools
@@ -42,20 +42,18 @@ def broadcast_shape(shape_a: Tuple[int, ...], shape_b: Tuple[int, ...]) -> Tuple
         "operands could not be broadcast, input shapes {} {}".format(shape_a, shape_b)
     ValueError: operands could not be broadcast, input shapes (2, 1) (8, 4, 3)
     """
-    return np.broadcast_shapes(shape_a, shape_b)
-    it = itertools.zip_longest(shape_a[::-1], shape_b[::-1], fillvalue=1)
-    resulting_shape = max(len(shape_a), len(shape_b)) * [None]
-    for i, (a, b) in enumerate(it):
-        if a == 0 or b == 0:
-            resulting_shape[i] = 0
-        elif a == 1 or b == 1 or a == b:
-            resulting_shape[i] = max(a, b)
-        else:
-            raise ValueError(
-                "operands could not be broadcast, input shapes {} {}".format(shape_a, shape_b)
-            )
+    try:
+        resulting_shape = torch.broadcast_shapes(shape_a, shape_b)
+    except TypeError:
+        raise TypeError("operand 1 must be tuple of ints, not {}".format(type(shape_a)))
+    except NameError:
+        raise TypeError("operands must be tuples of ints, not {} and {}".format(shape_a, shape_b))
+    except RuntimeError:
+        raise ValueError(
+            "operands could not be broadcast, input shapes {} {}".format(shape_a, shape_b)
+        )
 
-    return tuple(resulting_shape[::-1])
+    return tuple(resulting_shape)
 
 
 def sanitize_axis(

--- a/heat/core/tests/test_arithmetics.py
+++ b/heat/core/tests/test_arithmetics.py
@@ -313,7 +313,7 @@ class TestArithmetics(TestCase):
                         )
 
                         ht_diff_pend = ht.diff(lp_array, n=nl, axis=ax, prepend=0, append=ht_append)
-                        np_append = np.ones(append_shape, dtype=lp_array.larray.numpy().dtype)
+                        np_append = np.ones(append_shape, dtype=lp_array.larray.cpu().numpy().dtype)
                         np_diff_pend = ht.array(
                             np.diff(np_array, n=nl, axis=ax, prepend=0, append=np_append)
                         )

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -782,24 +782,24 @@ class TestStatistics(TestCase):
         random_volume_3 = ht.array([])
         with self.assertRaises(ValueError):
             ht.maximum(random_volume_1, random_volume_3)
-        random_volume_3 = ht.random.randn(4, 2, 3, split=0)
+        random_volume_4 = ht.random.randn(4, 2, 3, split=0)
         with self.assertRaises(ValueError):
-            ht.maximum(random_volume_1, random_volume_3)
-        random_volume_3 = torch.ones(12, 3, 3, device=self.device.torch_device)
+            ht.maximum(random_volume_1, random_volume_4)
+        random_volume_5 = torch.ones(12, 3, 3, device=self.device.torch_device)
         with self.assertRaises(TypeError):
-            ht.maximum(random_volume_1, random_volume_3)
-        random_volume_3 = ht.random.randn(6, 3, 3, split=1)
+            ht.maximum(random_volume_1, random_volume_5)
+        random_volume_6 = ht.random.randn(6, 3, 3, split=1)
         with self.assertRaises(NotImplementedError):
-            ht.maximum(random_volume_1, random_volume_3)
-        output = torch.ones(12, 3, 3, device=self.device.torch_device)
+            ht.maximum(random_volume_1, random_volume_6)
+        output1 = torch.ones(12, 3, 3, device=self.device.torch_device)
         with self.assertRaises(TypeError):
-            ht.maximum(random_volume_1, random_volume_2, out=output)
-        output = ht.ones((12, 4, 3))
+            ht.maximum(random_volume_1, random_volume_2, out=output1)
+        output2 = ht.ones((12, 4, 3))
         with self.assertRaises(ValueError):
-            ht.maximum(random_volume_1, random_volume_2, out=output)
-        output = ht.ones((6, 3, 3), split=1)
+            ht.maximum(random_volume_1, random_volume_2, out=output2)
+        output3 = ht.ones((6, 3, 3), split=1)
         with self.assertRaises(ValueError):
-            ht.maximum(random_volume_1, random_volume_2, out=output)
+            ht.maximum(random_volume_1, random_volume_2, out=output3)
 
     def test_mean(self):
         array_0_len = 5

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -779,7 +779,6 @@ class TestStatistics(TestCase):
         self.assertEqual(output.larray.dtype, torch.float32)
 
         # check exceptions
-        print("DEBUGGING: START EXCEPTIONS")
         random_volume_3 = ht.array([])
         with self.assertRaises(ValueError):
             ht.maximum(random_volume_1, random_volume_3)

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -779,6 +779,7 @@ class TestStatistics(TestCase):
         self.assertEqual(output.larray.dtype, torch.float32)
 
         # check exceptions
+        print("DEBUGGING: START EXCEPTIONS")
         random_volume_3 = ht.array([])
         with self.assertRaises(ValueError):
             ht.maximum(random_volume_1, random_volume_3)

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -1052,5 +1052,5 @@ class iinfo:
         return self
 
 
-# tensor is imported at the very end to break circular dependency
+# dndarray is imported at the very end to break circular dependency
 from . import dndarray


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Debugging GPU tests on #902. Work in progress.

Issue/s resolved: #891

## Changes proposed:
- `stride_tricks.broadcast_shape` to call `torch.broadcast_shapes`, not `np.broadcast_shapes`
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measuremens can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only provile the performance on each process. Printing the results with many processes
my be illegible. It may be easiest to save the output of each to a file.
--->


## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
yes / no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->

