### PR TITLE
`randint` accept ints for 'size'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#846](https://github.com/helmholtz-analytics/heat/pull/846) Fixed an issue in `_reduce_op` when axis and keepdim were set.
 - [#846](https://github.com/helmholtz-analytics/heat/pull/846) Fixed an issue in `min`, `max` where DNDarrays with empty processes can't be computed.
 - [#868](https://github.com/helmholtz-analytics/heat/pull/868) Fixed an issue in `__binary_op` where data was falsely distributed if a DNDarray has single element.
+- [#916](https://github.com/helmholtz-analytics/heat/pull/916) Fixed an issue in `random.randint` where the size parameter does not accept ints.
 
 ## Feature Additions
 

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -527,13 +527,13 @@ def randint(
 
     # sanitize shape
     if size is None:
-        size = (1,)
+        size = ()
     try:
         shape = tuple(int(ele) for ele in size)
     except TypeError:
         shape = (int(size),)
     else:
-        if not all(ele > 0 for ele in shape):
+        if not all(ele >= 0 for ele in shape):
             raise ValueError("negative dimensions are not allowed")
 
     # sanitize the data type

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -528,9 +528,13 @@ def randint(
     # sanitize shape
     if size is None:
         size = (1,)
-    shape = tuple(int(ele) for ele in size)
-    if not all(ele > 0 for ele in shape):
-        raise ValueError("negative dimensions are not allowed")
+    try:
+        shape = tuple(int(ele) for ele in size)
+    except TypeError:
+        shape = (int(size),)
+    finally:
+        if not all(ele > 0 for ele in shape):
+            raise ValueError("negative dimensions are not allowed")
 
     # sanitize the data type
     if dtype is None:

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -532,7 +532,7 @@ def randint(
         shape = tuple(int(ele) for ele in size)
     except TypeError:
         shape = (int(size),)
-    finally:
+    else:
         if not all(ele > 0 for ele in shape):
             raise ValueError("negative dimensions are not allowed")
 

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -240,6 +240,10 @@ class TestRandom(TestCase):
         b = ht.zeros((10,), dtype=ht.int64, split=0)
         self.assertTrue(ht.equal(a, b))
 
+        # size parameter allows int arguments
+        a = ht.random.randint(1, size=10, split=0, dtype=ht.int64)
+        self.assertTrue(ht.equal(a, b))
+
         # Two arrays with the same seed and same number of elements have the same random values
         ht.random.seed(13579)
         shape = (15, 13, 9, 21, 65)

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -244,6 +244,10 @@ class TestRandom(TestCase):
         a = ht.random.randint(1, size=10, split=0, dtype=ht.int64)
         self.assertTrue(ht.equal(a, b))
 
+        # size is None
+        a = ht.random.randint(0, 10)
+        self.assertEqual(a.shape, ())
+
         # Two arrays with the same seed and same number of elements have the same random values
         ht.random.seed(13579)
         shape = (15, 13, 9, 21, 65)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #913 

## Changes proposed:
- allow ints for size in randint

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- Bug fix

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measuremens can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

n/a

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
my be illegible. It may be easiest to save the output of each to a file.
--->

n/a

## Due Diligence
- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no