### PR TITLE
add workflows for PRs

### DIFF
--- a/.github/workflows/CommentPR.yml
+++ b/.github/workflows/CommentPR.yml
@@ -1,0 +1,68 @@
+name: Comment on the pull request
+
+on:
+  workflow_run:
+    workflows: ["Receive PR"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      PR_NR: ${{ steps.step1.outputs.test }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip pr_number.zip
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let fs = require('fs');
+            let issue_number = Number(fs.readFileSync('./pr_number'));
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: 'Thank you for the PR!'
+            });
+      - id: step1
+        run: echo "test=$(< ./pr_number)" >> "$GITHUB_OUTPUT"
+
+  push:
+    needs: upload
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Push branch'
+        run: |
+          git fetch origin pull/${{ needs.upload.outputs.PR_NR }}/head:${{ needs.upload.outputs.PR_NR }}
+          git checkout ${{ needs.upload.outputs.PR_NR }}
+          git push --repo=${{ secrets.CB_REPO }}

--- a/.github/workflows/CommentPR.yml
+++ b/.github/workflows/CommentPR.yml
@@ -63,6 +63,6 @@ jobs:
 
       - name: 'Push branch'
         run: |
-          git fetch origin pull/${{ needs.upload.outputs.PR_NR }}/head:${{ needs.upload.outputs.PR_NR }}
-          git checkout ${{ needs.upload.outputs.PR_NR }}
+          git fetch origin pull/${{ needs.upload.outputs.PR_NR }}/head:pr/${{ needs.upload.outputs.PR_NR }}
+          git checkout pr/${{ needs.upload.outputs.PR_NR }}
           git push --repo=${{ secrets.CB_REPO }}

--- a/.github/workflows/ReceivePR.yml
+++ b/.github/workflows/ReceivePR.yml
@@ -1,0 +1,39 @@
+name: Receive PR
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          architecture: x64
+
+      - name: Setup MPI
+        uses: mpi4py/setup-mpi@v1
+        with:
+          mpi: openmpi
+
+      - name: Test
+        run: |
+          pip install .[dev]
+          pre-commit run --all-files
+          python -m unittest
+
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/

--- a/.github/workflows/ReceivePR.yml
+++ b/.github/workflows/ReceivePR.yml
@@ -2,6 +2,8 @@ name: Receive PR
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 jobs:
   build:

--- a/.github/workflows/ci_cb.yml
+++ b/.github/workflows/ci_cb.yml
@@ -1,6 +1,10 @@
-name: Mirror and run GitLab CI
+name: CI run
 
