### PR TITLE
Features/384 sparse matrices

### DIFF
--- a/heat/core/coo_matrix.py
+++ b/heat/core/coo_matrix.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import math
+import numpy as np
+import torch
+import warnings
+
+from inspect import stack
+from mpi4py import MPI
+from pathlib import Path
+from typing import List, Union, Tuple, TypeVar, Optional
+from .dndarray import DNDarray
+
+__all__ = ["coo_matrix"]
+
+Communication = TypeVar("Communication")
+
+class coo_matrix():
+    def __init__(
+        self, 
+        array: torch.sparse_coo_tensor,
+        shape: Tuple[int, ...],
+        dtype: datatype,
+        split: Union[int, None],
+        device: Device,
+        comm: Communication,
+        balanced: bool,
+        gnnz: int,
+    ):
+        self.__shape = shape
+        self.__dtype = dtype
+        self.__ndim = array.__ndim()
+        self.__split = split
+        self.__device = device
+        self.__comm = comm
+        self.__balanced = balanced
+        self.__lnnz = array._nnz()
+        self.__gnnz = gnnz
+        #TODO: indices need to include explicit zeros        
+        self.__indices = array.nonzero(as_tuple=True)
+        print(self.__indices)
+        print("here")
+        self.__data = array[self.__indices]
+        print(self.__data)
+        self.has_canonical_format = True
+from . import complex_math
+from . import devices
+from . import factories
+from . import indexing
+from . import linalg
+from . import manipulations
+from . import printing
+from . import rounding
+from . import sanitation
+from . import statistics
+from . import stride_tricks
+from . import tiling
+from . import dndarray
+
+from .devices import Device
+from .stride_tricks import sanitize_axis
+from .types import datatype, canonical_heat_type

--- a/heat/core/coo_matrix.py
+++ b/heat/core/coo_matrix.py
@@ -77,6 +77,7 @@ class DNDcoo_array:
         self.__lnnz = array._nnz()
         self.__gnnz = gnnz
         self.__indices = indices(gshape, array, split, comm)
+        self.__lindices = array.coalesce().indices()
         # TODO: indices need to include explicit zeros
         # create
         # .coalesce()
@@ -114,6 +115,13 @@ class DNDcoo_array:
         Global indices of the ``coo_array``
         """
         return self.__indices
+
+    @property
+    def lindices(self) -> Tuple:
+        """
+        Global indices of the ``coo_array``
+        """
+        return self.__lindices
 
     @property
     def ndim(self) -> int:

--- a/heat/core/coo_matrix.py
+++ b/heat/core/coo_matrix.py
@@ -1,10 +1,10 @@
-"""Missing docstring in public module"""
 from __future__ import annotations
 
 import math
 import numpy as np
 import torch
 import warnings
+import heat as ht
 
 from inspect import stack
 from mpi4py import MPI
@@ -12,16 +12,20 @@ from pathlib import Path
 from typing import List, Union, Tuple, TypeVar, Optional
 from .dndarray import DNDarray
 
-__all__ = ["CooMatrix"]
+__all__ = ["coo_matrix"]
 
 Communication = TypeVar("Communication")
 
+def indices(gshape, obj, split, comm) -> coo_matrix:
+    start, _, _ = comm.chunk(gshape, split=split)
+    t_indices = obj.coalesce().indices()
+    t_indices[split] += start
+    global_indices = ht.array(t_indices, is_split=1)
+    return global_indices   
 
-class CooMatrix:
-    """Missing docstring in public class"""
-
+class coo_matrix():
     def __init__(
-        self,
+        self, 
         array: torch.sparse_coo_tensor,
         gshape: Tuple[int, ...],
         dtype: datatype,
@@ -33,20 +37,33 @@ class CooMatrix:
     ):
         self.__gshape = gshape
         self.__dtype = dtype
-        self.__ndim = array.ndim
         self.__split = split
         self.__device = device
         self.__comm = comm
         self.__balanced = balanced
         self.__lnnz = array._nnz()
         self.__gnnz = gnnz
-        # TODO: indices need to include explicit zeros
-        self.__indices = array.nonzero(as_tuple=True)
-        print(self.__indices)
-        print("here")
-        self.__data = array[self.__indices]
-        print(self.__data)
-        self.has_canonical_format = True
+        self.__indices = indices(gshape,array,split, comm)
+        #TODO: indices need to include explicit zeros       
+        # create 
+        # .coalesce() 
+        # self.__indices = array.nonzero(as_tuple=True)
+        # print(self.__indices)
+        # print("here")
+        # self.__data = array[self.__indices]
+        # print(self.__data)
+        self.has_canonical_format = True 
+
+    @property
+    def indices(self) -> coo_matrix:
+        return self.__indices
+
+    @property
+    def ndim(self) -> int:
+        """
+        Number of dimensions of the ``coo_array``
+        """
+        return len(self.__gshape)
 
 
 from . import complex_math

--- a/heat/core/coo_matrix.py
+++ b/heat/core/coo_matrix.py
@@ -1,3 +1,4 @@
+"""Missing docstring in public module"""
 from __future__ import annotations
 
 import math
@@ -11,15 +12,18 @@ from pathlib import Path
 from typing import List, Union, Tuple, TypeVar, Optional
 from .dndarray import DNDarray
 
-__all__ = ["coo_matrix"]
+__all__ = ["CooMatrix"]
 
 Communication = TypeVar("Communication")
 
-class coo_matrix():
+
+class CooMatrix:
+    """Missing docstring in public class"""
+
     def __init__(
-        self, 
+        self,
         array: torch.sparse_coo_tensor,
-        shape: Tuple[int, ...],
+        gshape: Tuple[int, ...],
         dtype: datatype,
         split: Union[int, None],
         device: Device,
@@ -27,22 +31,24 @@ class coo_matrix():
         balanced: bool,
         gnnz: int,
     ):
-        self.__shape = shape
+        self.__gshape = gshape
         self.__dtype = dtype
-        self.__ndim = array.__ndim()
+        self.__ndim = array.ndim
         self.__split = split
         self.__device = device
         self.__comm = comm
         self.__balanced = balanced
         self.__lnnz = array._nnz()
         self.__gnnz = gnnz
-        #TODO: indices need to include explicit zeros        
+        # TODO: indices need to include explicit zeros
         self.__indices = array.nonzero(as_tuple=True)
         print(self.__indices)
         print("here")
         self.__data = array[self.__indices]
         print(self.__data)
         self.has_canonical_format = True
+
+
 from . import complex_math
 from . import devices
 from . import factories

--- a/heat/core/coo_matrix.py
+++ b/heat/core/coo_matrix.py
@@ -65,6 +65,20 @@ class coo_matrix():
         """
         return len(self.__gshape)
 
