### PR TITLE
Bug/1012 Slicing arrays with 0-length axis

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -965,7 +965,11 @@ class DNDarray:
     def __key_adds_dimension(key: any, axis: int, self_proxy: torch.Tensor) -> bool:
         # determine if the key adds a new dimension
         zeros = (0,) * (self_proxy.ndim - 1)
-        return self_proxy[(*zeros[:axis], key[axis], *zeros[axis:])].ndim == 2
+        try:
+            proxy_slice = self_proxy[(*zeros[:axis], key[axis], *zeros[axis:])]
+        except IndexError:
+            return False
+        return proxy_slice.ndim == 2
 
     def item(self):
         """


### PR DESCRIPTION
## Description
Fixes a bug where adding a dimension (via slicing with `None`) on an array with an axis of length 0 resulted in an error.
This is a test case in the Python array API standard test suite.

Issue/s resolved: #1012

## Changes proposed:
- 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
