### PR TITLE
Fix division precision error in `random` module

### DIFF
--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -114,8 +114,8 @@ def __counter_sequence(
         raise ValueError("Shape is to big with {} elements".format(total_elements))
 
     if split is None:
-        values = torch.ceil(total_elements / 2)
-        even_end = total_elements % 2 == 0
+        values = total_elements.item() // 2 + total_elements.item() % 2
+        even_end = total_elements.item() % 2 == 0
         lslice = slice(None) if even_end else slice(None, -1)
         start = c_1
         end = start + int(values)

--- a/heat/core/random.py
+++ b/heat/core/random.py
@@ -125,7 +125,7 @@ def __counter_sequence(
         counts, displs, _ = comm.counts_displs_shape(shape, split)
 
         # Calculate number of local elements per process
-        local_elements = [total_elements / shape[split] * counts[i] for i in range(size)]
+        local_elements = [total_elements.item() / shape[split] * counts[i] for i in range(size)]
         cum_elements = torch.cumsum(torch.tensor(local_elements, device=device.torch_device), dim=0)
 
         # Calculate the correct borders and slices

--- a/heat/core/tests/test_random.py
+++ b/heat/core/tests/test_random.py
@@ -230,6 +230,11 @@ class TestRandom(TestCase):
         self.assertFalse(np.array_equal(a, c))
         self.assertFalse(np.array_equal(b, c))
 
+        # To check working with large number of elements
+        ht.random.randn(6667, 3523, dtype=ht.float64, split=None)
+        ht.random.randn(6667, 3523, dtype=ht.float64, split=0)
+        ht.random.randn(6667, 3523, dtype=ht.float64, split=1)
+
     def test_randint(self):
         # Checked that the random values are in the correct range
         a = ht.random.randint(low=0, high=10, size=(10, 10), dtype=ht.int64)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
_**Copied over from issue 1076**_
Apparently, torch has some precision problems during division. The division operation, that takes place when the number of elements in each process is calculated, causes some problem.

**Code:**
```
import torch
print(f"Number of elements in tensor: 6667*3523={23487841}")
print(23487841/3523)
print(torch.tensor(23487841)/3523)
```

**Output:**
```
Number of elements in tensor: 6667*3523=23487841
6667.0
tensor(6666.9995)
```

This small precision error is blown up when the number of elements is huge. That's probably why the tests did not catch the bug because the number of elements were small enough.

Issue/s resolved: #1076 

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
Bug fix

## Due Diligence
- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [ ] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
no
