### PR TITLE
Bug/992 precision loss

### DIFF
--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -139,10 +139,12 @@ def arange(
     # compose the local tensor
     start += offset * step
     stop = start + lshape[0] * step
-    data = torch.arange(start, stop, step, device=device.torch_device)
-
     htype = types.canonical_heat_type(dtype)
-    data = data.type(htype.torch_type())
+    if types.issubdtype(htype, types.floating):
+        data = torch.arange(start, stop, step, dtype=htype.torch_type(), device=device.torch_device)
+    else:
+        data = torch.arange(start, stop, step, device=device.torch_device)
+        data = data.type(htype.torch_type())
 
     return DNDarray(data, gshape, htype, split, device, comm, balanced)
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -299,8 +299,11 @@ def array(
         obj = obj.larray
 
     # sanitize the data type
-    if dtype is not None:
+    if dtype is None:
+        torch_dtype = None
+    else:
         dtype = types.canonical_heat_type(dtype)
+        torch_dtype = dtype.torch_type()
 
     # sanitize device
     if device is not None:
@@ -316,6 +319,7 @@ def array(
             try:
                 obj = torch.tensor(
                     obj,
+                    dtype=torch_dtype,
                     device=device.torch_device
                     if device is not None
                     else devices.get_device().torch_device,
@@ -326,6 +330,7 @@ def array(
         if not isinstance(obj, DNDarray):
             obj = torch.as_tensor(
                 obj,
+                dtype=torch_dtype,
                 device=device.torch_device
                 if device is not None
                 else devices.get_device().torch_device,
@@ -335,7 +340,6 @@ def array(
     if dtype is None:
         dtype = types.canonical_heat_type(obj.dtype)
     else:
-        torch_dtype = dtype.torch_type()
         if obj.dtype != torch_dtype:
             obj = obj.type(torch_dtype)
 

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -142,6 +142,8 @@ class TestFactories(TestCase):
                 == torch.tensor(tuple_data, dtype=torch.int8, device=self.device.torch_device)
             ).all()
         )
+        check_precision = ht.array(16777217.0, dtype=ht.float64)
+        self.assertEqual(check_precision.sum(), 16777217)
 
         # basic array function, unsplit data, no copy
         torch_tensor = torch.tensor([6, 5, 4, 3, 2, 1], device=self.device.torch_device)

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -106,6 +106,9 @@ class TestFactories(TestCase):
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(three_arg_arange_dtype_float64.sum(axis=0, keepdim=True), 20.0)
 
+        check_precision = ht.arange(16777217.0, 16777218, 1, dtype=ht.float64)
+        self.assertEqual(check_precision.sum(), 16777217)
+
         # exceptions
         with self.assertRaises(ValueError):
             ht.arange(-5, 3, split=1)


### PR DESCRIPTION
## Description
Fixed precision loss in several functions when using `float64` data type.

Issue/s resolved: #992

## Changes proposed:
- Passed in the `dtype` argument to backend torch functions instead of converting to desired data type after using default torch data type.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