+    @property
+    def lnnz(self) -> int:
+        """
+        Number of non-zero elemnent on the local process of the ``coo_array``
+        """
+        return self.__lnnz
+    
+    @property
+    def gshape(self) -> int:
+        """
+        Number of non-zero elemnent on the local process of the ``coo_array``
+        """
+        return self.__gshape
+
 
 from . import complex_math
 from . import devices

--- a/heat/core/coo_matrix.py
+++ b/heat/core/coo_matrix.py
@@ -1,3 +1,4 @@
+"""Provides HeAT's core data structure, the DNDcoo_array, a distributed n-dimensional coo sparse array"""
 from __future__ import annotations
 
 import math
@@ -10,22 +11,54 @@ from inspect import stack
 from mpi4py import MPI
 from pathlib import Path
 from typing import List, Union, Tuple, TypeVar, Optional
-from .dndarray import DNDarray
 
-__all__ = ["coo_matrix"]
+# from .coo_matrix import DNDcoo_array
+
+__all__ = ["DNDcoo_array"]
 
 Communication = TypeVar("Communication")
 
-def indices(gshape, obj, split, comm) -> coo_matrix:
+
+def indices(gshape, obj, split, comm):
+    """
+    Returns the indices of the ob if dense
+    """
     start, _, _ = comm.chunk(gshape, split=split)
     t_indices = obj.coalesce().indices()
     t_indices[split] += start
     global_indices = ht.array(t_indices, is_split=1)
-    return global_indices   
+    return global_indices
 
