### PR TITLE
Non-negative sample size for `linspace`/`logspace`

### DIFF
--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -946,7 +946,7 @@ def linspace(
     start = float(start)
     stop = float(stop)
     num = int(num)
-    if num <= 0:
+    if num < 0:
         raise ValueError(
             "number of samples 'num' must be non-negative integer, but was {}".format(num)
         )

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -647,6 +647,9 @@ class TestFactories(TestCase):
         self.assertEqual(ascending.larray.dtype, torch.float32)
         self.assertEqual(ascending.split, None)
 
+        zero_samples = ht.logspace(-3, 5, num=0)
+        self.assertEqual(zero_samples.size, 0)
+
         # simple inverse log space
         descending = ht.logspace(-5, 3, num=100)
         self.assertIsInstance(descending, ht.DNDarray)

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -586,6 +586,9 @@ class TestFactories(TestCase):
         self.assertEqual(ascending.larray.dtype, torch.float32)
         self.assertEqual(ascending.split, None)
 
+        zero_samples = ht.linspace(-3, 5, num=0)
+        self.assertEqual(zero_samples.size, 0)
+
         # simple inverse linear space
         descending = ht.linspace(-5, 3, num=100)
         self.assertIsInstance(descending, ht.DNDarray)
@@ -633,8 +636,6 @@ class TestFactories(TestCase):
             ht.linspace(-5, 3, split=1)
         with self.assertRaises(ValueError):
             ht.linspace(-5, 3, num=-1)
-        with self.assertRaises(ValueError):
-            ht.linspace(-5, 3, num=0)
 
     def test_logspace(self):
         # simple log space

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -688,8 +688,6 @@ class TestFactories(TestCase):
             ht.logspace(-5, 3, split=1)
         with self.assertRaises(ValueError):
             ht.logspace(-5, 3, num=-1)
-        with self.assertRaises(ValueError):
-            ht.logspace(-5, 3, num=0)
 
     def test_meshgrid(self):
         # arrays < 2


### PR DESCRIPTION
## Description
Allow `linspace` to be called with 0 sample size. This also fixes an inconsistency with the documentation, which already allows `num` to be non-negative.

Issue/s resolved: #994

## Type of change
- New feature (non-breaking change which adds functionality)

## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
