### PR TITLE
Bug/996 `iinfo`/`finfo` `min` value

### DIFF
--- a/heat/core/tests/test_types.py
+++ b/heat/core/tests/test_types.py
@@ -375,6 +375,7 @@ class TestTypeConversion(TestCase):
         self.assertEqual(info32.bits, 32)
         self.assertEqual(info32.max, 2147483647)
         self.assertEqual(info32.min, -2147483648)
+        self.assertEqual(ht.iinfo(ht.uint8).min, 0)
 
         with self.assertRaises(TypeError):
             ht.iinfo(1.0)

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -996,10 +996,8 @@ class finfo:
 
     def _init(self, dtype: Type[datatype]):
         _torch_finfo = torch.finfo(dtype.torch_type())
-        for word in ["bits", "eps", "max", "tiny"]:
+        for word in ["bits", "eps", "max", "min", "tiny"]:
             setattr(self, word, getattr(_torch_finfo, word))
-
-        self.min = -self.max
 
         return self
 
@@ -1044,10 +1042,8 @@ class iinfo:
 
     def _init(self, dtype: Type[datatype]):
         _torch_iinfo = torch.iinfo(dtype.torch_type())
-        for word in ["bits", "max"]:
+        for word in ["bits", "min", "max"]:
             setattr(self, word, getattr(_torch_iinfo, word))
-
-        self.min = -(self.max + 1)
 
         return self
 


### PR DESCRIPTION
## Description
Reads the minimum value of a data type directly from the return values of pytorch `iinfo` and `finfo` functions. This is superior to the old method of calculating the minimum value from the maximum value as the minimum value is calculated differently for different data types (e.g. `min = -(max + 1)` works for signed integers but not unsigned integers).

Issue/s resolved: #996

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
