### PR TITLE
Fixed code that verifies lshape while using is_split

### DIFF
--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -406,12 +406,12 @@ def array(
                 for i in range(length):
                     if i == is_split:
                         continue
-                    elif lshape[i] != neighbour_shape[i] and lshape[i] - 1 != neighbour_shape[i]:
+                    elif lshape[i] != neighbour_shape[i]:
                         neighbour_shape[is_split] = np.iinfo(neighbour_shape.dtype).min
 
         # sum up the elements along the split dimension
         reduction_buffer = np.array(neighbour_shape[is_split])
-        comm.Allreduce(MPI.IN_PLACE, reduction_buffer, MPI.SUM)
+        comm.Allreduce(MPI.IN_PLACE, reduction_buffer, MPI.MIN)
         if reduction_buffer < 0:
             raise ValueError("unable to construct tensor, shape of local data chunk does not match")
         ttl_shape = np.array(obj.shape)

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -381,9 +381,13 @@ def array(
         obj = sanitize_memory_layout(obj, order=order)
     # check with the neighboring rank whether the local shape would fit into a global shape
     elif is_split is not None:
-        gshape = np.array(gshape)
-        lshape = np.array(lshape)
         obj = sanitize_memory_layout(obj, order=order)
+
+        # Check whether the shape of distributed data
+        # matches in all dimensions except the split axis
+        neighbour_shape = np.array(gshape)
+        lshape = np.array(lshape)
+
         if comm.rank < comm.size - 1:
             comm.Isend(lshape, dest=comm.rank + 1)
         if comm.rank != 0:
@@ -395,18 +399,18 @@ def array(
             if length != len(lshape):
                 discard_buffer = np.empty(length)
                 comm.Recv(discard_buffer, source=comm.rank - 1)
-                gshape[is_split] = np.iinfo(gshape.dtype).min
+                neighbour_shape[is_split] = np.iinfo(neighbour_shape.dtype).min
             else:
                 # check whether the individual shape elements match
-                comm.Recv(gshape, source=comm.rank - 1)
+                comm.Recv(neighbour_shape, source=comm.rank - 1)
                 for i in range(length):
                     if i == is_split:
                         continue
-                    elif lshape[i] != gshape[i] and lshape[i] - 1 != gshape[i]:
-                        gshape[is_split] = np.iinfo(gshape.dtype).min
+                    elif lshape[i] != neighbour_shape[i] and lshape[i] - 1 != neighbour_shape[i]:
+                        neighbour_shape[is_split] = np.iinfo(neighbour_shape.dtype).min
 
         # sum up the elements along the split dimension
-        reduction_buffer = np.array(gshape[is_split])
+        reduction_buffer = np.array(neighbour_shape[is_split])
         comm.Allreduce(MPI.IN_PLACE, reduction_buffer, MPI.SUM)
         if reduction_buffer < 0:
             raise ValueError("unable to construct tensor, shape of local data chunk does not match")

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -308,6 +308,12 @@ class TestFactories(TestCase):
         with self.assertRaises(TypeError):
             ht.array((4,), comm={})
 
+        # data already distributed but don't match in shape
+        if self.get_size() > 1:
+            with self.assertRaises(ValueError):
+                dim = self.get_rank() + 1
+                ht.array([[0] * dim] * dim, is_split=0)
+
     def test_asarray(self):
         # same heat array
         arr = ht.array([1, 2])


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

The reuse of gshape array as the receiving buffer made the code a bit too difficult to understand. So, created a new array `neighbour_shape` to hold, well...., the neighbour's shape.

The use of `MPI.SUM`, to find if any process has encountered a mismatch in local shapes with its neighbour, leads to errors because of integer limitations. When two or more processes find a mismatch, the huge negative values are added together and I guess because of integer overflow, they disappear into the unknown and finally, we are left with a positive value. So, it does not create any errors when it should. This can be easily solved by using `MPI.MIN` instead.

One more thing that I don't understand is, why `gshape[i]` is allowed to be one less than `lshape[i]` in line [405](https://github.com/helmholtz-analytics/heat/blob/0949a48f94cf1e3e2a5893064f985e37007bb7ea/heat/core/factories.py#L405). I know there must be a reason for it. I just don't understand why.

### Code snippet:
```
import heat as ht
import torch

rank = ht.communication.MPI_WORLD.rank
dim = rank+1

larray = [[0]*dim]*dim
print("Rank", rank, larray)

d = ht.array(larray, is_split=0)

# literally any operation that involves communication 
# between processes will crash
# like this simple print statement
print(d)
```

## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Updated changelog.md under the title "Pending Additions"

#### Does this change modify the behaviour of other functions? If so, which?
no

<!-- Remove this line for GPU Cluster tests. It will need an approval. --->
skip ci