-class coo_matrix():
+
+class DNDcoo_array:
+    """
+    Distributed N-Dimentional coo_sparse tensor. It follows scipy
+    coo_array attributes.
+
+    Parameters
+    ----------
+    array : torch.Tensor
+        Local array elements
+    gshape : Tuple[int,...]
+        The global shape of the sparse array
+    dtype : datatype
+        The datatype of the sparse array
+    split : int or None
+        The axis on which the sparse array is divided between processes
+    device : Device
+        The device on which the local arrays are using (cpu or gpu)
+    comm : Communication
+        The communications object for sending and receiving data
+    balanced: bool or None
+        Describes whether the data are evenly distributed across processes.
+        If this information is not available (``self.balanced is None``), it
+        can be gathered via the :func:`is_balanced()` method (requires communication).
+    gnnz: int or None
+        Number of non-zero elements of the sparse array
+    """
+
     def __init__(
-        self, 
+        self,
         array: torch.sparse_coo_tensor,
         gshape: Tuple[int, ...],
         dtype: datatype,
@@ -43,19 +76,43 @@ class coo_matrix():
         self.__balanced = balanced
         self.__lnnz = array._nnz()
         self.__gnnz = gnnz
-        self.__indices = indices(gshape,array,split, comm)
-        #TODO: indices need to include explicit zeros       
-        # create 
-        # .coalesce() 
+        self.__indices = indices(gshape, array, split, comm)
+        # TODO: indices need to include explicit zeros
+        # create
+        # .coalesce()
         # self.__indices = array.nonzero(as_tuple=True)
         # print(self.__indices)
         # print("here")
         # self.__data = array[self.__indices]
         # print(self.__data)
-        self.has_canonical_format = True 
+        self.has_canonical_format = True
 
     @property
-    def indices(self) -> coo_matrix:
+    def balanced(self) -> bool:
+        """
+        Boolean value indicating if the coo_array is balanced between the MPI processes
+        """
+        return self.__balanced
+
+    @property
+    def comm(self) -> Communication:
+        """
+        The :class:`~heat.core.communication.Communication` of the ``coo_array``
+        """
+        return self.__comm
+
+    @property
+    def device(self) -> Device:
+        """
+        The :class:`~heat.core.devices.Device` of the ``coo_array``
+        """
+        return self.__device
+
+    @property
+    def indices(self) -> Tuple:
+        """
+        Global indices of the ``coo_array``
+        """
         return self.__indices
 
     @property
@@ -71,13 +128,48 @@ class coo_matrix():
         Number of non-zero elemnent on the local process of the ``coo_array``
         """
         return self.__lnnz
-    
+
     @property
-    def gshape(self) -> int:
+    def shape(self) -> int:
         """
-        Number of non-zero elemnent on the local process of the ``coo_array``
+        Global shape of the coo array ``coo_array``
         """
         return self.__gshape
+
+    @property
+    def gnnz(self) -> int:
+        """
+        Number of global non-zero elemnents of the ``coo_array``
+        """
+        return self.__gnnz
+
+    @property
+    def dtype(self):
+        """
+        The :class:`~heat.core.types.datatype` of the ``coo_array``
+        """
+        return self.__dtype
+
+    @property
+    def row(self):
+        """
+        COO format row index array of the array
+        """
+        return self.__indices[0]
+
+    @property
+    def col(self):
+        """
+        COO format col index array of the array
+        """
+        return self.__indices[1]
+
+    @property
+    def split(self) -> int:
+        """
+        Returns the axis on which the ``coo_array`` is split
+        """
+        return self.__split
 
 
 from . import complex_math
@@ -92,7 +184,8 @@ from . import sanitation
 from . import statistics
 from . import stride_tricks
 from . import tiling
-from . import dndarray
+
+# from . import coo_array
 
 from .devices import Device
 from .stride_tricks import sanitize_axis

--- a/heat/core/dcoo_array.py
+++ b/heat/core/dcoo_array.py
@@ -14,7 +14,7 @@ from typing import List, Union, Tuple, TypeVar, Optional
 
 # from .coo_matrix import DNDcoo_array
 
-__all__ = ["DNDcoo_array"]
+__all__ = ["Dcoo_array"]
 
 Communication = TypeVar("Communication")
 
@@ -30,7 +30,7 @@ def indices(gshape, obj, split, comm):
     return global_indices
 
 
-class DNDcoo_array:
+class Dcoo_array:
     """
     Distributed N-Dimentional coo_sparse tensor. It follows scipy
     coo_array attributes.

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -1,8 +1,10 @@
 """Provides high-level DNDarray initialization functions"""
 
+from tokenize import cookie_re
 import numpy as np
 import torch
 import warnings
+import scipy
 from scipy.sparse import coo_matrix
 
 from typing import Callable, Iterable, Optional, Sequence, Tuple, Type, Union, List
@@ -167,88 +169,107 @@ def sparse_coo_matrix(
     # sanitize comm object
     comm = sanitize_comm(comm)
 
+    # size
+    size = comm.size
+
     # determine the local and the global shape. If split is None, they are identical
-    gshape = list(obj.shape)
-    lshape = gshape.copy()
+    # gshape = list(obj.shape)
+    # lshape = gshape.copy()
     balanced = True
 
     # content shall be split, chunk the passed data object up
     # if scipy, stack row and col and transpose
-    if isinstance(obj, torch.sparse_coo_tensor):
-        gindices = obj.indices().transpose(1, 2, 0)
+    # if isinstance(obj, torch.sparse_coo_tensor):
+    #     gindices = obj.indices().transpose(1, 2, 0)
     # scipy only supports 2D (matrices)
-    elif isinstance(obj, coo_matrix):
-        gindices = obj.nonzero().transpose(1, 2, 0)
-    else:
-        print("type not supported")
-    if split is not None:
-        start, end, indices = comm.chunk(gshape, split)
-        indices = indices.intersection(gindices)
-        # TODO:
-        # how to get the values using specific indices
-        #
+    if isinstance(obj, scipy.sparse.coo_matrix):
+        # TODO: turn torch coo tensor
+        values = obj.data
+        indices = np.vstack((obj.row, obj.col))
+        i = torch.tensor(indices)
+        v = torch.tensor(values)
+        shape = obj.shape
+        obj = torch.sparse_coo_tensor(i, v, torch.Size(shape))
+        # gindices = obj.nonzero().transpose(1, 2, 0)
+        # print(type(obj))
 
-        # obj = obj[slices].clone()
-        # obj = sanitize_memory_layout(obj, order=order)
-    # check with the neighboring rank whether the local shape would fit into a global shape
-    elif is_split is not None:
-        gshape = np.array(gshape)
-        lshape = np.array(lshape)
-        obj = sanitize_memory_layout(obj, order=order)
-        if comm.rank < comm.size - 1:
-            comm.Isend(lshape, dest=comm.rank + 1)
-        if comm.rank != 0:
-            # look into the message of the neighbor to see whether the shape length fits
-            status = MPI.Status()
-            comm.Probe(source=comm.rank - 1, status=status)
-            length = status.Get_count() // lshape.dtype.itemsize
-            # the number of shape elements does not match with the 'left' rank
-            if length != len(lshape):
-                discard_buffer = np.empty(length)
-                comm.Recv(discard_buffer, source=comm.rank - 1)
-                gshape[is_split] = np.iinfo(gshape.dtype).min
-            else:
-                # check whether the individual shape elements match
-                comm.Recv(gshape, source=comm.rank - 1)
-                for i in range(length):
-                    if i == is_split:
-                        continue
-                    elif lshape[i] != gshape[i] and lshape[i] - 1 != gshape[i]:
-                        gshape[is_split] = np.iinfo(gshape.dtype).min
+    output_shape = tuple(obj.shape)
+    output_shape = list(output_shape)
 
-        # sum up the elements along the split dimension
-        reduction_buffer = np.array(gshape[is_split])
-        comm.Allreduce(MPI.IN_PLACE, reduction_buffer, MPI.SUM)
-        if reduction_buffer < 0:
-            raise ValueError("unable to construct tensor, shape of local data chunk does not match")
-        ttl_shape = np.array(obj.shape)
-        ttl_shape[is_split] = lshape[is_split]
-        comm.Allreduce(MPI.IN_PLACE, ttl_shape, MPI.SUM)
-        gshape[is_split] = ttl_shape[is_split]
-        split = is_split
-        # compare to calculated balanced lshape (cf. dndarray.is_balanced())
-        gshape = tuple(int(ele) for ele in gshape)
-        lshape = tuple(int(ele) for ele in lshape)
-        _, _, chk = comm.chunk(gshape, split)
-        test_lshape = tuple([x.stop - x.start for x in chk])
-        match = 1 if test_lshape == lshape else 0
-        gmatch = comm.allreduce(match, MPI.SUM)
-        if gmatch != comm.size:
-            balanced = False
+    output_shape[split] = output_shape[split] * size
+    output_shape = tuple(output_shape)
+    # if split is not None:
+    #     start, end, indices = comm.chunk(gshape, split)
+    #     # indices = indices.intersection(gindices)
+    #     # TODO:
+    #     # how to get the values using specific indices
+    #     #
 
-        # get the global nnz: gnnz
-        gnnz = torch.tensor(obj.__nnz())
-        comm.Allreduce(MPI.IN_PLACE, gnnz, MPI.SUM)
+    #     # obj = obj[slices].clone()
+    #     # obj = sanitize_memory_layout(obj, order=order)
+    # # check with the neighboring rank whether the local shape would fit into a global shape
+    # elif is_split is not None:
+    #     gshape = np.array(gshape)
+    #     lshape = np.array(lshape)
+    #     obj = sanitize_memory_layout(obj, order=order)
+    #     if comm.rank < comm.size - 1:
+    #         comm.Isend(lshape, dest=comm.rank + 1)
+    #     if comm.rank != 0:
+    #         # look into the message of the neighbor to see whether the shape length fits
+    #         status = MPI.Status()
+    #         comm.Probe(source=comm.rank - 1, status=status)
+    #         length = status.Get_count() // lshape.dtype.itemsize
+    #         # the number of shape elements does not match with the 'left' rank
+    #         if length != len(lshape):
+    #             discard_buffer = np.empty(length)
+    #             comm.Recv(discard_buffer, source=comm.rank - 1)
+    #             gshape[is_split] = np.iinfo(gshape.dtype).min
+    #         else:
+    #             # check whether the individual shape elements match
+    #             comm.Recv(gshape, source=comm.rank - 1)
+    #             for i in range(length):
+    #                 if i == is_split:
+    #                     continue
+    #                 elif lshape[i] != gshape[i] and lshape[i] - 1 != gshape[i]:
+    #                     gshape[is_split] = np.iinfo(gshape.dtype).min
 
-        # get the global indices: coo has no indices attr
-        # indices = torch.tensor(obj.indices())
-        # comm.Allgather(MPI.IN_PLACE, indices)
-        # Need just local indices or global and local ???
+    #     # sum up the elements along the split dimension
+    #     reduction_buffer = np.array(gshape[is_split])
+    #     comm.Allreduce(MPI.IN_PLACE, reduction_buffer, MPI.SUM)
+    #     if reduction_buffer < 0:
+    #         raise ValueError("unable to construct tensor, shape of local data chunk does not match")
+    #     ttl_shape = np.array(obj.shape)
+    #     ttl_shape[is_split] = lshape[is_split]
+    #     comm.Allreduce(MPI.IN_PLACE, ttl_shape, MPI.SUM)
+    #     gshape[is_split] = ttl_shape[is_split]
+    #     split = is_split
+    #     # compare to calculated balanced lshape (cf. dndarray.is_balanced())
+    #     gshape = tuple(int(ele) for ele in gshape)
+    #     lshape = tuple(int(ele) for ele in lshape)
+    #     _, _, chk = comm.chunk(gshape, split)
+    #     test_lshape = tuple([x.stop - x.start for x in chk])
+    #     match = 1 if test_lshape == lshape else 0
+    #     gmatch = comm.allreduce(match, MPI.SUM)
+    #     if gmatch != comm.size:
+    #         balanced = False
 
-    elif split is None and is_split is None:
-        obj = sanitize_memory_layout(obj, order=order)
+    # get the global nnz: gnnz
+    gnnz = torch.tensor(obj._nnz())
+    comm.Allreduce(MPI.IN_PLACE, gnnz, MPI.SUM)
 
-    return coo_matrix(obj, tuple(gshape), dtype, split, device, comm, balanced, gnnz)
+    # elif split is None and is_split is None:
+    #     obj = sanitize_memory_layout(obj, order=order)
+
+    return DNDcoo_array(
+        obj,
+        gshape=output_shape,
+        dtype=dtype,
+        split=split,
+        device=device,
+        comm=comm,
+        balanced=balanced,
+        gnnz=gnnz.item(),
+    )
 
     # obj_dnd = array(obj, dtype, copy, ndmin, order, split, is_split, device, comm)
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -9,6 +9,7 @@ from typing import Callable, Iterable, Optional, Sequence, Tuple, Type, Union, L
 from .communication import MPI, sanitize_comm, Communication
 from .devices import Device
 from .dndarray import DNDarray
+from .coo_matrix import coo_matrix
 from .memory import sanitize_memory_layout
 from .sanitation import sanitize_in, sanitize_sequence
 from .stride_tricks import sanitize_axis, sanitize_shape
@@ -34,6 +35,7 @@ __all__ = [
     "ones_like",
     "zeros",
     "zeros_like",
+    "sparse_matrix",
 ]
 
 
@@ -146,6 +148,98 @@ def arange(
 
     return DNDarray(data, gshape, htype, split, device, comm, balanced)
 
+
+def sparse_coo_matrix(
+    obj: Iterable,
+    dtype: Optional[Type[datatype]] = None,
+    copy: bool = True,
+    ndmin: int = 0,
+    order: str = "C",
+    split: Optional[int] = None,
+    is_split: Optional[int] = None,
+    device: Optional[Device] = None,
+    comm: Optional[Communication] = None,
+    # nnz:
+    # is csr/csc/coo
+) -> coo_matrix:
+
+    # sanitize comm object
+    comm = sanitize_comm(comm)
+
+    # determine the local and the global shape. If split is None, they are identical
+    gshape = list(obj.shape)
+    lshape = gshape.copy()
+    balanced = True
+
+    # content shall be split, chunk the passed data object up
+    if split is not None:
+        _, _, slices = comm.chunk(gshape, split)
+        obj = obj[slices].clone()
+        obj = sanitize_memory_layout(obj, order=order)
+    # check with the neighboring rank whether the local shape would fit into a global shape
+    elif is_split is not None:
+        gshape = np.array(gshape)
+        lshape = np.array(lshape)
+        obj = sanitize_memory_layout(obj, order=order)
+        if comm.rank < comm.size - 1:
+            comm.Isend(lshape, dest=comm.rank + 1)
+        if comm.rank != 0:
+            # look into the message of the neighbor to see whether the shape length fits
+            status = MPI.Status()
+            comm.Probe(source=comm.rank - 1, status=status)
+            length = status.Get_count() // lshape.dtype.itemsize
+            # the number of shape elements does not match with the 'left' rank
+            if length != len(lshape):
+                discard_buffer = np.empty(length)
+                comm.Recv(discard_buffer, source=comm.rank - 1)
+                gshape[is_split] = np.iinfo(gshape.dtype).min
+            else:
+                # check whether the individual shape elements match
+                comm.Recv(gshape, source=comm.rank - 1)
+                for i in range(length):
+                    if i == is_split:
+                        continue
+                    elif lshape[i] != gshape[i] and lshape[i] - 1 != gshape[i]:
+                        gshape[is_split] = np.iinfo(gshape.dtype).min
+
+        # sum up the elements along the split dimension
+        reduction_buffer = np.array(gshape[is_split])
+        comm.Allreduce(MPI.IN_PLACE, reduction_buffer, MPI.SUM)
+        if reduction_buffer < 0:
+            raise ValueError("unable to construct tensor, shape of local data chunk does not match")
+        ttl_shape = np.array(obj.shape)
+        ttl_shape[is_split] = lshape[is_split]
+        comm.Allreduce(MPI.IN_PLACE, ttl_shape, MPI.SUM)
+        gshape[is_split] = ttl_shape[is_split]
+        split = is_split
+        # compare to calculated balanced lshape (cf. dndarray.is_balanced())
+        gshape = tuple(int(ele) for ele in gshape)
+        lshape = tuple(int(ele) for ele in lshape)
+        _, _, chk = comm.chunk(gshape, split)
+        test_lshape = tuple([x.stop - x.start for x in chk])
+        match = 1 if test_lshape == lshape else 0
+        gmatch = comm.allreduce(match, MPI.SUM)
+        if gmatch != comm.size:
+            balanced = False
+
+
+        # get the global nnz: gnnz
+        gnnz = torch.tensor(obj.__nnz())
+        comm.Allreduce(MPI.IN_PLACE, gnnz, MPI.SUM)
+
+        # get the global indices: coo has no indices attr
+        indices = torch.tensor(obj.indices())
+        comm.Allgather(MPI.IN_PLACE, indices)
+
+
+    elif split is None and is_split is None:
+        obj = sanitize_memory_layout(obj, order=order)
+
+    return coo_matrix(obj, tuple(gshape), dtype, split, device, comm, balanced)
+
+    # obj_dnd = array(obj, dtype, copy, ndmin, order, split, is_split, device, comm)
+
+    # return coo_matrix(obj_dnd.larray, obj_dnd.gshape, obj_dnd.dtype, obj_dnd.split, obj_dnd.device, obj_dnd.comm, obj_dnd.balanced)
 
 def array(
     obj: Iterable,
@@ -405,11 +499,12 @@ def array(
                     elif lshape[i] != gshape[i] and lshape[i] - 1 != gshape[i]:
                         gshape[is_split] = np.iinfo(gshape.dtype).min
 
-        # sum up the elements along the split dimension
+        # sum up the elements (local size) along the split dimension
         reduction_buffer = np.array(gshape[is_split])
+        # make a torch tensor for nnz values
         comm.Allreduce(MPI.IN_PLACE, reduction_buffer, MPI.SUM)
         if reduction_buffer < 0:
-            raise ValueError("unable to construct tensor, shape of local data chunk does not match")
+            raise ValueError("unable to construct tensor, shape of local data chunk does not match")    
         ttl_shape = np.array(obj.shape)
         ttl_shape[is_split] = lshape[is_split]
         comm.Allreduce(MPI.IN_PLACE, ttl_shape, MPI.SUM)

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -241,14 +241,14 @@ def sparse_coo_matrix(
         comm.Allreduce(MPI.IN_PLACE, gnnz, MPI.SUM)
 
         # get the global indices: coo has no indices attr
-        indices = torch.tensor(obj.indices())
-        comm.Allgather(MPI.IN_PLACE, indices)
+        # indices = torch.tensor(obj.indices())
+        # comm.Allgather(MPI.IN_PLACE, indices)
         # Need just local indices or global and local ???
 
     elif split is None and is_split is None:
         obj = sanitize_memory_layout(obj, order=order)
 
-    return coo_matrix(obj, tuple(gshape), dtype, split, device, comm, balanced, gnnz, indices)
+    return coo_matrix(obj, tuple(gshape), dtype, split, device, comm, balanced, gnnz)
 
     # obj_dnd = array(obj, dtype, copy, ndmin, order, split, is_split, device, comm)
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -10,7 +10,7 @@ from typing import Callable, Iterable, Optional, Sequence, Tuple, Type, Union, L
 from .communication import MPI, sanitize_comm, Communication
 from .devices import Device
 from .dndarray import DNDarray
-from .coo_matrix import coo_matrix
+from .coo_matrix import DNDcoo_array
 from .memory import sanitize_memory_layout
 from .sanitation import sanitize_in, sanitize_sequence
 from .stride_tricks import sanitize_axis, sanitize_shape

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -10,7 +10,7 @@ from typing import Callable, Iterable, Optional, Sequence, Tuple, Type, Union, L
 from .communication import MPI, sanitize_comm, Communication
 from .devices import Device
 from .dndarray import DNDarray
-from .coo_matrix import CooMatrix
+from .coo_matrix import coo_matrix
 from .memory import sanitize_memory_layout
 from .sanitation import sanitize_in, sanitize_sequence
 from .stride_tricks import sanitize_axis, sanitize_shape
@@ -162,7 +162,7 @@ def sparse_coo_matrix(
     comm: Optional[Communication] = None,
     # nnz:
     # is csr/csc/coo
-) -> CooMatrix:
+) -> coo_matrix:
     """Missing docstring in public function."""
     # sanitize comm object
     comm = sanitize_comm(comm)

--- a/test.py
+++ b/test.py
@@ -1,6 +1,9 @@
 """Testing file for coo sparse array class"""
 import heat as ht
+from heat.core.factories import sparse_coo_matrix
 import torch
+import numpy as np
+from scipy.sparse import coo_matrix
 
 # TEST SPARSE COO
 rank = ht.communication.MPI_WORLD.rank
@@ -8,18 +11,17 @@ size = ht.communication.MPI_WORLD.size
 comm = ht.communication.MPI_WORLD
 # comm = MPI.COMM_WORLD
 
-i = [[0, 1, 1], [1, 0, 1]]
+i = [[0, 1, 1], [1, 0, 1], [2, 0, 2], [1, 0, 1]]
 v = [3, 4, 5]
-s = torch.sparse_coo_tensor(i, v, (2, 2))
-split = 1
-
+s = torch.sparse_coo_tensor(i, v, (2, 2, 3, 2))
+split = 3
 # output_shape = (s.shape[split]*size,) + tuple(s.shape[:3])
 
 # Have to change the shape to list to be able to change the value of shape[split]
 output_shape = tuple(s.shape)
 output_shape = list(output_shape)
 output_shape[split] = output_shape[split] * size
-print(output_shape)
+# print(output_shape)
 output_shape = tuple(output_shape)
 ht_s = ht.coo_matrix.DNDcoo_array(
     s,
@@ -31,4 +33,28 @@ ht_s = ht.coo_matrix.DNDcoo_array(
     balanced=True,
     comm=comm,
 )
+
+scipy_coo = coo_matrix(([3, 4, 5], ([0, 1, 1], [2, 0, 2])), shape=(2, 3))
+ht_s = ht.sparse_coo_matrix(scipy_coo, split=1)
 print(ht_s.indices)
+print(ht_s.lindices)
+print(ht_s.gnnz)
+print(ht_s.lnnz)
+# row  = np.array([0, 0, 1, 3, 1, 0, 0])
+# col  = np.array([0, 2, 1, 3, 1, 0, 0])
+# data = np.array([1, 1, 1, 1, 1, 1, 1])
+# coo = coo_matrix((data, (row, col)), shape=(4, 4))
+# print(type(coo.col))
+# new =  sparse_coo_matrix(coo, split=0)
+
+# torch coo sparse tensor
+i = [[0, 7, 18], [2, 0, 8]]
+v = [3, 4, 5]
+s = torch.sparse_coo_tensor(i, v, (20, 13))
+ht_s = ht.sparse_coo_matrix(s, split=1)
+# print(ht_s.indices)
+# print(ht_s.lindices)
+# print(ht_s.gnnz)
+# print(ht_s.lnnz)
+
+from heat import factories

--- a/test.py
+++ b/test.py
@@ -7,11 +7,18 @@ size = ht.communication.MPI_WORLD.size
 comm = ht.communication.MPI_WORLD
 # comm = MPI.COMM_WORLD
 
-i = [[0, 1, 1], [2, 0, 2], [1, 1, 0]]
+i = [[0, 1, 1], [1, 0, 1],[1, 0, 1],[1, 0, 1]]
 v =  [3, 4, 5]
-s = torch.sparse_coo_tensor(i, v, (2, 3,2))
+s = torch.sparse_coo_tensor(i, v, (2, 2,2,2))
+split=3
 
-output_shape = (s.shape[0]*size,) + tuple(s.shape[1:])
-# print(size)
-ht_s = ht.coo_matrix.coo_matrix(s, gshape = output_shape, split=2, dtype=ht.int64, gnnz=6, device="cpu", balanced=True, comm=comm)
+#output_shape = (s.shape[split]*size,) + tuple(s.shape[:3])
+
+# Have to change the shape to list to be able to change the value of shape[split]
+output_shape = tuple(s.shape)
+output_shape = list(output_shape)
+output_shape[split] = output_shape[split]*size
+print(output_shape)
+output_shape = tuple(output_shape)
+ht_s = ht.coo_matrix.coo_matrix(s, gshape = output_shape, split=split, dtype=ht.int64, gnnz=6, device="cpu", balanced=True, comm=comm)
 print(ht_s.indices)

--- a/test.py
+++ b/test.py
@@ -23,7 +23,7 @@ output_shape = list(output_shape)
 output_shape[split] = output_shape[split] * size
 # print(output_shape)
 output_shape = tuple(output_shape)
-ht_s = ht.coo_matrix.DNDcoo_array(
+ht_s = ht.dcoo_array.Dcoo_array(
     s,
     gshape=output_shape,
     split=split,
@@ -33,13 +33,14 @@ ht_s = ht.coo_matrix.DNDcoo_array(
     balanced=True,
     comm=comm,
 )
+print(ht_s.indices)
 
 scipy_coo = coo_matrix(([3, 4, 5], ([0, 1, 1], [2, 0, 2])), shape=(2, 3))
-ht_s = ht.sparse_coo_matrix(scipy_coo, split=1)
-print(ht_s.indices)
-print(ht_s.lindices)
-print(ht_s.gnnz)
-print(ht_s.lnnz)
+ht_s = ht.sparse_coo_matrix(scipy_coo, is_split=1)
+# print(ht_s.indices)
+# print(ht_s.lindices)
+# print(ht_s.gnnz)
+# print(ht_s.lnnz)
 # row  = np.array([0, 0, 1, 3, 1, 0, 0])
 # col  = np.array([0, 2, 1, 3, 1, 0, 0])
 # data = np.array([1, 1, 1, 1, 1, 1, 1])
@@ -48,10 +49,10 @@ print(ht_s.lnnz)
 # new =  sparse_coo_matrix(coo, split=0)
 
 # torch coo sparse tensor
-i = [[0, 7, 18], [2, 0, 8]]
-v = [3, 4, 5]
-s = torch.sparse_coo_tensor(i, v, (20, 13))
-ht_s = ht.sparse_coo_matrix(s, split=1)
+# i = [[0, 7, 18], [2, 0, 8]]
+# v = [3, 4, 5]
+# s = torch.sparse_coo_tensor(i, v, (20, 13))
+# ht_s = ht.sparse_coo_matrix(s, is_split=0)
 # print(ht_s.indices)
 # print(ht_s.lindices)
 # print(ht_s.gnnz)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,9 @@
+import heat as ht
+
+print("Input array:")
+b = ht.array([
+    [[1,2,0,0], [2,0,0,5]],
+    [[1,2,0,0], [2,0,0,5]]
+    ])
+print(b)
+b = ht.sparse_matrix(b)

--- a/test.py
+++ b/test.py
@@ -1,9 +1,17 @@
 import heat as ht
+import torch
 
-print("Input array:")
-b = ht.array([
-    [[1,2,0,0], [2,0,0,5]],
-    [[1,2,0,0], [2,0,0,5]]
-    ])
-print(b)
-b = ht.sparse_matrix(b)
+# TEST SPARSE COO
+rank = ht.communication.MPI_WORLD.rank
+size = ht.communication.MPI_WORLD.size
+comm = ht.communication.MPI_WORLD
+# comm = MPI.COMM_WORLD
+
+i = [[0, 1, 1], [2, 0, 2], [1, 1, 0]]
+v =  [3, 4, 5]
+s = torch.sparse_coo_tensor(i, v, (2, 3,2))
+
+output_shape = (s.shape[0]*size,) + tuple(s.shape[1:])
+# print(size)
+ht_s = ht.coo_matrix.coo_matrix(s, gshape = output_shape, split=2, dtype=ht.int64, gnnz=6, device="cpu", balanced=True, comm=comm)
+print(ht_s.indices)

--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+"""Testing file for coo sparse array class"""
 import heat as ht
 import torch
 
@@ -7,18 +8,27 @@ size = ht.communication.MPI_WORLD.size
 comm = ht.communication.MPI_WORLD
 # comm = MPI.COMM_WORLD
 
-i = [[0, 1, 1], [1, 0, 1],[1, 0, 1],[1, 0, 1]]
-v =  [3, 4, 5]
-s = torch.sparse_coo_tensor(i, v, (2, 2,2,2))
-split=3
+i = [[0, 1, 1], [1, 0, 1]]
+v = [3, 4, 5]
+s = torch.sparse_coo_tensor(i, v, (2, 2))
+split = 1
 
-#output_shape = (s.shape[split]*size,) + tuple(s.shape[:3])
+# output_shape = (s.shape[split]*size,) + tuple(s.shape[:3])
 
 # Have to change the shape to list to be able to change the value of shape[split]
 output_shape = tuple(s.shape)
 output_shape = list(output_shape)
-output_shape[split] = output_shape[split]*size
+output_shape[split] = output_shape[split] * size
 print(output_shape)
 output_shape = tuple(output_shape)
-ht_s = ht.coo_matrix.coo_matrix(s, gshape = output_shape, split=split, dtype=ht.int64, gnnz=6, device="cpu", balanced=True, comm=comm)
+ht_s = ht.coo_matrix.DNDcoo_array(
+    s,
+    gshape=output_shape,
+    split=split,
+    dtype=ht.int64,
+    gnnz=6,
+    device="cpu",
+    balanced=True,
+    comm=comm,
+)
 print(ht_s.indices)


### PR DESCRIPTION
## Description
### New class: coo_matrix:
coo_matrix class (should be re-named to coo_array). Indices are calculated using a function in the class file 

Issue/s resolved: 
- coo_indices are now working
- gshape calculation from a torch.sparse_coo_tensor in the test.py file: turnt the shape to tuple (couldn't modify the tuple), then to a list, changed the gshape[split] value, then turnt it to a tuple again. 


#### Does this change modify the behaviour of other functions? If so, which?
Should the function indices be part of the class?