-on: [push]
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release/**'
 
 jobs:
   build:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 test:
-  image: nvidia/cuda:11.7.1-runtime-ubuntu22.04
+  image: nvcr.io/nvidia/pytorch:22.11-py3
   tags:
     - cuda
     - x86_64
@@ -7,10 +7,7 @@ test:
     - apt update
     - apt -y install build-essential python3-pip curl git
     - "curl -X POST -H \"Accept: application/vnd.github+json\" -H \"Authorization: Bearer $GITHUB_TOKEN\" -H \"X-GitHub-Api-Version: 2022-11-28\" https://api.github.com/repos/helmholtz-analytics/heat/statuses/$CI_COMMIT_SHA -d '{\"state\":\"pending\",\"target_url\":\"https://codebase.helmholtz.cloud/haf/heat/-/jobs/$CI_JOB_ID\",\"description\":\"The build runs!\",\"context\":\"continuous-integration/codebase\"}'\n"
-    - DEBIAN_FRONTEND=noninteractive apt -y install libopenmpi-dev openmpi-bin openmpi-doc
-    - apt -y install libhdf5-openmpi-dev libpnetcdf-dev
     - pip install pytest coverage
-    - pip3 install torch torchvision torchaudio
     - pip install .[hdf5,netcdf]
     - COVERAGE_FILE=report/cov/coverage1 HEAT_TEST_USE_DEVICE=cpu mpirun --allow-run-as-root -n 1 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report1.xml heat/
     - COVERAGE_FILE=report/cov/coverage2 HEAT_TEST_USE_DEVICE=cpu mpirun --allow-run-as-root -n 2 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report2.xml heat/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,13 +6,14 @@ test:
   script:
     - apt update
     - apt -y install build-essential python3-pip curl git
+    - "curl -X POST -H \"Accept: application/vnd.github+json\" -H \"Authorization: Bearer $GITHUB_TOKEN\" -H \"X-GitHub-Api-Version: 2022-11-28\" https://api.github.com/repos/helmholtz-analytics/heat/statuses/$CI_COMMIT_SHA -d '{\"state\":\"pending\",\"target_url\":\"https://codebase.helmholtz.cloud/haf/heat/-/jobs/$CI_JOB_ID\",\"description\":\"The build runs!\",\"context\":\"continuous-integration/codebase\"}'\n"
     - DEBIAN_FRONTEND=noninteractive apt -y install libopenmpi-dev openmpi-bin openmpi-doc
     - apt -y install libhdf5-openmpi-dev libpnetcdf-dev
     - pip install pytest coverage
     - pip3 install torch torchvision torchaudio
     - pip install .[hdf5,netcdf]
-    - COVERAGE_FILE=report/cov/coverage1 HEAT_TEST_USE_DEVICE=cpu mpirun --allow-run-as-root -n 1 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report1.xml heat/
-    - COVERAGE_FILE=report/cov/coverage2 HEAT_TEST_USE_DEVICE=gpu mpirun --allow-run-as-root -n 3 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report3.xml heat/
+    - COVERAGE_FILE=report/cov/coverage2 HEAT_TEST_USE_DEVICE=cpu mpirun --allow-run-as-root -n 2 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report2.xml heat/
+    - COVERAGE_FILE=report/cov/coverage3 HEAT_TEST_USE_DEVICE=gpu mpirun --allow-run-as-root -n 3 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report3.xml heat/
     - COVERAGE_FILE=report/cov/coverage5 HEAT_TEST_USE_DEVICE=cpu mpirun --allow-run-as-root -n 5 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report5.xml heat/
     - COVERAGE_FILE=report/cov/coverage8 HEAT_TEST_USE_DEVICE=gpu mpirun --allow-run-as-root -n 6 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report6.xml heat/
     - coverage combine report/cov/*
@@ -21,6 +22,13 @@ test:
     - curl -Os https://uploader.codecov.io/latest/linux/codecov
     - chmod +x codecov
     - ./codecov -F unit -f ./coverage.xml -t $CODECOV_TOKEN -Z
+  after_script:
+    - |
+      case $CI_JOB_STATUS in
+        'success') curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/helmholtz-analytics/heat/statuses/$CI_COMMIT_SHA -d '{"state":"success","target_url":"https://codebase.helmholtz.cloud/haf/heat/-/jobs/$CI_JOB_ID","description":"The build succeeded!","context":"continuous-integration/codebase"}';;
+        'failed') curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/helmholtz-analytics/heat/statuses/$CI_COMMIT_SHA -d '{"state":"failure","target_url":"https://codebase.helmholtz.cloud/haf/heat/-/jobs/$CI_JOB_ID","description":"The build failed!","context":"continuous-integration/codebase"}';;
+        *) curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/helmholtz-analytics/heat/statuses/$CI_COMMIT_SHA -d '{"state":"error","target_url":"https://codebase.helmholtz.cloud/haf/heat/-/jobs/$CI_JOB_ID","description":"The build errored!","context":"continuous-integration/codebase"}';;
+      esac
   artifacts:
     when: always
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ test:
     - pip install pytest coverage
     - pip3 install torch torchvision torchaudio
     - pip install .[hdf5,netcdf]
+    - COVERAGE_FILE=report/cov/coverage1 HEAT_TEST_USE_DEVICE=cpu mpirun --allow-run-as-root -n 1 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report1.xml heat/
     - COVERAGE_FILE=report/cov/coverage2 HEAT_TEST_USE_DEVICE=cpu mpirun --allow-run-as-root -n 2 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report2.xml heat/
     - COVERAGE_FILE=report/cov/coverage3 HEAT_TEST_USE_DEVICE=gpu mpirun --allow-run-as-root -n 3 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report3.xml heat/
     - COVERAGE_FILE=report/cov/coverage5 HEAT_TEST_USE_DEVICE=cpu mpirun --allow-run-as-root -n 5 coverage run --source=heat --parallel-mode -m pytest --junitxml=report/test/report5.xml heat/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Heat is a distributed tensor framework for high performance data analytics.
 # Project Status
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2531472.svg)](https://doi.org/10.5281/zenodo.2531472)
-[![Mirror and run GitLab CI](https://github.com/helmholtz-analytics/heat/actions/workflows/ci_cb.yml/badge.svg)](https://github.com/helmholtz-analytics/heat/actions/workflows/ci_cb.yml)
+[![CI workflow](https://github.com/helmholtz-analytics/heat/actions/workflows/ci_cb.yml/badge.svg)](https://github.com/helmholtz-analytics/heat/actions/workflows/ci_cb.yml)
 [![Documentation Status](https://readthedocs.org/projects/heat/badge/?version=latest)](https://heat.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/helmholtz-analytics/heat/branch/main/graph/badge.svg)](https://codecov.io/gh/helmholtz-analytics/heat)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -55,11 +55,8 @@ computational and memory needs of your laptop and desktop.
 
 # Support Channels
 
-We use [StackOverflow](https://stackoverflow.com/tags/pyheat/) as a forum for questions about Heat.
-If you do not find an answer to your question, then please ask a new question there and be sure to
-tag it with "pyheat".
-
-You can also reach us on [GitHub Discussions](https://github.com/helmholtz-analytics/heat/discussions).
+We use [GitHub Discussions](https://github.com/helmholtz-analytics/heat/discussions) as a forum for questions about Heat.
+If you found a bug or miss a feature, then please file a new [issue](https://github.com/helmholtz-analytics/heat/issues/new/choose).
 
 # Requirements
 


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Adds workflows that get activated when a new PR is created. Runs a unit test on a single process and returns a message on success. The local PR branch is then send to the mirrored repository.

Pushes on the main and release branches are mirrored only to avoid double testing of branches/PR on the upstream repository.

Issue/s resolved: #1113 

## Changes proposed:
- add workflows for PRs
- update existing workflow for mirroring

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- workflow update