### PR TITLE
Fix `main` after merging `release/1.2.x`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,7 +46,7 @@ my be illegible. It may be easiest to save the output of each to a file.
 - [ ] All split configurations tested
 - [ ] Multiple dtypes tested in relevant functions
 - [ ] Documentation updated (if needed)
-- [ ] Updated changelog.md under the title "Pending Additions"
+- [ ] Title of PR is suitable for corresponding CHANGELOG entry
 
 #### Does this change modify the behaviour of other functions? If so, which?
 yes / no

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,6 +24,8 @@ categories:
     label: 'manipulation'
   - title: 'Random'
     label: 'random'
+  - title: 'Sparse'
+    label: 'sparse'
   - title: 'Google Summer of Code 2022'
     label: 'GSoC22'
   - title: '💯 Benchmarking'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,13 +30,13 @@ jobs:
     name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}; options ${{ matrix.install-options }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup MPI
         uses: mpi4py/setup-mpi@v1
         with:
           mpi: ${{ matrix.mpi }}
       - name: Use Python ${{ matrix.py-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py-version }}
           architecture: x64

--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -1,3 +1,5 @@
+# This workflow was added by CodeSee. Learn more at https://codesee.io/
+# This is v2.0 of this workflow file
 on:
   push:
     branches:
@@ -5,77 +7,16 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-name: CodeSee Map
+name: CodeSee
+
+permissions: read-all
 
 jobs:
-  test_map_action:
+  codesee:
     runs-on: ubuntu-latest
     continue-on-error: true
-    name: Run CodeSee Map Analysis
+    name: Analyze the repo with CodeSee
     steps:
-      - name: checkout
-        id: checkout
-        uses: actions/checkout@v2
+      - uses: Codesee-io/codesee-action@v2
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-
-      # codesee-detect-languages has an output with id languages.
-      - name: Detect Languages
-        id: detect-languages
-        uses: Codesee-io/codesee-detect-languages-action@latest
-
-      - name: Configure JDK 16
-        uses: actions/setup-java@v2
-        if: ${{ fromJSON(steps.detect-languages.outputs.languages).java }}
-        with:
-          java-version: '16'
-          distribution: 'zulu'
-
-      # CodeSee Maps Go support uses a static binary so there's no setup step required.
-
-      - name: Configure Node.js 14
-        uses: actions/setup-node@v2
-        if: ${{ fromJSON(steps.detect-languages.outputs.languages).javascript }}
-        with:
-          node-version: '14'
-
-      - name: Configure Python 3.x
-        uses: actions/setup-python@v2
-        if: ${{ fromJSON(steps.detect-languages.outputs.languages).python }}
-        with:
-          python-version: '3.10'
-          architecture: 'x64'
-
-      - name: Configure Ruby '3.x'
-        uses: ruby/setup-ruby@v1
-        if: ${{ fromJSON(steps.detect-languages.outputs.languages).ruby }}
-        with:
-          ruby-version: '3.0'
-
-      # CodeSee Maps Rust support uses a static binary so there's no setup step required.
-
-      - name: Generate Map
-        id: generate-map
-        uses: Codesee-io/codesee-map-action@latest
-        with:
-          step: map
-          github_ref: ${{ github.ref }}
-          languages: ${{ steps.detect-languages.outputs.languages }}
-
-      - name: Upload Map
-        id: upload-map
-        uses: Codesee-io/codesee-map-action@latest
-        with:
-          step: mapUpload
-          api_token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
-          github_ref: ${{ github.ref }}
-
-      - name: Insights
-        id: insights
-        uses: Codesee-io/codesee-map-action@latest
-        with:
-          step: insights
-          api_token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
-          github_ref: ${{ github.ref }}
+          codesee-token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,72 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '37 10 * * 5'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@807578363a7869ca324a79039e6db9c843e0e100 # v2.1.27
+        with:
+          sarif_file: results.sarif

--- a/heat/__init__.py
+++ b/heat/__init__.py
@@ -14,6 +14,6 @@ from . import naive_bayes
 from . import nn
 from . import optim
 from . import regression
-from . import spatial
 from . import sparse
+from . import spatial
 from . import utils

--- a/heat/__init__.py
+++ b/heat/__init__.py
@@ -15,4 +15,5 @@ from . import nn
 from . import optim
 from . import regression
 from . import spatial
+from . import sparse
 from . import utils

--- a/heat/core/_operations.py
+++ b/heat/core/_operations.py
@@ -1,6 +1,4 @@
-"""
-Generalized MPI operations. i.e. element-wise binary operations
-"""
+"""Generalized operations for DNDarray"""
 
 import builtins
 import numpy as np

--- a/heat/core/communication.py
+++ b/heat/core/communication.py
@@ -159,7 +159,12 @@ class MPICommunication(Communication):
         return self.size > 1
 
     def chunk(
-        self, shape: Tuple[int], split: int, rank: int = None, w_size: int = None
+        self,
+        shape: Tuple[int],
+        split: int,
+        rank: int = None,
+        w_size: int = None,
+        sparse: bool = False,
     ) -> Tuple[int, Tuple[int], Tuple[slice]]:
         """
         Calculates the chunk of data that will be assigned to this compute node given a global data shape and a split
@@ -179,7 +184,8 @@ class MPICommunication(Communication):
         w_size : int, optional
             The MPI world size, defaults to ``self.size``.
             Intended for creating chunk maps without communication
-
+        sparse : bool, optional
+            Specifies whether the array is a sparse matrix
         """
         # ensure the split axis is valid, we actually do not need it
         split = sanitize_axis(shape, split)
@@ -201,6 +207,9 @@ class MPICommunication(Communication):
         else:
             start = rank * chunk + remainder
         end = start + chunk
+
+        if sparse:
+            return start, end
 
         return (
             start,

--- a/heat/core/devices.py
+++ b/heat/core/devices.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import torch
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from . import communication
 
@@ -73,6 +73,22 @@ class Device:
         Return the descriptive information of :class:`~heat.core.device.Device`.
         """
         return "{}:{}".format(self.device_type, self.device_id)
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Overloads the `==` operator for local equal check.
+
+        Parameters
+        ----------
+        other : Any
+            The object to compare with
+        """
+        if isinstance(other, Device):
+            return self.device_type == other.device_type and self.device_id == other.device_id
+        elif isinstance(other, torch.device):
+            return self.device_type == other.type and self.device_id == other.index
+        else:
+            return NotImplemented
 
 
 # create a CPU device singleton

--- a/heat/core/signal.py
+++ b/heat/core/signal.py
@@ -16,6 +16,7 @@ __all__ = ["convolve"]
 def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
     """
     Returns the discrete, linear convolution of two one-dimensional `DNDarray`s or scalars.
+
     Parameters
     ----------
     a : DNDarray or scalar
@@ -38,10 +39,12 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
           convolution product is only given for points where the signals
           overlap completely. Values outside the signal boundary have no
           effect.
+
     Examples
     --------
     Note how the convolution operator flips the second array
     before "sliding" the two across one another:
+
     >>> a = ht.ones(10)
     >>> v = ht.arange(3).astype(ht.float)
     >>> ht.convolve(a, v, mode='full')
@@ -54,6 +57,7 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
     >>> v = ht.arange(3, split = 0).astype(ht.float)
     >>> ht.convolve(a, v, mode='valid')
     DNDarray([3., 3., 3., 3., 3., 3., 3., 3.])
+
     [0/3] DNDarray([3., 3., 3.])
     [1/3] DNDarray([3., 3., 3.])
     [2/3] DNDarray([3., 3.])
@@ -61,6 +65,7 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
     >>> v = ht.arange(3, split = 0)
     >>> ht.convolve(a, v)
     DNDarray([0., 1., 3., 3., 3., 3., 3., 3., 3., 3., 3., 2.], dtype=ht.float32, device=cpu:0, split=0)
+
     [0/3] DNDarray([0., 1., 3., 3.])
     [1/3] DNDarray([3., 3., 3., 3.])
     [2/3] DNDarray([3., 3., 3., 2.])

--- a/heat/core/tests/test_signal.py
+++ b/heat/core/tests/test_signal.py
@@ -20,59 +20,94 @@ class TestSignal(TestCase):
             [0, 1, 3, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46, 50, 54, 42, 29, 15]
         ).astype(ht.int)
 
-        signal = ht.arange(0, 16, split=0).astype(ht.int)
+        dis_signal = ht.arange(0, 16, split=0).astype(ht.int)
+        signal = ht.arange(0, 16).astype(ht.int)
+        full_ones = ht.ones(7, split=0).astype(ht.int)
         kernel_odd = ht.ones(3).astype(ht.int)
         kernel_even = [1, 1, 1, 1]
+        dis_kernel_odd = ht.ones(3, split=0).astype(ht.int)
+        dis_kernel_even = ht.ones(4, split=0).astype(ht.int)
 
         with self.assertRaises(TypeError):
             signal_wrong_type = [0, 1, 2, "tre", 4, "five", 6, "ʻehiku", 8, 9, 10]
             ht.convolve(signal_wrong_type, kernel_odd, mode="full")
         with self.assertRaises(TypeError):
             filter_wrong_type = [1, 1, "pizza", "pineapple"]
-            ht.convolve(signal, filter_wrong_type, mode="full")
+            ht.convolve(dis_signal, filter_wrong_type, mode="full")
         with self.assertRaises(ValueError):
-            ht.convolve(signal, kernel_odd, mode="invalid")
+            ht.convolve(dis_signal, kernel_odd, mode="invalid")
         with self.assertRaises(ValueError):
-            s = signal.reshape((2, -1))
+            s = dis_signal.reshape((2, -1))
             ht.convolve(s, kernel_odd)
         with self.assertRaises(ValueError):
             k = ht.eye(3)
-            ht.convolve(signal, k)
+            ht.convolve(dis_signal, k)
         with self.assertRaises(ValueError):
-            ht.convolve(kernel_even, full_even)
-        with self.assertRaises(ValueError):
-            ht.convolve(signal, kernel_even, mode="same")
+            ht.convolve(dis_signal, kernel_even, mode="same")
         if self.comm.size > 1:
-            with self.assertRaises(TypeError):
-                k = ht.ones(4, split=0).astype(ht.int)
-                ht.convolve(signal, k)
-        if self.comm.size >= 5:
             with self.assertRaises(ValueError):
-                ht.convolve(signal, kernel_even, mode="valid")
+                ht.convolve(full_ones, kernel_even, mode="valid")
+            with self.assertRaises(ValueError):
+                ht.convolve(kernel_even, full_ones, mode="valid")
+        if self.comm.size > 5:
+            with self.assertRaises(ValueError):
+                ht.convolve(dis_signal, kernel_even)
 
         # test modes, avoid kernel larger than signal chunk
         if self.comm.size <= 3:
             modes = ["full", "same", "valid"]
             for i, mode in enumerate(modes):
                 # odd kernel size
-                conv = ht.convolve(signal, kernel_odd, mode=mode)
+                conv = ht.convolve(dis_signal, kernel_odd, mode=mode)
                 gathered = manipulations.resplit(conv, axis=None)
                 self.assertTrue(ht.equal(full_odd[i : len(full_odd) - i], gathered))
+
+                conv = ht.convolve(dis_signal, dis_kernel_odd, mode=mode)
+                gathered = manipulations.resplit(conv, axis=None)
+                self.assertTrue(ht.equal(full_odd[i : len(full_odd) - i], gathered))
+
+                conv = ht.convolve(signal, dis_kernel_odd, mode=mode)
+                gathered = manipulations.resplit(conv, axis=None)
+                self.assertTrue(ht.equal(full_odd[i : len(full_odd) - i], gathered))
+
                 # different data types
-                conv = ht.convolve(signal.astype(ht.float), kernel_odd)
+                conv = ht.convolve(dis_signal.astype(ht.float), kernel_odd)
+                gathered = manipulations.resplit(conv, axis=None)
+                self.assertTrue(ht.equal(full_odd.astype(ht.float), gathered))
+
+                conv = ht.convolve(dis_signal.astype(ht.float), dis_kernel_odd)
+                gathered = manipulations.resplit(conv, axis=None)
+                self.assertTrue(ht.equal(full_odd.astype(ht.float), gathered))
+
+                conv = ht.convolve(signal.astype(ht.float), dis_kernel_odd)
                 gathered = manipulations.resplit(conv, axis=None)
                 self.assertTrue(ht.equal(full_odd.astype(ht.float), gathered))
 
                 # even kernel size
                 # skip mode 'same' for even kernels
                 if mode != "same":
-                    conv = ht.convolve(signal, kernel_even, mode=mode)
+                    conv = ht.convolve(dis_signal, kernel_even, mode=mode)
+                    dis_conv = ht.convolve(dis_signal, dis_kernel_even, mode=mode)
                     gathered = manipulations.resplit(conv, axis=None)
+                    dis_gathered = manipulations.resplit(dis_conv, axis=None)
 
                     if mode == "full":
                         self.assertTrue(ht.equal(full_even, gathered))
+                        self.assertTrue(ht.equal(full_even, dis_gathered))
                     else:
                         self.assertTrue(ht.equal(full_even[3:-3], gathered))
+                        self.assertTrue(ht.equal(full_even[3:-3], dis_gathered))
+
+                # distributed large signal and kernel
+                np.random.seed(12)
+                np_a = np.random.randint(1000, size=4418)
+                np_b = np.random.randint(1000, size=1543)
+                np_conv = np.convolve(np_a, np_b, mode=mode)
+
+                a = ht.array(np_a, split=0, dtype=ht.int32)
+                b = ht.array(np_b, split=0, dtype=ht.int32)
+                conv = ht.convolve(a, b, mode=mode)
+                self.assert_array_equal(conv, np_conv)
 
         # test edge cases
         # non-distributed signal, size-1 kernel
@@ -81,3 +116,6 @@ class TestSignal(TestCase):
         kernel = ht.ones(1).astype(ht.int)
         conv = ht.convolve(alt_signal, kernel)
         self.assertTrue(ht.equal(signal, conv))
+
+        conv = ht.convolve(1, 5)
+        self.assertTrue(ht.equal(ht.array([5]), conv))

--- a/heat/sparse/__init__.py
+++ b/heat/sparse/__init__.py
@@ -1,0 +1,7 @@
+"""add sparse heat function to the ht.sparse namespace"""
+
+from .arithmetics import *
+from .dcsr_matrix import *
+from .factories import *
+from ._operations import *
+from .manipulations import *

--- a/heat/sparse/_operations.py
+++ b/heat/sparse/_operations.py
@@ -1,0 +1,168 @@
+"""Generalized operations for DCSR_matrix"""
+import torch
+import numpy as np
+
+from heat.sparse.dcsr_matrix import DCSR_matrix
+
+from . import factories
+from ..core.communication import MPI
+from ..core.dndarray import DNDarray
+from ..core import types
+
+from typing import Callable, Optional, Dict
+
+__all__ = []
+
+
+def __binary_op_csr(
+    operation: Callable,
+    t1: DCSR_matrix,
+    t2: DCSR_matrix,
+    out: Optional[DCSR_matrix] = None,
+    fn_kwargs: Optional[Dict] = {},
+) -> DCSR_matrix:
+    """
+    Generic wrapper for element-wise binary operations of two operands.
+    Takes the operation function and the two operands involved in the operation as arguments.
+
+    Parameters
+    ----------
+    operation : PyTorch function
+        The operation to be performed. Function that performs operation elements-wise on the involved tensors,
+        e.g. add values from other to self
+    t1: DCSR_matrix
+        The first operand involved in the operation.
+    t2: DCSR_matrix
+        The second operand involved in the operation.
+    out: DCSR_matrix, optional
+        Output buffer in which the result is placed. If not provided, a freshly allocated matrix is returned.
+    fn_kwargs: Dict, optional
+        keyword arguments used for the given operation
+        Default: {} (empty dictionary)
+
+    Returns
+    -------
+    result: ht.sparse.DCSR_matrix
+        A DCSR_matrix containing the results of element-wise operation.
+    """
+    if not np.isscalar(t1) and not isinstance(t1, DCSR_matrix):
+        raise TypeError(
+            f"Only Dcsr_matrices and numeric scalars are supported, but input was {type(t1)}"
+        )
+    if not np.isscalar(t2) and not isinstance(t2, DCSR_matrix):
+        raise TypeError(
+            f"Only Dcsr_matrices and numeric scalars are supported, but input was {type(t2)}"
+        )
+
+    if not isinstance(t1, DCSR_matrix) and not isinstance(t2, DCSR_matrix):
+        raise TypeError(
+            f"Operator only to be used with Dcsr_matrices, but input types were {type(t1)} and {type(t2)}"
+        )
+
+    promoted_type = types.result_type(t1, t2).torch_type()
+
+    # If one of the inputs is a scalar
+    # just perform the operation on the data tensor
+    # and create a new sparse matrix
+    if np.isscalar(t1) or np.isscalar(t2):
+        matrix = t1
+        scalar = t2
+
+        if np.isscalar(t1):
+            matrix = t2
+            scalar = t1
+
+        res_values = operation(matrix.larray.values().to(promoted_type), scalar, **fn_kwargs)
+        res_torch_sparse_csr = torch.sparse_csr_tensor(
+            matrix.lindptr,
+            matrix.lindices,
+            res_values,
+            size=matrix.lshape,
+            device=matrix.device.torch_device,
+        )
+        return factories.sparse_csr_matrix(
+            res_torch_sparse_csr, is_split=matrix.split, comm=matrix.comm, device=matrix.device
+        )
+
+    if t1.shape != t2.shape:
+        raise ValueError(
+            f"Dcsr_matrices of different shapes are not supported, but input shapes were {t1.shape} and {t2.shape}"
+        )
+    output_shape = t1.shape
+
+    if t1.split is not None or t2.split is not None:
+        if t1.split is None:
+            t1 = factories.sparse_csr_matrix(t1.larray, split=0)
+
+        if t2.split is None:
+            t2 = factories.sparse_csr_matrix(t2.larray, split=0)
+
+    output_split = t1.split
+    output_device = t1.device
+    output_comm = t1.comm
+    output_balanced = t1.balanced
+    output_lshape = t1.lshape
+
+    # sanitize out buffer
+    if out is not None:
+        if out.shape != output_shape:
+            raise ValueError(
+                f"Output buffer shape is not compatible with the result. Expected {output_shape}, received {out.shape}"
+            )
+
+        if out.split != output_split:
+            if out.split is None:
+                out = factories.sparse_csr_matrix(out.larray, split=0)
+            else:
+                out = factories.sparse_csr_matrix(
+                    torch.sparse_csr_tensor(
+                        torch.tensor(out.indptr, dtype=torch.int64),
+                        torch.tensor(out.indices, dtype=torch.int64),
+                        torch.tensor(out.data),
+                    )
+                )
+
+        out.device = output_device
+        out.balanced = (
+            output_balanced  # At this point, inputs and out buffer assumed to be balanced
+        )
+
+    # If there are no non-zero elements in either tensors, skip torch operation to
+    #   1. Avoid unnecessary computation
+    #   2. Avoid undefined behaviour when no data in process
+    if t1.lnnz == 0 and t2.lnnz == 0:
+        result = t1.larray
+    else:
+        result = operation(t1.larray.to(promoted_type), t2.larray.to(promoted_type), **fn_kwargs)
+
+    if output_split is not None:
+        output_gnnz = torch.tensor(result._nnz())
+        output_comm.Allreduce(MPI.IN_PLACE, output_gnnz, MPI.SUM)
+        output_gnnz = output_gnnz.item()
+    else:
+        output_gnnz = torch.tensor(result._nnz())
+
+    output_type = types.canonical_heat_type(result.dtype)
+
+    if out is None:
+        return DCSR_matrix(
+            array=torch.sparse_csr_tensor(
+                result.crow_indices().to(torch.int64),
+                result.col_indices().to(torch.int64),
+                result.values(),
+                size=output_lshape,
+            ),
+            gnnz=output_gnnz,
+            gshape=output_shape,
+            dtype=output_type,
+            split=output_split,
+            device=output_device,
+            comm=output_comm,
+            balanced=output_balanced,
+        )
+
+    out.larray.copy_(result)
+    out.gnnz = output_gnnz
+    out.dtype = output_type
+    out.comm = output_comm
+    return out

--- a/heat/sparse/arithmetics.py
+++ b/heat/sparse/arithmetics.py
@@ -1,0 +1,89 @@
+"""Arithmetic functions for Dcsr_matrices"""
+from __future__ import annotations
+
+import torch
+
+from .dcsr_matrix import DCSR_matrix
+
+from . import _operations
+
+__all__ = [
+    "add",
+    "mul",
+]
+
+
+def add(t1: DCSR_matrix, t2: DCSR_matrix) -> DCSR_matrix:
+    """
+    Element-wise addition of values from two operands, commutative.
+    Takes the first and second operand (scalar or :class:`~heat.sparse.DCSR_matrix`) whose elements are to be added
+    as argument and returns a ``DCSR_matrix`` containing the results of element-wise addition of ``t1`` and ``t2``.
+
+    Parameters
+    ----------
+    t1: DCSR_matrix
+        The first operand involved in the addition
+    t2: DCSR_matrix
+        The second operand involved in the addition
+
+    Examples
+    --------
+    >>> heat_sparse_csr
+    (indptr: tensor([0, 2, 3]), indices: tensor([0, 2, 2]), data: tensor([1., 2., 3.]), dtype=ht.float32, device=cpu:0, split=0)
+    >>> heat_sparse_csr.todense()
+    DNDarray([[1., 0., 2.],
+              [0., 0., 3.]], dtype=ht.float32, device=cpu:0, split=0)
+    >>> sum_sparse = heat_sparse_csr + heat_sparse_csr
+        (or)
+    >>> sum_sparse = ht.sparse.sparse_add(heat_sparse_csr, heat_sparse_csr)
+    >>> sum_sparse
+    (indptr: tensor([0, 2, 3], dtype=torch.int32), indices: tensor([0, 2, 2], dtype=torch.int32), data: tensor([2., 4., 6.]), dtype=ht.float32, device=cpu:0, split=0)
+    >>> sum_sparse.todense()
+    DNDarray([[2., 0., 4.],
+              [0., 0., 6.]], dtype=ht.float32, device=cpu:0, split=0)
+    """
+    return _operations.__binary_op_csr(torch.add, t1, t2)
+
+
+DCSR_matrix.__add__ = lambda self, other: add(self, other)
+DCSR_matrix.__add__.__doc__ = add.__doc__
+DCSR_matrix.__radd__ = lambda self, other: add(self, other)
+DCSR_matrix.__radd__.__doc__ = add.__doc__
+
+
+def mul(t1: DCSR_matrix, t2: DCSR_matrix) -> DCSR_matrix:
+    """
+    Element-wise multiplication (NOT matrix multiplication) of values from two operands, commutative.
+    Takes the first and second operand (scalar or :class:`~heat.sparse.DCSR_matrix`) whose elements are to be
+    multiplied as argument.
+
+    Parameters
+    ----------
+    t1: DCSR_matrix
+        The first operand involved in the multiplication
+    t2: DCSR_matrix
+        The second operand involved in the multiplication
+
+    Examples
+    --------
+    >>> heat_sparse_csr
+    (indptr: tensor([0, 2, 3]), indices: tensor([0, 2, 2]), data: tensor([1., 2., 3.]), dtype=ht.float32, device=cpu:0, split=0)
+    >>> heat_sparse_csr.todense()
+    DNDarray([[1., 0., 2.],
+              [0., 0., 3.]], dtype=ht.float32, device=cpu:0, split=0)
+    >>> pdt_sparse = heat_sparse_csr * heat_sparse_csr
+        (or)
+    >>> pdt_sparse = ht.sparse.sparse_mul(heat_sparse_csr, heat_sparse_csr)
+    >>> pdt_sparse
+    (indptr: tensor([0, 2, 3]), indices: tensor([0, 2, 2]), data: tensor([1., 4., 9.]), dtype=ht.float32, device=cpu:0, split=0)
+    >>> pdt_sparse.todense()
+    DNDarray([[1., 0., 4.],
+              [0., 0., 9.]], dtype=ht.float32, device=cpu:0, split=0)
+    """
+    return _operations.__binary_op_csr(torch.mul, t1, t2)
+
+
+DCSR_matrix.__mul__ = lambda self, other: mul(self, other)
+DCSR_matrix.__mul__.__doc__ = mul.__doc__
+DCSR_matrix.__rmul__ = lambda self, other: mul(self, other)
+DCSR_matrix.__rmul__.__doc__ = mul.__doc__

--- a/heat/sparse/dcsr_matrix.py
+++ b/heat/sparse/dcsr_matrix.py
@@ -1,0 +1,339 @@
+"""Provides DCSR_matrix, a distributed compressed sparse row matrix"""
+from __future__ import annotations
+
+import torch
+from mpi4py import MPI
+from typing import Union, Tuple, TypeVar
+
+from ..core.devices import Device
+from ..core.dndarray import DNDarray
+from ..core.factories import array
+from ..core.types import datatype, canonical_heat_type
+
+__all__ = ["DCSR_matrix"]
+
+Communication = TypeVar("Communication")
+
+
+class DCSR_matrix:
+    """
+    Distributed Compressed Sparse Row Matrix. It is composed of
+    PyTorch sparse_csr_tensors local to each process.
+
+    Parameters
+    ----------
+    array : torch.Tensor (layout ==> torch.sparse_csr)
+        Local sparse array
+    gnnz: int
+        Total number of non-zero elements across all processes
+    gshape : Tuple[int,...]
+        The global shape of the array
+    dtype : datatype
+        The datatype of the array
+    split : int or None
+        If split is not None, it denotes the axis on which the array is divided between processes.
+        DCSR_matrix only supports distribution along axis 0.
+    device : Device
+        The device on which the local arrays are using (cpu or gpu)
+    comm : Communication
+        The communications object for sending and receiving data
+    balanced: bool or None
+        Describes whether the data are evenly distributed across processes.
+    """
+
+    def __init__(
+        self,
+        array: torch.Tensor,
+        gnnz: int,
+        gshape: Tuple[int, ...],
+        dtype: datatype,
+        split: Union[int, None],
+        device: Device,
+        comm: Communication,
+        balanced: bool,
+    ):
+        self.__array = array
+        self.__gnnz = gnnz
+        self.__gshape = gshape
+        self.__dtype = dtype
+        self.__split = split
+        self.__device = device
+        self.__comm = comm
+        self.__balanced = balanced
+
+    def global_indptr(self) -> DNDarray:
+        """
+        Global indptr of the ``DCSR_matrix`` as a ``DNDarray``
+        """
+        if self.split is None:
+            raise ValueError("This method works only for distributed matrices")
+
+        # Need to know the number of non-zero elements
+        # in the processes with lesser rank
+        all_nnz = torch.zeros(self.comm.size + 1, device=self.device.torch_device)
+
+        # Each process must drop their nnz in index = rank + 1
+        all_nnz[self.comm.rank + 1] = self.lnnz
+        self.comm.Allreduce(MPI.IN_PLACE, all_nnz, MPI.SUM)
+
+        # Build prefix array out of all the nnz
+        all_nnz = torch.cumsum(all_nnz, dim=0)
+
+        global_indptr = self.lindptr + int(all_nnz[self.comm.rank])
+
+        # Remove the (n+1) the element from all the processes except last
+        if self.comm.rank != self.comm.size - 1:
+            global_indptr = global_indptr[:-1]
+
+        # NOTE: indptr might be unbalanced in distribution but should not be self balanced
+        return array(
+            global_indptr,
+            dtype=self.lindptr.dtype,
+            device=self.device,
+            comm=self.comm,
+            is_split=self.split,
+        )
+
+    @property
+    def balanced(self) -> bool:
+        """
+        Boolean value indicating if the DCSR_matrix is balanced between the MPI processes
+        """
+        return self.__balanced
+
+    @property
+    def comm(self) -> Communication:
+        """
+        The :class:`~heat.core.communication.Communication` of the ``DCSR_matrix``
+        """
+        return self.__comm
+
+    @property
+    def device(self) -> Device:
+        """
+        The :class:`~heat.core.devices.Device` of the ``DCSR_matrix``
+        """
+        return self.__device
+
+    @property
+    def larray(self) -> torch.Tensor:
+        """
+        Local data of the ``DCSR_matrix``
+        """
+        return self.__array
+
+    @property
+    def data(self) -> torch.Tensor:
+        """
+        Global data of the ``DCSR_matrix``
+        """
+        if self.split is None:
+            return self.ldata
+
+        data_buffer = torch.zeros(
+            size=(self.gnnz,), dtype=self.dtype.torch_type(), device=self.device.torch_device
+        )
+        counts, displs = self.counts_displs_nnz()
+        self.comm.Allgatherv(self.ldata, (data_buffer, counts, displs))
+        return data_buffer
+
+    @property
+    def gdata(self) -> torch.Tensor:
+        """
+        Global data of the ``DCSR_matrix``
+        """
+        return self.data
+
+    @property
+    def ldata(self) -> torch.Tensor:
+        """
+        Local data of the ``DCSR_matrix``
+        """
+        return self.__array.values()
+
+    @property
+    def indptr(self) -> torch.Tensor:
+        """
+        Global indptr of the ``DCSR_matrix``
+        """
+        if self.split is None:
+            return self.lindptr
+
+        return self.global_indptr().resplit(axis=None).larray
+
+    @property
+    def gindptr(self) -> torch.Tensor:
+        """
+        Global indptr of the ``DCSR_matrix``
+        """
+        return self.indptr
+
+    @property
+    def lindptr(self) -> torch.Tensor:
+        """
+        Local indptr of the ``DCSR_matrix``
+        """
+        return self.__array.crow_indices()
+
+    @property
+    def indices(self) -> torch.Tensor:
+        """
+        Global indices of the ``DCSR_matrix``
+        """
+        if self.split is None:
+            return self.lindices
+
+        indices_buffer = torch.zeros(
+            size=(self.gnnz,), dtype=self.lindices.dtype, device=self.device.torch_device
+        )
+        counts, displs = self.counts_displs_nnz()
+        self.comm.Allgatherv(self.lindices, (indices_buffer, counts, displs))
+        return indices_buffer
+
+    @property
+    def gindices(self) -> torch.Tensor:
+        """
+        Global indices of the ``DCSR_matrix``
+        """
+        return self.indices
+
+    @property
+    def lindices(self) -> torch.Tensor:
+        """
+        Local indices of the ``DCSR_matrix``
+        """
+        return self.__array.col_indices()
+
+    @property
+    def ndim(self) -> int:
+        """
+        Number of dimensions of the ``DCSR_matrix``
+        """
+        return len(self.__gshape)
+
+    @property
+    def nnz(self) -> int:
+        """
+        Total number of non-zero elements of the ``DCSR_matrix``
+        """
+        return self.__gnnz
+
+    @property
+    def gnnz(self) -> int:
+        """
+        Total number of non-zero elements of the ``DCSR_matrix``
+        """
+        return self.nnz
+
+    @property
+    def lnnz(self) -> int:
+        """
+        Number of non-zero elements on the local process of the ``DCSR_matrix``
+        """
+        return self.__array._nnz()
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """
+        Global shape of the ``DCSR_matrix``
+        """
+        return self.__gshape
+
+    @property
+    def gshape(self) -> Tuple[int, ...]:
+        """
+        Global shape of the ``DCSR_matrix``
+        """
+        return self.shape
+
+    @property
+    def lshape(self) -> Tuple[int, ...]:
+        """
+        Local shape of the ``DCSR_matrix``
+        """
+        return tuple(self.__array.size())
+
+    @property
+    def dtype(self):
+        """
+        The :class:`~heat.core.types.datatype` of the ``DCSR_matrix``
+        """
+        return self.__dtype
+
+    @property
+    def split(self) -> int:
+        """
+        Returns the axis on which the ``DCSR_matrix`` is split
+        """
+        return self.__split
+
+    def is_distributed(self) -> bool:
+        """
+        Determines whether the data of this ``DCSR_matrix`` is distributed across multiple processes.
+        """
+        return self.split is not None and self.comm.is_distributed()
+
+    def counts_displs_nnz(self) -> Tuple[Tuple[int], Tuple[int]]:
+        """
+        Returns actual counts (number of non-zero items per process) and displacements (offsets) of the DCSR_matrix.
+        Does not assume load balance.
+        """
+        if self.split is not None:
+            counts = torch.zeros(self.comm.size)
+            counts[self.comm.rank] = self.lnnz
+            self.comm.Allreduce(MPI.IN_PLACE, counts, MPI.SUM)
+            displs = [0] + torch.cumsum(counts, dim=0)[:-1].tolist()
+            return tuple(counts.tolist()), tuple(displs)
+        else:
+            raise ValueError(
+                "Non-distributed DCSR_matrix. Cannot calculate counts and displacements."
+            )
+
+    def astype(self, dtype, copy=True) -> DCSR_matrix:
+        """
+        Returns a casted version of this matrix.
+        Casted matrix is a new matrix of the same shape but with given type of this matrix. If copy is ``True``, the
+        same matrix is returned instead.
+
+        Parameters
+        ----------
+        dtype : datatype
+            HeAT type to which the matrix is cast
+        copy : bool, optional
+            By default the operation returns a copy of this matrix. If copy is set to ``False`` the cast is performed
+            in-place and this matrix is returned
+        """
+        dtype = canonical_heat_type(dtype)
+        casted_matrix = self.__array.type(dtype.torch_type())
+        if copy:
+            return DCSR_matrix(
+                casted_matrix,
+                self.gnnz,
+                self.gshape,
+                dtype,
+                self.split,
+                self.device,
+                self.comm,
+                self.balanced,
+            )
+
+        self.__array = casted_matrix
+        self.__dtype = dtype
+
+        return self
+
+    def __repr__(self) -> str:
+        """
+        Computes a printable representation of the passed DCSR_matrix.
+        """
+        print_string = (
+            f"(indptr: {self.indptr}, indices: {self.indices}, data: {self.data}, "
+            f"dtype=ht.{self.dtype.__name__}, device={self.device}, split={self.split})"
+        )
+
+        # Check has to happen after generating string because
+        # generation of string invokes functions that require
+        # participation from all processes
+        if self.comm.rank != 0:
+            return ""
+        return print_string

--- a/heat/sparse/manipulations.py
+++ b/heat/sparse/manipulations.py
@@ -1,0 +1,79 @@
+"""Manipulation operations for (potentially distributed) `DCSR_matrix`."""
+from __future__ import annotations
+
+from heat.sparse.dcsr_matrix import DCSR_matrix
+
+from ..core.memory import sanitize_memory_layout
+from ..core.dndarray import DNDarray
+from ..core.factories import empty
+
+__all__ = [
+    "todense",
+]
+
+
+def todense(sparse_matrix: DCSR_matrix, order="C", out: DNDarray = None) -> DNDarray:
+    """
+    Convert :class:`~heat.sparse.DCSR_matrix` to a dense :class:`~heat.core.DNDarray`.
+    Output follows the same distribution among processes as the input
+
+    Parameters
+    ----------
+    sparse_matrix : :class:`~heat.sparse.DCSR_matrix`
+        The sparse csr matrix which is to be converted to a dense array
+    order: str, optional
+        Options: ``'C'`` or ``'F'``. Specifies the memory layout of the newly created `DNDarray`. Default is ``order='C'``,
+        meaning the array will be stored in row-major order (C-like). If ``order=‘F’``, the array will be stored in
+        column-major order (Fortran-like).
+    out : DNDarray
+        Output buffer in which the values of the dense format is stored.
+        If not specified, a new DNDarray is created.
+
+    Raises
+    ------
+    ValueError
+        If shape of output buffer does not match that of the input.
+    ValueError
+        If split axis of output buffer does not match that of the input.
+
+    Examples
+    --------
+    >>> indptr = torch.tensor([0, 2, 3, 6])
+    >>> indices = torch.tensor([0, 2, 2, 0, 1, 2])
+    >>> data = torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.float)
+    >>> torch_sparse_csr = torch.sparse_csr_tensor(indptr, indices, data)
+    >>> heat_sparse_csr = ht.sparse.sparse_csr_matrix(torch_sparse_csr, split=0)
+    >>> heat_sparse_csr
+    (indptr: tensor([0, 2, 3, 6]), indices: tensor([0, 2, 2, 0, 1, 2]), data: tensor([1., 2., 3., 4., 5., 6.]), dtype=ht.float32, device=cpu:0, split=0)
+    >>> heat_sparse_csr.todense()
+    DNDarray([[1., 0., 2.],
+              [0., 0., 3.],
+              [4., 5., 6.]], dtype=ht.float32, device=cpu:0, split=0)
+    """
+    if out is not None:
+        if out.shape != sparse_matrix.shape:
+            raise ValueError(
+                f"Expected output buffer with shape {sparse_matrix.shape} but was {out.shape}"
+            )
+
+        if out.split != sparse_matrix.split:
+            raise ValueError(
+                f"Expected output buffer with split axis {sparse_matrix.split} but was {out.split}"
+            )
+
+    if out is None:
+        out = empty(
+            shape=sparse_matrix.shape,
+            split=sparse_matrix.split,
+            dtype=sparse_matrix.dtype,
+            device=sparse_matrix.device,
+            comm=sparse_matrix.comm,
+            order=order,
+        )
+
+    out.larray = sanitize_memory_layout(sparse_matrix.larray.to_dense(), order=order)
+    return out
+
+
+DCSR_matrix.todense = lambda self, order="C", out=None: todense(self, order, out)
+DCSR_matrix.to_dense = lambda self, order="C", out=None: todense(self, order, out)

--- a/heat/sparse/tests/__init__.py
+++ b/heat/sparse/tests/__init__.py
@@ -1,0 +1,4 @@
+from .test_arithmetics import *
+from .test_dcsrmatrix import *
+from .test_factories import *
+from .test_manipulations import *

--- a/scripts/heat_dev.yml
+++ b/scripts/heat_dev.yml
@@ -1,0 +1,16 @@
+name: heat_dev
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.9
+  - openmpi
+  - mpi4py
+  - h5py[version='>=2.9',build=mpi*]
+  - netcdf4
+  - pytorch=1.13.0
+  - torchvision
+  - scipy
+  - pre-commit
+  - black
+  - flake8

--- a/scripts/heat_env.yml
+++ b/scripts/heat_env.yml
@@ -1,0 +1,16 @@
+name: heat_env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.9
+  - openmpi
+  - mpi4py
+  - h5py[version='>=2.9',build=mpi*]
+  - netcdf4
+  - pytorch=1.13.0
+  - torchvision
+  - scipy
+  - pip
+  - pip:
+    - heat

--- a/scripts/heat_test.py
+++ b/scripts/heat_test.py
@@ -1,0 +1,9 @@
+""" Test script for MPI & Heat installation """
+
+import heat as ht
+
+x = ht.arange(10, split=0)
+if x.comm.rank == 0:
+    print("x is distributed: ", x.is_distributed())
+print("Global DNDarray x: ", x)
+print("Local torch tensor on rank ", x.comm.rank, ": ", x.larray)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: suboptimal merge result of the latest `release/1.2.x` into `main` 

## Changes proposed:
- entire branch should be at [a5515f0850](https://github.com/helmholtz-analytics/heat/tree/a5515f08501388f95b571eb28e604d88a7dc86c4/heat) level, including new CI
- bug fixes and new pytorch workflow from `release` branch merged into `main`
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue)
## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measuremens can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
NA
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
my be illegible. It may be easiest to save the output of each to a file.
--->
Na

## Due Diligence
- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
no
