### PR TITLE
Fix #1085: Convolve with distributed kernel on multiple GPUs

### DIFF
--- a/heat/core/signal.py
+++ b/heat/core/signal.py
@@ -156,7 +156,8 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
         size = v.comm.size
 
         for r in range(size):
-            rec_v = v.comm.Bcast(t_v, root=r)
+            rec_v = t_v.clone()
+            v.comm.Bcast(rec_v, root=r)
             t_v1 = rec_v.reshape(1, 1, rec_v.shape[0])
             local_signal_filtered = fc.conv1d(signal, t_v1)
             # unpack 3D result into 1D

--- a/heat/core/signal.py
+++ b/heat/core/signal.py
@@ -156,7 +156,7 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
         size = v.comm.size
 
         for r in range(size):
-            rec_v = v.comm.bcast(t_v, root=r)
+            rec_v = v.comm.Bcast(t_v, root=r)
             t_v1 = rec_v.reshape(1, 1, rec_v.shape[0])
             local_signal_filtered = fc.conv1d(signal, t_v1)
             # unpack 3D result into 1D


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Issue resolved: #1085 
Convolve is not working with multiple gpus with distributed kernel.

## Changes proposed:
- bcast --> Bcast

## Type of change
- Bug fix 
<!--
i.e.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->


## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
no
