### PR TITLE
hSVD (prescribed rank or tolerance) 

### DIFF
--- a/heat/core/linalg/__init__.py
+++ b/heat/core/linalg/__init__.py
@@ -5,3 +5,4 @@ Import all linear algebra functions into the ht.linalg namespace
 from .basics import *
 from .solver import *
 from .qr import *
+from .svdtools import *

--- a/heat/core/linalg/svdtools.py
+++ b/heat/core/linalg/svdtools.py
@@ -1,0 +1,524 @@
+"""
+distributed hierarchical SVD - first draft
+"""
+import numpy as np
+import collections
+import torch
+from typing import Type, Callable, Dict, Any, TypeVar, Union, Tuple
+
+from ..communication import MPICommunication
+from ..dndarray import DNDarray
+from .. import factories
+from .. import types
+from ..linalg import matmul, vector_norm
+from ..indexing import where
+from ..random import randn
+
+from ..manipulations import vstack, hstack, diag, balance
+
+from .. import statistics
+from math import log, ceil, floor, sqrt
+
+
+__all__ = ["hsvd_rank", "hsvd_reltol", "hsvd"]
+
+
+#########################################################################################
+# user-friendly versions of hSVD
+#########################################################################################
+
+
+def hsvd_rank(
+    A: DNDarray,
+    maxrank: int,
+    maxmergedim: Union[int, None] = None,
+    safetyshift: int = 5,
+    full: bool = False,
+    silent: bool = True,
+) -> Union[
+    Tuple[DNDarray, DNDarray, DNDarray, float], Tuple[DNDarray, DNDarray, DNDarray], DNDarray
+]:
+    """
+    Hierarchical SVD (hSVD) with prescribed truncation rank maxrank.
+    If A = U diag(sigma) V^T is the true SVD of A, this routine computes an approximation for U[:,:maxrank] (and sigma[:maxrank], V[:,:maxrank])
+
+    The accuracy of this approximation depends on the structure of A ("low-rank" is best) and appropriate choice of parameters.
+
+    Parameters
+    ----------
+    A : DNDarray
+        2D-array (float32/64) of which the hSVD has to be computed.
+    maxrank : int
+        truncation rank.
+    full : bool, optional
+        full=True implies that also Sigma and V are computed and returned. The default is False.
+
+    'Expert' parameters
+    ----------
+
+    maxmergedim : Union[int, None], optional
+        maximal size of the concatenation matrices during the merging procedure. The default is None and results in an appropriate choice depending on the size of the local slices of A and maxrank.
+    safetyshift : int, optional
+        Increases the actual truncation rank within the computations by a safety shift. The default is 5.
+    silent : bool, optional
+        silent=False implies that some information on the computations are printed. The default is True.
+
+    Returns
+    -------
+    (Union[    Tuple[DNDarray, DNDarray, DNDarray, float], Tuple[DNDarray, DNDarray, DNDarray], DNDarray])
+        if full=True: U, Sigma, V, a-posteriori error estimate for the reconstruction error ||A-U Sigma V^T ||_F / ||A||_F (computed according to [2] along the "true" merging tree).
+        if full=False: U, a-posteriori error estimate
+
+    References
+    -------
+    [1] Iwen, Ong. A distributed and incremental SVD algorithm for agglomerative data analysis on large networks. SIAM J. Matrix Anal. Appl., 37(4), 2016.
+    [2] Himpe, Leibner, Rave. Hierarchical approximate proper orthogonal decomposition. SIAM J. Sci. Comput., 40 (5), 2018.
+    """
+    if not isinstance(A, DNDarray):
+        raise RuntimeError("Argument needs to be a DNDarray but is {}.".format(type(A)))
+    if not A.ndim == 2:
+        raise RuntimeError("A needs to be a 2D matrix")
+    if not A.dtype == types.float32 and not A.dtype == types.float64:
+        raise RuntimeError(
+            "Argument needs to be a DNDarray with datatype float32 or float64, but data type is {}.".format(
+                A.dtype
+            )
+        )
+    # if A.comm.rank == 0:
+    #     print(
+    #         "INFO: Please be aware of the fact that hiearchical SVD (hSVD) with prescribed trunction rank maxrank only yields accurate results when the underlying matrix is of low-rank structure with rank at most maxrank."
+    #     )
+    A_local_size = max(A.lshape_map[:, 1])
+
+    if maxmergedim is not None and maxmergedim < 2 * (maxrank + safetyshift) + 1:
+        raise RuntimeError(
+            "Given maxrank=%d, the choice maxmergedim=%d is too small. Please ensure maxmergedim > 2*(maxrank + safetyshift) or do not specify maxmergedim in order to work with the default value."
+            % (maxrank, maxmergedim)
+        )
+
+    if maxmergedim is None:
+        if A_local_size >= 2 * (maxrank + safetyshift):
+            maxmergedim = A_local_size
+        else:
+            maxmergedim = 2 * (maxrank + safetyshift) + 1
+            if A.comm.rank == 0:
+                print(
+                    "Warning: Given maxrank (or saftyshift) is so large that arrays of size larger than A.larray have to be dealt with on a single process. This may cause memory issues."
+                )
+
+    return hsvd(
+        A,
+        maxrank=maxrank,
+        maxmergedim=maxmergedim,
+        reltol=None,
+        safetyshift=safetyshift,
+        no_of_merges=None,
+        full=full,
+        silent=silent,
+        warnings_off=True,
+    )
+
+
+def hsvd_reltol(
+    A: DNDarray,
+    reltol: float,
+    maxrank: Union[int, None] = None,
+    maxmergedim: Union[int, None] = None,
+    safetyshift: int = 5,
+    no_of_merges: Union[int, None] = None,
+    full: bool = False,
+    silent: bool = True,
+) -> Union[
+    Tuple[DNDarray, DNDarray, DNDarray, float], Tuple[DNDarray, DNDarray, DNDarray], DNDarray
+]:
+    """
+    Hierchical SVD (hSVD) with prescribed upper bound on the relative reconstruction error.
+    If A = U diag(sigma) V^T is the true SVD of A, this routine computes an approximation for U[:,:r] (and sigma[:r], V[:,:r])
+    such that the rel. reconstruction error ||A-U[:,:r] diag(sigma[:r]) V[:,:r]^T ||_F / ||A||_F does not exceed reltol.
+
+    The accuracy of this approximation depends on the structure of A ("low-rank" is best) and appropriate choice of parameters.
+
+    Parameters
+    ----------
+    A : DNDarray
+        2D-array (float32/64) of which the hSVD has to be computed.
+    reltol : float
+        desired upper bound on the relative reconstruction error ||A-U Sigma V^T ||_F / ||A||_F. This upper bound is processed into 'local'
+        tolerances during the actual computations assuming the worst case scenario of a binary "merging tree"; therefore, the a-posteriori
+        error for the relative error using the true "merging tree" (see output) may be significantly smaller than reltol.
+        Prescription of maxrank or maxmergedim (disabled in default) can result in loss of desired precision, but can help to avoid memory issues.
+    full : bool, optional
+        full=True implies that also Sigma and V are computed and returned. The default is False.
+
+
+    'Expert' parameters
+    ------
+    no_of_merges : Union[int, None], optional
+        Maximum number of processes to be merged at each step. If no further arguments are provided (see below),
+        this completely determines the "merging tree" and may cause memory issues. The default is None and results in a binary merging tree.
+        Note that no_of_merges dominates maxrank and maxmergedim in the sense that at most no_of_merges processes are merged
+        even if maxrank and maxmergedim would allow merging more processes.
+    maxrank : Union[int, None], optional
+        maximal truncation rank. The default is None.
+        Setting at least one of maxrank and maxmergedim is recommended to avoid memory issues, but can result in loss of desired precision.
+        Setting only maxrank (and not maxmergedim) results in an appropriate default choice for maxmergedim depending on the size of the local slices of A and the value of maxrank.
+    maxmergedim : Union[int, None], optional
+        maximal size of the concatenation matrices during the merging procedure. The default is None and results in an appropriate choice depending on the size of the local slices of A and maxrank. The default is None.
+        Setting at least one of maxrank and maxmergedim is recommended to avoid memory issues, but can result in loss of desired precision.
+        Setting only maxmergedim (and not maxrank) results in an appropriate default choice for maxrank.
+    safetyshift : int, optional
+        Increases the actual truncation rank within the computations by a safety shift. The default is 5.
+    silent : bool, optional
+        silent=False implies that some information on the computations are printed. The default is True.
+
+    Returns
+    -------
+    (Union[    Tuple[DNDarray, DNDarray, DNDarray, float], Tuple[DNDarray, DNDarray, DNDarray], DNDarray])
+        if full=True: U, Sigma, V, a-posteriori error estimate for the reconstruction error ||A-U Sigma V^T ||_F / ||A||_F (computed according to [2] along the "true" merging tree used in the computations).
+        if full=False: U, a-posteriori error estimate
+
+    References
+    -------
+    [1] Iwen, Ong. A distributed and incremental SVD algorithm for agglomerative data analysis on large networks. SIAM J. Matrix Anal. Appl., 37(4), 2016.
+    [2] Himpe, Leibner, Rave. Hierarchical approximate proper orthogonal decomposition. SIAM J. Sci. Comput., 40 (5), 2018.
+    """
+    if not isinstance(A, DNDarray):
+        raise RuntimeError("Argument needs to be a DNDarray but is {}.".format(type(A)))
+    if not A.ndim == 2:
+        raise RuntimeError("A needs to be a 2D matrix")
+    if not A.dtype == types.float32 and not A.dtype == types.float64:
+        raise RuntimeError(
+            "Argument needs to be a DNDarray with datatype float32 or float64, but data type is {}.".format(
+                A.dtype
+            )
+        )
+    # if A.comm.rank == 0:
+    #     print(
+    #         "INFO: Please be aware of the fact that hiearchical SVD (hSVD) with prescribed reltol is only efficient when the rank to reach this accuracy is rather small compared to the overal matrix size. In other cases, either memory issues or loss of desired precision may occure."
+    #     )
+    A_local_size = max(A.lshape_map[:, 1])
+
+    if maxmergedim is not None and maxrank is None:
+        maxrank = floor(A_local_size / 2) - safetyshift
+        if maxrank <= 0:
+            raise RuntimeError("maxmergedim is too small or safetyshift is too large.")
+        if A.comm.rank == 0:
+            print(
+                "Warning: Prescribing maxmergedim is recommended to avoid memory issues, but may result in loss of desired precision (reltol). If this occures, a separate warning will be raised."
+            )
+
+    if maxmergedim is None and maxrank is not None:
+        if A_local_size >= 2 * (maxrank + safetyshift):
+            maxmergedim = A_local_size
+        else:
+            maxmergedim = 2 * (maxrank + safetyshift) + 1
+            if A.comm.rank == 0:
+                print(
+                    "Warning: Given maxrank (or saftyshift) is so large that arrays of size larger than A.larray have to be dealt with on a single process. This may cause memory issues."
+                )
+        if A.comm.rank == 0:
+            print(
+                "Warning: Prescribing maxrank is recommended to avoid memory issues, but may result in loss of desired precision (reltol). If this occures, a separate warning will be raised."
+            )
+
+    if (
+        maxmergedim is not None
+        and maxrank is not None
+        and maxmergedim < 2 * (maxrank + safetyshift) + 1
+    ):
+        raise RuntimeError(
+            "Given maxrank=%d, the choice maxmergedim=%d is too small. Please ensure maxmergedim > 2*(maxrank + safetyshift) or do not specify maxmergedim in order to work with the default value."
+            % (maxrank, maxmergedim)
+        )
+
+    if maxmergedim is None and maxrank is None:
+        if no_of_merges is None:
+            no_of_merges = 2
+        maxmergedim = 2 * (A.shape[1] + safetyshift) + 1
+        maxrank = A.shape[1]
+        if A.comm.rank == 0:
+            print(
+                "Warning: Prescribing only reltol and the number of processes to be merged in each step (without specifying maxrank or maxmergedim) may result in memory issues."
+            )
+
+    if no_of_merges is not None and no_of_merges < 2:
+        raise RuntimeError(
+            "It is required that no_of_merges >= 2. Please consider omitting this argument in order to use the default value."
+        )
+
+    return hsvd(
+        A,
+        maxrank=maxrank,
+        maxmergedim=maxmergedim,
+        reltol=reltol,
+        safetyshift=safetyshift,
+        no_of_merges=no_of_merges,
+        full=full,
+        silent=silent,
+        warnings_off=True,
+    )
+
+
+################################################################################################
+# hSVD - "full" routine for the experts
+################################################################################################
+
+
+def hsvd(
+    A: DNDarray,
+    maxrank: Union[int, None] = None,
+    maxmergedim: Union[int, None] = None,
+    reltol: Union[float, None] = None,
+    safetyshift: int = 0,
+    no_of_merges: Union[int, None] = None,
+    full: bool = False,
+    silent: bool = True,
+    warnings_off: bool = False,
+) -> Union[
+    Tuple[DNDarray, DNDarray, DNDarray, float], Tuple[DNDarray, DNDarray, DNDarray], DNDarray
+]:
+    """
+    This function computes an approximate truncated SVD of A utilizing a distributed hiearchical algorithm; see the references.
+    The present function `hsvd` is a low-level routine, provides many options/parameters, but no default values, and is not recommended for usage by non-experts since conflicts
+    arising from inappropriate parameter choice will not be catched. We strongly recommend to use the corresponding high-level functions `hsvd_rank` and `hsvd_reltol` instead.
+
+    Input
+    -------
+    A: DNDarray
+        2D-array (float32/64) of which hSVD has to be computed
+    maxrank: Union[int, None] = None
+        truncation rank of the SVD
+    maxmergedim: Union[int, None] = None
+        maximal size of the concatenation matrices when "merging" the local SVDs
+    reltol: Union[float, None] = None
+        upper bound on the relative reconstruction error ||A-U Sigma V^T ||_F / ||A||_F (may deteriorate due to other parameters)
+    safetyshift: int = 0
+        shift that increases the actual truncation rank of the local SVDs during the computations in order to increase accuracy
+    no_of_merges: Union[int, None] = None
+        maximum number of local SVDs to be "merged" at one step
+    full: bool = False
+        determines whether to compute U, Sigma, V (full) or not (then U only)
+    silent: bool = True
+        determines whether to print infos on the computations performed (silent=False)
+    warnings_off: bool = False
+        switch on and off warnings that are not intended for the high-level routines based on this function
+
+    Returns
+    -------
+    (Union[    Tuple[DNDarray, DNDarray, DNDarray, float], Tuple[DNDarray, DNDarray, DNDarray], DNDarray])
+        if full=True: U, Sigma, V, a-posteriori error estimate for the reconstruction error ||A-U Sigma V^T ||_F / ||A||_F (computed according to [2] along the "true" merging tree used in the computations).
+        if full=False: U, a-posteriori error estimate
+
+    References
+    -------
+    [1] Iwen, Ong. A distributed and incremental SVD algorithm for agglomerative data analysis on large networks. SIAM J. Matrix Anal. Appl., 37(4), 2016.
+    [2] Himpe, Leibner, Rave. Hierarchical approximate proper orthogonal decomposition. SIAM J. Sci. Comput., 40 (5), 2018.
+    """
+    if not warnings_off and A.comm.rank == 0:
+        print(
+            "Warning: You are using the 'expert variant' of hierarchical SVD with the maximum number of parameters to choose. Please consider using the variants hsvd_rank or hsvd_reltol with less parameters and appropriate default choices instead if you are not familar to the algorithmic details."
+        )
+
+    # if split dimension is 0, transpose matrix and remember this
+    transposeflag = False
+    if A.split == 0:
+        transposeflag = True
+        A = A.T
+
+    no_procs = A.comm.Get_size()
+
+    Anorm = vector_norm(A)
+
+    if reltol is not None:
+        loctol = Anorm.larray * reltol / sqrt(2 * no_procs - 1)
+    else:
+        loctol = None
+
+    # compute the SVDs on the 0th level
+    level = 0
+    active_nodes = [i for i in range(no_procs)]
+    if A.comm.rank == 0 and not silent:
+        print(
+            "hSVD level %d...\t" % level,
+            "processes ",
+            "\t\t".join(["%d" % an for an in active_nodes]),
+        )
+
+    U_loc, sigma_loc, err_squared_loc = compute_local_truncated_svd(
+        level, A.comm.rank, A.larray, maxrank, loctol, safetyshift
+    )
+    U_loc = torch.linalg.matmul(U_loc, torch.diag(sigma_loc))
+
+    finished = False
+    while not finished:
+        # communicate dimension of currenlty active nodes to all other nodes
+        dims_global = [0] * no_procs
+        dims_global[A.comm.rank] = U_loc.shape[1]
+        for k in range(no_procs):
+            dims_global[k] = A.comm.bcast(dims_global[k], root=k)
+
+        if A.comm.rank == 0 and not silent:
+            print(
+                "              current ranks:",
+                "\t\t".join(["%d" % dims_global[an] for an in active_nodes]),
+            )
+
+        # determine future nodes and prepare sending
+        future_nodes = [0]
+        send_to = [[]] * no_procs
+        current_idx = 0
+        current_future_node = 0
+        used_budget = 0
+        k = 0
+        counter = 0
+        while k < len(active_nodes):
+            current_idx = active_nodes[k]
+            if used_budget + dims_global[current_idx] > maxmergedim or counter == no_of_merges:
+                current_future_node = current_idx
+                future_nodes.append(current_future_node)
+                used_budget = dims_global[current_idx]
+                counter = 1
+            else:
+                if not used_budget == 0:
+                    send_to[current_idx] = current_future_node
+                used_budget += dims_global[current_idx]
+                counter += 1
+            k += 1
+
+        recv_from = [[]] * no_procs
+        for i in future_nodes:
+            recv_from[i] = [k for k in range(no_procs) if send_to[k] == i]
+
+        if A.comm.rank in future_nodes:
+            # FUTURE NODES
+            # in the future nodes receive local arrays from previous level
+            err_squared_loc = [err_squared_loc] + [
+                torch.zeros_like(err_squared_loc) for i in recv_from[A.comm.rank]
+            ]
+            U_loc = [U_loc] + [
+                torch.zeros(
+                    (A.shape[0], dims_global[i]), dtype=A.larray.dtype, device=A.device.torch_device
+                )
+                for i in recv_from[A.comm.rank]
+            ]
+            for k in range(len(recv_from[A.comm.rank])):
+                A.comm.Recv(U_loc[k + 1], recv_from[A.comm.rank][k], tag=recv_from[A.comm.rank][k])
+                A.comm.Recv(
+                    err_squared_loc[k + 1],
+                    recv_from[A.comm.rank][k],
+                    tag=2 * no_procs + recv_from[A.comm.rank][k],
+                )
+            # concatenate the received arrays
+            U_loc = torch.hstack(U_loc)
+            err_squared_loc = sum(err_squared_loc)
+            level += 1
+            if A.comm.rank == 0 and not silent:
+                print(
+                    "hSVD level %d...\t" % level,
+                    "processes ",
+                    "\t\t".join(["%d" % fn for fn in future_nodes]),
+                )
+            # compute "local" SVDs on the current level
+
+            if len(future_nodes) == 1:
+                safetyshift = 0
+            U_loc, sigma_loc, err_squared_loc_new = compute_local_truncated_svd(
+                level, A.comm.rank, U_loc, maxrank, loctol, safetyshift
+            )
+
+            if len(future_nodes) > 1:
+                # prepare next level or...
+                U_loc = torch.linalg.matmul(U_loc, torch.diag(sigma_loc))
+            err_squared_loc += err_squared_loc_new
+        elif A.comm.rank in active_nodes and A.comm.rank not in future_nodes:
+            # NOT FUTURE NODES
+            # in these nodes we only send the local arrays to the respective future node
+            A.comm.Send(U_loc, send_to[A.comm.rank], tag=A.comm.rank)
+            A.comm.Send(err_squared_loc, send_to[A.comm.rank], tag=2 * no_procs + A.comm.rank)
+
+        if len(future_nodes) == 1:
+            finished = True
+        else:
+            active_nodes = future_nodes
+
+    # After completion of the SVD, distribute the result from process 0 to all processes again
+    U_loc_shape = A.comm.bcast(U_loc.shape, root=0)
+    if A.comm.rank != 0:
+        U_loc = torch.zeros(U_loc_shape, dtype=A.larray.dtype, device=A.device.torch_device)
+    req = A.comm.Ibcast(U_loc, root=0)
+    req.Wait()
+    req = A.comm.Ibcast(err_squared_loc, root=0)
+    req.Wait()
+
+    U = factories.array(U_loc, device=A.device, split=None, comm=A.comm)
+
+    rel_error_estimate = (
+        factories.array(err_squared_loc**0.5, device=A.device, split=None, comm=A.comm) / Anorm
+    )
+
+    # Postprocessing:
+    # compute V if required or if split=0 for the input
+    # in case of split=0 undo the transposition...
+    if transposeflag or full:
+        V = matmul(A.T, U)
+        sigma = vector_norm(V, axis=0)
+        V = matmul(V, diag(1 / sigma))
+
+        if transposeflag and full:
+            return V, sigma, U, rel_error_estimate
+        elif transposeflag and not full:
+            return V, rel_error_estimate
+        else:
+            return U, sigma, V, rel_error_estimate
+        return U, rel_error_estimate
+
+    return U, rel_error_estimate
+
+
+##############################################################################################
+# AUXILIARY ROUTINES
+##############################################################################################
+
+
+def compute_local_truncated_svd(
+    level: int,
+    proc_id: int,
+    U_loc: torch.Tensor,
+    maxrank: int,
+    loctol: Union[float, None],
+    safetyshift: int,
+) -> Tuple[torch.Tensor, torch.Tensor, float]:
+    """
+    Auxiliary routine for hsvd: computes the truncated SVD of the respective local array
+    """
+    U_loc, sigma_loc, _ = torch.linalg.svd(U_loc, full_matrices=False)
+
+    if U_loc.dtype == torch.float64:
+        noiselevel = 1e-14
+    elif U_loc.dtype == torch.float32:
+        noiselevel = 1e-7
+
+    cut_noise_rank = max(torch.argwhere(sigma_loc >= noiselevel)) + 1
+
+    if loctol is None:
+        loc_trunc_rank = min(maxrank, cut_noise_rank)
+    else:
+        ideal_trunc_rank = min(
+            torch.argwhere(
+                torch.tensor(
+                    [torch.norm(sigma_loc[k:]) ** 2 for k in range(sigma_loc.shape[0] + 1)],
+                    device=U_loc.device,
+                )
+                < loctol**2
+            )
+        )
+        loc_trunc_rank = min(maxrank, ideal_trunc_rank, cut_noise_rank)
+        if loc_trunc_rank != ideal_trunc_rank:
+            print(
+                "in hSVD (level %d, process %d): abs tol = %2.2e requires truncation to rank %d, but maxrank=%d. Loss of desired precision (reltol) very likely!"
+                % (level, proc_id, loctol, ideal_trunc_rank, maxrank)
+            )
+
+    loc_trunc_rank = min(sigma_loc.shape[0], loc_trunc_rank + safetyshift)
+    err_squared_loc = torch.linalg.norm(sigma_loc[loc_trunc_rank - safetyshift :]) ** 2
+    return U_loc[:, :loc_trunc_rank], sigma_loc[:loc_trunc_rank], err_squared_loc

