### PR TITLE
Work-around for pre-commit ci failure

### DIFF
--- a/heat/nn/data_parallel.py
+++ b/heat/nn/data_parallel.py
@@ -251,8 +251,8 @@ class DataParallel(tnn.Module):
         param_name : str
             Name of the parameter
         """
-
         # hook function for blocking gradient data exchange
+
         def _hook(grad_loc: torch.Tensor) -> torch.Tensor:
             with torch.no_grad():
                 wrk = grad_loc.to(torch.float)  # bfloat16)
@@ -288,8 +288,8 @@ class DataParallel(tnn.Module):
         layer_name : str
             Name of the layer
         """
-
         # hook function for non-blocking parameter update
+
         def _hook(_, input_):
             # update parameters of given layer
             param_slice = self._param_slices[layer_name]


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Black and Pydocstyle have conflicting requirements of code style. Probably due to the [new release of black](https://black.readthedocs.io/en/stable/change_log.html#id3). Found a work-around in [this comment](https://www.github.com/PyCQA/pydocstyle/issues/361#issuecomment-834166047). 
![image](https://user-images.githubusercontent.com/73862377/218516203-934b79e8-4d1c-41be-a55c-7975e21b8d1f.png)
black wants an empty line before the internal function. pydocstyle does not want an empty line after docstring. 
