### PR TITLE
Add array API test suite into CI

### DIFF
--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -1,0 +1,87 @@
+name: Test Array API
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Use Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+    - name: Install
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .
+    - name: Checkout array-api-tests
+      uses: actions/checkout@v3
+      with:
+        repository: data-api/array-api-tests
+        ref: 2022.05.18
+        path: array-api-tests
+        submodules: 'true'
+    - name: Install dependencies
+      run: |
+        python -m pip install -r array-api-tests/requirements.txt
+    - name: Run the test suite
+      env:
+        ARRAY_API_TESTS_MODULE: heat.array_api
+      run: |
+        # Skip testing functions with known issues
+        cat << EOF >> skips.txt
+
+        # copy not implemented
+        array_api_tests/test_creation_functions.py::test_asarray_arrays
+        # https://github.com/numpy/numpy/issues/20870
+        array_api_tests/test_data_type_functions.py::test_can_cast
+        # The return dtype for trace is not consistent in the spec
+        # https://github.com/data-apis/array-api/issues/202#issuecomment-952529197
+        array_api_tests/test_linalg.py::test_trace
+        # waiting on NumPy to allow/revert distinct NaNs for np.unique
+        # https://github.com/numpy/numpy/issues/20326#issuecomment-1012380448
+        array_api_tests/test_set_functions.py
+
+        # https://github.com/numpy/numpy/issues/21373
+        array_api_tests/test_array_object.py::test_getitem
+
+        # missing copy arg
+        array_api_tests/test_signatures.py::test_func_signature[reshape]
+
+        # https://github.com/numpy/numpy/issues/21211
+        array_api_tests/test_special_cases.py::test_iop[__iadd__(x1_i is -0 and x2_i is -0) -> -0]
+        # https://github.com/numpy/numpy/issues/21213
+        array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -infinity and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +infinity]
+        array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -0 and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +0]
+        # noted diversions from spec
+        array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
+        array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
+        array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
+        array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
+        array_api_tests/test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
+        array_api_tests/test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+        array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
+        array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
+        array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
+        array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
+        array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
+        array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
+        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
+        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
+        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
+        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
+        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+
+        EOF
+
+        pytest array-api-tests/array_api_tests -v -rxXfE --ci --disable-extension

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -40,48 +40,125 @@ jobs:
         # Skip testing functions with known issues
         cat << EOF >> skips.txt
 