--- a/heat/core/linalg/tests/test_svdtools.py
+++ b/heat/core/linalg/tests/test_svdtools.py
@@ -1,0 +1,176 @@
+""" Reminder for me: To run this file go to home/heat and execute
+mpirun -np XXX python -m unittest -vf heat/core/linalg/tests/test_svdtools.py
+"""
+
+
+import torch
+import os
+import unittest
+import heat as ht
+import numpy as np
+from mpi4py import MPI
+
+from ...tests.test_suites.basic_test import TestCase
+
+
+class TestHSVD(TestCase):
+    def test_hsvd_rank(self):
+        nprocs = MPI.COMM_WORLD.Get_size()
+        test_matrices = [
+            ht.random.randn(50, 15 * nprocs, dtype=ht.float32, split=1),
+            ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=1),
+            ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=0),
+            ht.random.randn(15 * nprocs, 50, dtype=ht.float64, split=0),
+            ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=None),
+            ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=None),
+        ]
+        reltols = [1e-1, 1e-2, 1e-3]
+        ranks = [5, 10, 15]
+
+        # check if hsvd yields "reasonable" results for random matrices, i.e.
+        #    U (resp. V) is orthogonal for split=1 (resp. split=0)
+        #    hsvd_rank yields the correct rank
+        #    the true reconstruction error is <= error estimate
+        #    for hsvd_reltol: true reconstruction error <= reltol (provided no further options)
+
+        for A in test_matrices:
+            if A.dtype == ht.float64:
+                dtype_tol = 1e-12
+            if A.dtype == ht.float32:
+                dtype_tol = 1e-4
+
+            for r in ranks:
+                U, sigma, V, err_est = ht.linalg.hsvd_rank(A, r, full=True, silent=True)
+                hsvd_rk = U.shape[1]
+                self.assertEqual(hsvd_rk, r)
+                if A.split == 1:
+                    U_orth_err = (
+                        ht.norm(
+                            U.T @ U
+                            - ht.eye(hsvd_rk, dtype=U.dtype, split=U.T.split, device=U.device)
+                        )
+                        / hsvd_rk**0.5
+                    )
+                    self.assertTrue(U_orth_err <= dtype_tol)
+                if A.split == 0:
+                    V_orth_err = (
+                        ht.norm(
+                            V.T @ V
+                            - ht.eye(hsvd_rk, dtype=V.dtype, split=V.T.split, device=V.device)
+                        )
+                        / hsvd_rk**0.5
+                    )
+                    self.assertTrue(V_orth_err <= dtype_tol)
+                true_rel_err = ht.norm(U @ ht.diag(sigma) @ V.T - A) / ht.norm(A)
+                self.assertTrue(true_rel_err <= err_est)
+
+                # check if wrong parameter choice is catched
+                with self.assertRaises(RuntimeError):
+                    ht.linalg.hsvd_rank(A, r, maxmergedim=4)
+
+            for tol in reltols:
+                U, sigma, V, err_est = ht.linalg.hsvd_reltol(A, tol, full=True, silent=True)
+                hsvd_rk = U.shape[1]
+                if A.split == 1:
+                    U_orth_err = (
+                        ht.norm(
+                            U.T @ U
+                            - ht.eye(hsvd_rk, dtype=U.dtype, split=U.T.split, device=U.device)
+                        )
+                        / hsvd_rk**0.5
+                    )
+                    print(U_orth_err)
+                    self.assertTrue(U_orth_err <= dtype_tol)
+                if A.split == 0:
+                    V_orth_err = (
+                        ht.norm(
+                            V.T @ V
+                            - ht.eye(hsvd_rk, dtype=V.dtype, split=V.T.split, device=V.device)
+                        )
+                        / hsvd_rk**0.5
+                    )
+                    self.assertTrue(V_orth_err <= dtype_tol)
+                true_rel_err = ht.norm(U @ ht.diag(sigma) @ V.T - A) / ht.norm(A)
+                self.assertTrue(true_rel_err <= err_est)
+                self.assertTrue(true_rel_err <= tol)
+
+                # check if wrong parameter choices are catched
+                with self.assertRaises(RuntimeError):
+                    ht.linalg.hsvd_reltol(A, tol, maxmergedim=4)
+                with self.assertRaises(RuntimeError):
+                    ht.linalg.hsvd_reltol(A, tol, maxmergedim=10, maxrank=11)
+                with self.assertRaises(RuntimeError):
+                    ht.linalg.hsvd_reltol(A, tol, no_of_merges=1)
+
+        # check if wrong input arrays are catched
+        wrong_test_matrices = [
+            0,
+            ht.ones((15, 15 * nprocs, 15), split=1, dtype=ht.float64),
+            ht.ones(15 * nprocs, split=0, dtype=ht.float64),
+            ht.ones((50, 15 * nprocs), dtype=ht.int8, split=1),
+            ht.ones((50, 15 * nprocs), dtype=ht.int16, split=1),
+            ht.ones((50, 15 * nprocs), dtype=ht.int32, split=1),
+            ht.ones((50, 15 * nprocs), dtype=ht.int64, split=1),
+            ht.ones((50, 15 * nprocs), dtype=ht.complex64, split=1),
+            ht.ones((50, 15 * nprocs), dtype=ht.complex128, split=1),
+        ]
+
+        for A in wrong_test_matrices:
+            with self.assertRaises(RuntimeError):
+                ht.linalg.hsvd_rank(A, 5)
+            with self.assertRaises(RuntimeError):
+                ht.linalg.hsvd_rank(A, 1e-1)
+
+        # check if full=False yields the correct number of outputs (=1)
+        self.assertEqual(len(ht.linalg.hsvd_rank(test_matrices[0], 5)), 2)
+        self.assertEqual(len(ht.linalg.hsvd_reltol(test_matrices[0], 5e-1)), 2)
+
+        # check if hsvd_rank yields correct results for maxrank <= truerank
+
+        true_rk = max(10, nprocs)
+        test_matrices_low_rank = [
+            ht.utils.data.matrixgallery.random_known_rank(
+                50, 15 * nprocs, true_rk, split=1, dtype=ht.float32
+            ),
+            ht.utils.data.matrixgallery.random_known_rank(
+                50, 15 * nprocs, true_rk, split=1, dtype=ht.float32
+            ),
+            ht.utils.data.matrixgallery.random_known_rank(
+                15 * nprocs, 50, true_rk, split=0, dtype=ht.float64
+            ),
+            ht.utils.data.matrixgallery.random_known_rank(
+                15 * nprocs, 50, true_rk, split=0, dtype=ht.float64
+            ),
+        ]
+
+        for mat in test_matrices_low_rank:
+            A = mat[0]
+            if A.dtype == ht.float64:
+                dtype_tol = 1e-12
+            if A.dtype == ht.float32:
+                dtype_tol = 1e-4
+
+            for r in [true_rk, true_rk + 2]:
+                U, s, V, _ = ht.linalg.hsvd_rank(A, r, full=True)
+                V = V[:, :true_rk].resplit(V.split)
+                U = U[:, :true_rk].resplit(U.split)
+                s = s[:true_rk]
+
+                U_orth_err = (
+                    ht.norm(
+                        U.T @ U - ht.eye(true_rk, dtype=U.dtype, split=U.T.split, device=U.device)
+                    )
+                    / true_rk**0.5
+                )
+                V_orth_err = (
+                    ht.norm(
+                        V.T @ V - ht.eye(true_rk, dtype=V.dtype, split=V.T.split, device=V.device)
+                    )
+                    / true_rk**0.5
+                )
+                true_rel_err = ht.norm(U @ ht.diag(s) @ V.T - A) / ht.norm(A)
+
+                self.assertTrue(ht.norm(s - mat[1][1]) / ht.norm(mat[1][1]) <= dtype_tol)
+                self.assertTrue(U_orth_err <= dtype_tol)
+                self.assertTrue(V_orth_err <= dtype_tol)
+                self.assertTrue(true_rel_err <= dtype_tol)

