### PR TITLE
FAIR-RS and best practice badges

### DIFF
--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -1,0 +1,15 @@
+name: fair-software
+
+on: push
+
+jobs:
+  verify:
+    name: "fair-software"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fair-software/howfairis-github-action@0.2.1
+        name: Measure compliance with fair-software.eu recommendations
+        env:
+          PYCHARM_HOSTED: "Trick colorama into displaying colored output"
+        with:
+          MY_REPO_URL: "https://github.com/${{ github.repository }}"


### PR DESCRIPTION
## Description

The goal is to make HeAT FAIR-RS compliant according to https://fair-software.eu/. We already cover most of the requisites, so we just need to show it with some new shiny badges.

Issue/s resolved: #

## Changes proposed:
- New action based on https://github.com/fair-software/howfairis-github-action that regulary check if the repository is FAIR compliant.
- One new README tag based on the result of previously mentioned action.
- Another tag based on the results of https://bestpractices.coreinfrastructure.org/en (I don't have the permission to grant it access to the repo)

## Type of change
- Documentation update


## Due Diligence
- [x] Documentation updated (if needed)
- [x] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
no