-        # copy not implemented
-        array_api_tests/test_creation_functions.py::test_asarray_arrays
-        # https://github.com/numpy/numpy/issues/20870
-        array_api_tests/test_data_type_functions.py::test_can_cast
-        # The return dtype for trace is not consistent in the spec
-        # https://github.com/data-apis/array-api/issues/202#issuecomment-952529197
-        array_api_tests/test_linalg.py::test_trace
-        # waiting on NumPy to allow/revert distinct NaNs for np.unique
-        # https://github.com/numpy/numpy/issues/20326#issuecomment-1012380448
-        array_api_tests/test_set_functions.py
+        # PR #938 Indexing overhaul
+        array-api-tests/array_api_tests/test_array_object.py::test_getitem
+        array-api-tests/array_api_tests/test_array_object.py::test_setitem
+        array-api-tests/array_api_tests/test_array_object.py::test_getitem_masking
+        array-api-tests/array_api_tests/test_array_object.py::test_setitem_masking
+        array-api-tests/array_api_tests/test_linalg.py::test_matrix_matmul
+        array-api-tests/array_api_tests/test_manipulation_functions.py::test_concat
+        array-api-tests/array_api_tests/test_manipulation_functions.py::test_stack
+        array-api-tests/array_api_tests/test_searching_functions.py::test_argmax
+        array-api-tests/array_api_tests/test_searching_functions.py::test_argmin
+        array-api-tests/array_api_tests/test_searching_functions.py::test_nonzero
+        array-api-tests/array_api_tests/test_searching_functions.py::test_where
+        array-api-tests/array_api_tests/test_special_cases.py::test_nan_propagation[max]
+        array-api-tests/array_api_tests/test_special_cases.py::test_nan_propagation[min]
+        array-api-tests/array_api_tests/test_special_cases.py::test_nan_propagation[prod]
+        array-api-tests/array_api_tests/test_special_cases.py::test_nan_propagation[sum]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[add(isfinite(x1_i) and x1_i != 0 and x2_i == -x1_i) -> +0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_iop[__iadd__(isfinite(x1_i) and x1_i != 0 and x2_i == -x1_i) -> +0]
+        array-api-tests/array_api_tests/test_statistical_functions.py::test_max
+        array-api-tests/array_api_tests/test_statistical_functions.py::test_mean
+        array-api-tests/array_api_tests/test_statistical_functions.py::test_min
+        array-api-tests/array_api_tests/test_statistical_functions.py::test_prod
+        array-api-tests/array_api_tests/test_statistical_functions.py::test_var
+        array-api-tests/array_api_tests/test_utility_functions.py::test_all
+        array-api-tests/array_api_tests/test_utility_functions.py::test_any
 
-        # https://github.com/numpy/numpy/issues/21373
-        array_api_tests/test_array_object.py::test_getitem
+        # Pytorch dtypes https://github.com/pytorch/pytorch/issues/58734
+        array-api-tests/array_api_tests/test_array_object.py::test_scalar_casting[__int__(uint16)]
+        array-api-tests/array_api_tests/test_array_object.py::test_scalar_casting[__int__(uint32)]
+        array-api-tests/array_api_tests/test_array_object.py::test_scalar_casting[__int__(uint64)]
+        array-api-tests/array_api_tests/test_array_object.py::test_scalar_casting[__index__(uint16)]
+        array-api-tests/array_api_tests/test_array_object.py::test_scalar_casting[__index__(uint32]
+        array-api-tests/array_api_tests/test_array_object.py::test_scalar_casting[__inndes__(uint64)]
+        array-api-tests/array_api_tests/test_data_type_functions.py::test_iinfo[uint16]
+        array-api-tests/array_api_tests/test_data_type_functions.py::test_iinfo[uint32]
+        array-api-tests/array_api_tests/test_data_type_functions.py::test_iinfo[uint64]
+        array-api-tests/array_api_tests/test_statistical_functions.py::test_sum
+        array-api-tests/array_api_tests/test_type_promotion.py
 
-        # missing copy arg
-        array_api_tests/test_signatures.py::test_func_signature[reshape]
+        # PR #1000 any/all keepdim
+        array-api-tests/array_api_tests/test_linalg.py::test_matrix_transpose
+        array-api-tests/array_api_tests/test_operators_and_elementwise_functions.py::test_abs
+        array-api-tests/array_api_tests/test_operators_and_elementwise_functions.py::test_bitwise_left_shift
+        array-api-tests/array_api_tests/test_operators_and_elementwise_functions.py::test_bitwise_right_shift
+        array-api-tests/array_api_tests/test_operators_and_elementwise_functions.py::test_floor_divide
+        array-api-tests/array_api_tests/test_operators_and_elementwise_functions.py::test_positive
+        array-api-tests/array_api_tests/test_operators_and_elementwise_functions.py::test_pow
+        array-api-tests/array_api_tests/test_operators_and_elementwise_functions.py::test_remainder
 
-        # https://github.com/numpy/numpy/issues/21211
-        array_api_tests/test_special_cases.py::test_iop[__iadd__(x1_i is -0 and x2_i is -0) -> -0]
-        # https://github.com/numpy/numpy/issues/21213
-        array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -infinity and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +infinity]
-        array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -0 and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +0]
-        # noted diversions from spec
-        array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
-        array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
-        array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
-        array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
-        array_api_tests/test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
-        array_api_tests/test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
-        array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
-        array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
-        array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
-        array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
-        array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
-        array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
-        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
-        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
-        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
-        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
-        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
-        array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+        # PR #993 Precision loss
+        array-api-tests/array_api_tests/test_creation_functions.py::test_arange
+        array-api-tests/array_api_tests/test_creation_functions.py::test_linspace
+
+        # PR #1018 __reduce_op bug
+        array-api-tests/array_api_tests/test_creation_functions.py::test_asarray_arrays
+        array-api-tests/array_api_tests/test_creation_functions.py::test_full
+        array-api-tests/array_api_tests/test_creation_functions.py::test_full_like
+        array-api-tests/array_api_tests/test_creation_functions.py::test_ones
+        array-api-tests/array_api_tests/test_creation_functions.py::test_ones_like
+        array-api-tests/array_api_tests/test_creation_functions.py::test_zeros
+        array-api-tests/array_api_tests/test_creation_functions.py::test_zeros_like
+        array-api-tests/array_api_tests/test_operators_and_elementwise_functions.py::test_negative
+        array-api-tests/array_api_tests/test_special_cases.py::test_empty_arrays[prod]
+        array-api-tests/array_api_tests/test_special_cases.py::test_nan_propagation[sum]
+
+        # k not implemented
+        array-api-tests/array_api_tests/test_creation_functions.py::test_eye
+
+        # PR #1020 broadcasting
+        array-api-tests/array_api_tests/test_data_type_functions.py::test_broadcast_arrays
+        array-api-tests/array_api_tests/test_data_type_functions.py::test_broadcast_to
+
+        # PR #749 unique
+        array-api-tests/array_api_tests/test_set_functions.py::test_unique_all
+        array-api-tests/array_api_tests/test_set_functions.py::test_unique_counts
+        array-api-tests/array_api_tests/test_set_functions.py::test_unique_inverse
+        array-api-tests/array_api_tests/test_set_functions.py::test_unique_values
+        array-api-tests/array_api_tests/test_signatures.py::test_func_signature[unique_all]
+        array-api-tests/array_api_tests/test_signatures.py::test_func_signature[unique_counts]
+        array-api-tests/array_api_tests/test_sorting_functions.py::test_sort
+
+        # PR #996 argsort
+        array-api-tests/array_api_tests/test_signatures.py::test_func_signature[argsort]
+        array-api-tests/array_api_tests/test_sorting_functions.py::test_argsort
+
+        # tensordot
+        array-api-tests/array_api_tests/test_linalg.py::test_tensordot
+
+        # Special cases
+        array-api-tests/array_api_tests/test_operators_and_elementwise_functions.py::test_square
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[remainder(x1_i is -0 and x2_i > 0) -> +0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[remainder(x1_i is +0 and x2_i < 0) -> -0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[__mod__(x1_i is -0 and x2_i > 0) -> +0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_binary[__mod__(x1_i is +0 and x2_i < 0) -> -0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
+        array-api-tests/array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_iop[__imod__(x1_i is -0 and x2_i > 0) -> +0]
+        array-api-tests/array_api_tests/test_special_cases.py::test_iop[__imod__(x1_i is +0 and x2_i < 0) -> -0]
+        # std special cases
+        array-api-tests/array_api_tests/test_statistical_functions.py::test_std
+        array-api-tests/array_api_tests/test_special_cases.py::test_empty_arrays[std]
+        array-api-tests/array_api_tests/test_special_cases.py::test_nan_propagation[std]
 
         EOF
 
-        pytest array-api-tests/array_api_tests -v -rxXfE --ci --disable-extension
+        pytest array-api-tests/array_api_tests -v -rxXfE --ci --disable-extension linalg


### PR DESCRIPTION
## Description
Incorporate the [array API test suite](https://github.com/data-apis/array-api-tests) into the CI.

## Changes proposed:
- Checkout the latest release of the test suite and run the tests
- Tests are run using Python 3.8 and 3.9 (Array API prereq is Python >=3.8)

## Type of change
- CI

## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