--- a/heat/utils/data/matrixgallery.py
+++ b/heat/utils/data/matrixgallery.py
@@ -7,9 +7,13 @@ from ...core.dndarray import DNDarray
 from ...core.communication import Communication
 from ...core.devices import Device
 from ...core.types import datatype
-from typing import Type, Union
+from ...core.random import randn, rand
+from ...core.linalg import qr, matmul
+from ...core.manipulations import diag, sort
+from ...core.exponential import log
+from typing import Type, Union, Tuple, Callable
 
-__all__ = ["parter"]
+__all__ = ["parter", "random_known_singularvalues", "random_known_rank"]
 
 
 def parter(
@@ -59,3 +63,89 @@ def parter(
         raise ValueError("expected split value to be either {{None,0,1}}, but was {}".format(split))
 
     return 1.0 / (II - JJ + 0.5)
+
+
+def random_orthogonal(
+    m: int,
+    n: int,
+    split: Union[None, int] = None,
+    device: Union[None, str, Device] = None,
+    comm: Union[None, Communication] = None,
+    dtype: Type[datatype] = core.float32,
+) -> DNDarray:
+    """Auxiliary routine: creates a random mxn matrix with orthonormal columns
+    Caveat: this is done by QR of mxn matrices with i.i.d. normal entries, so this does not produce the uniform distribution on the orthogonal matrices...
+    """
+    if n > m:
+        raise RuntimeError("No orthogonal matrix of shape %d x %d possible." % (m, n))
+
+    # TODO: if QR does not make problems anymore, replace split=None by split=split
+    U = randn(m, n, split=None, dtype=dtype, comm=comm, device=device)
+    Q, _ = qr(U)
+
+    return Q[:, :n].resplit_(split)
+
+
+def random_known_singularvalues(
+    m: int,
+    n: int,
+    singular_values: DNDarray,
+    split: Union[None, int] = None,
+    device: Union[None, str, Device] = None,
+    comm: Union[None, Communication] = None,
+    dtype: Type[datatype] = core.float32,
+) -> Tuple[DNDarray, Tuple[DNDarray]]:
+    """
+    Creates an m x n matrix with singular values given by the entries of the input array singular_values.
+    Caveat: if the entries of singular_values are not sorted, the singular value decomposition of A is so as well....
+    The singular vectors are chosen randomly (cf. random_orthogonal)
+    """
+    if not isinstance(singular_values, DNDarray):
+        raise RuntimeError(
+            "Argument singular_values needs to be a DNDarray but is {}.".format(
+                type(singular_values)
+            )
+        )
+    if not singular_values.ndim == 1:
+        raise RuntimeError(
+            "Argument singular_values needs to be a 1D array, but dimension is {}.".format(
+                singular_values.ndim
+            )
+        )
+    if singular_values.shape[0] > min(m, n):
+        raise RuntimeError("Number of given singular values must not exceed matrix dimensions.")
+
+    r = singular_values.shape[0]
+    U = random_orthogonal(m, r, split=split, device=device, comm=comm, dtype=dtype)
+    V = random_orthogonal(n, r, split=split, device=device, comm=comm, dtype=dtype)
+
+    A = matmul(U, matmul(diag(singular_values), V.T))
+
+    return A.resplit_(split), (U, singular_values, V)
+
+
+def random_known_rank(
+    m: int,
+    n: int,
+    r: int,
+    quantile_function: Callable = lambda x: -log(x),
+    split: Union[None, int] = None,
+    device: Union[None, str, Device] = None,
+    comm: Union[None, Communication] = None,
+    dtype: Type[datatype] = core.float32,
+) -> Tuple[DNDarray, Tuple[DNDarray]]:
+    """
+    Creates a random m x n matrix with rank r.
+    This routine uses random_known_singular values with r singular randomly chosen
+    w.r.t. the distribution with quantile function given by the input quantile_function. Default yields exponential distibution with parameter lambda=1.
+    Unlike random_known_singularvalues, the singular values of the output are sorted in descending order.
+    """
+    if r > min(m, n):
+        raise RuntimeError("rank must not exceed matrix dimensions.")
+
+    singular_values = rand(r, dtype=dtype, comm=comm, device=device)
+    singular_values = sort(quantile_function(singular_values), descending=True)[0]
+
+    return random_known_singularvalues(
+        m, n, singular_values, split=split, device=device, comm=comm, dtype=dtype
+    )

--- a/heat/utils/data/tests/test_matrixgallery.py
+++ b/heat/utils/data/tests/test_matrixgallery.py
@@ -8,6 +8,17 @@ class TestMatrixgallery(TestCase):
         self.assertEqual(parter.shape, (20, 20))
         # TODO: check for singular values of the parter matrix
 
+    def __check_orthogonality(self, U):
+        U_orth_err = (
+            ht.norm(U.T @ U - ht.eye(U.shape[1], dtype=U.dtype, split=U.T.split, device=U.device))
+            / U.shape[1] ** 0.5
+        )
+        if U.dtype == ht.float64:
+            dtype_tol = 1e-12
+        if U.dtype == ht.float32:
+            dtype_tol = 1e-6
+        self.assertTrue(U_orth_err <= dtype_tol)
+
     def test_parter(self):
         parter = ht.utils.data.matrixgallery.parter(20)
         self.__check_parter(parter)
@@ -20,3 +31,58 @@ class TestMatrixgallery(TestCase):
 
         with self.assertRaises(ValueError):
             ht.utils.data.matrixgallery.parter(20, split=2, comm=ht.MPI_WORLD)
+
+    def test_random_orthogonal(self):
+        with self.assertRaises(RuntimeError):
+            ht.utils.data.matrixgallery.random_orthogonal(10, 20)
+
+        Q = ht.utils.data.matrixgallery.random_orthogonal(20, 15)
+        # Q_orth_err = ht.norm(
+        #                     Q.T @ Q
+        #                     - ht.eye(Q.shape[1], dtype=Q.dtype, split=Q.T.split, device=Q.device)
+        #                 )
+        # self.assertTrue(Q_orth_err <= 1e-6)
+        self.__check_orthogonality(Q)
+
+    def test_random_known_singularvalues(self):
+        with self.assertRaises(RuntimeError):
+            ht.utils.data.matrixgallery.random_known_singularvalues(30, 20, "abc", split=1)
+        with self.assertRaises(RuntimeError):
+            ht.utils.data.matrixgallery.random_known_singularvalues(30, 20, ht.eye(20), split=1)
+        with self.assertRaises(RuntimeError):
+            ht.utils.data.matrixgallery.random_known_singularvalues(30, 20, ht.ones(50), split=1)
+
+        svals_input = ht.ones(15)
+        A, SVD = ht.utils.data.matrixgallery.random_known_singularvalues(
+            30, 20, svals_input, split=1
+        )
+        U = SVD[0]
+        S = SVD[1]
+        V = SVD[2]
+        if A.dtype == ht.float64:
+            dtype_tol = 1e-12
+        if A.dtype == ht.float32:
+            dtype_tol = 1e-6
+        self.__check_orthogonality(U)
+        self.__check_orthogonality(V)
+        self.assertTrue(ht.allclose(S, svals_input, rtol=dtype_tol))
+        A_err = ht.norm(A - U @ ht.diag(S) @ V.T) / ht.norm(A)
+        self.assertTrue(A_err <= dtype_tol)
+
+    def test_random_known_rank(self):
+        with self.assertRaises(RuntimeError):
+            ht.utils.data.matrixgallery.random_known_rank(30, 20, 25, split=1)
+        rkinput = 15
+        A, SVD = ht.utils.data.matrixgallery.random_known_rank(30, 20, rkinput, split=1)
+        U = SVD[0]
+        S = SVD[1]
+        V = SVD[2]
+        if A.dtype == ht.float64:
+            dtype_tol = 1e-12
+        if A.dtype == ht.float32:
+            dtype_tol = 1e-6
+        self.__check_orthogonality(U)
+        self.__check_orthogonality(V)
+        self.assertTrue(S.shape[0] == rkinput)
+        A_err = ht.norm(A - U @ ht.diag(S) @ V.T) / ht.norm(A)
+        self.assertTrue(A_err <= dtype_tol)


### PR DESCRIPTION
 ## Description

Hiearchical SVD (hSVD) computes an approximate truncated SVD of $A \in \mathbb{R}^{m \times n}$ utilizing a distributed hiearchical algorithm; the truncation rank is given by $maxrank$, i.e.  if $A = U diag(\sigma) V^T$, $U \in \mathbb{R}^{m \times m}$, $V \in \mathbb{R}^{n \times n}$, $\sigma \in \mathbb{R}^{\min(m,n)}$ is the true SVD of $A$, this routine computes an approximation for $U[:,:maxrank]$ (and $sigma[:maxrank]$, $V[:,:maxrank]$).

There are three routines:
* `hsvd`: "expert" version with all parameters to be set; potential conflicts are not catched 
* `hsvd_rank`: user-friendly version with appropriate default-parameters to compute hSVD with prescribed truncation rank 
* `hsvd_reltol`: user-friendly version with appropriate default-parameters to compute hSVD with prescribed relative reconstruction accuracy 

#### Selected References:
[1] Iwen, Ong. A distributed and incremental SVD algorithm for agglomerative data analysis on large networks. SIAM J. Matrix Anal. Appl., 37(4), 2016.
[2] Himpe, Leibner, Rave. Hierarchical approximate proper orthogonal decomposition. SIAM J. Sci. Comput., 40 (5), 2018.

### Dependencies
hSVD makes use of the pytorch-SVD and MPI-communication. No dependencies on HeAT linear algebra, except for matmul. 

## Type of change

- New feature: hSVD 

## Memory requirements
TBD

## Performance
TBD


## Due Diligence
- [X] All split configurations tested
- [X] Multiple dtypes tested in relevant functions
- [X] Documentation updated (if needed)
- [X] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
no
