### PR TITLE
Fixed bugs due to behaviour change in `torch.nn.Module.zero_grad()` and `torch.Tensor.item()` in torch 2.0

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1484,7 +1484,7 @@ class DNDarray:
         for c, k in enumerate(key):
             try:
                 key[c] = k.item()
-            except (AttributeError, ValueError):
+            except (AttributeError, RuntimeError):
                 pass
 
         rank = self.comm.rank

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1484,7 +1484,7 @@ class DNDarray:
         for c, k in enumerate(key):
             try:
                 key[c] = k.item()
-            except (AttributeError, RuntimeError):
+            except (AttributeError, ValueError):
                 pass
 
         rank = self.comm.rank

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -579,7 +579,7 @@ class TestDNDarray(TestCase):
         self.assertEqual(type(x.item()), float)
 
         x = ht.zeros((1, 2))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             x.item()
 
     def test_len(self):

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -579,7 +579,7 @@ class TestDNDarray(TestCase):
         self.assertEqual(type(x.item()), float)
 
         x = ht.zeros((1, 2))
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             x.item()
 
     def test_len(self):

--- a/heat/optim/dp_optimizer.py
+++ b/heat/optim/dp_optimizer.py
@@ -828,7 +828,7 @@ class DASO:
         """
         # reset view onto params in order to reset all gradients
         self.local_optimizer.param_groups[0]["params"] = self.params_ref[:]
-        self.local_optimizer.zero_grad()
+        self.local_optimizer.zero_grad(set_to_none=False)
 
 
 class DataParallelOptimizer:
@@ -874,4 +874,4 @@ class DataParallelOptimizer:
         """
         # reset view onto params in order to reset all gradients
         self.torch_optimizer.param_groups[0]["params"] = self.params_ref[:]
-        self.torch_optimizer.zero_grad()
+        self.torch_optimizer.zero_grad(set_to_none=False)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         "mpi4py>=3.0.0",
         "numpy>=1.13.0",
-        "torch>=1.7.0, <1.13.2",
+        "torch>=1.7.0, <",
         "scipy>=0.14.0",
         "pillow>=6.0.0",
         "torchvision>=0.8.0",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         "mpi4py>=3.0.0",
         "numpy>=1.13.0",
-        "torch>=1.7.0, <",
+        "torch>=1.7.0, <2.0.1",
         "scipy>=0.14.0",
         "pillow>=6.0.0",
         "torchvision>=0.8.0",


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
This PR fixes the following errors in the tests.
**1. `AttributeError: 'NoneType' object has no attribute 'data'`**
Due to a change in default behaviour of `torch.nn.Module.zero_grad()` as stated in the "Backwards Incompatible Changes" in the [2.0 release](https://github.com/pytorch/pytorch/releases/tag/v2.0.0)

**Solution:** Set `set_to_none` to `False` explicitly to preserve previous heat behaviour. 
Can also be modified to follow Pytorch and set the grads to `None` by default to reduce peak memory usage. But it would be a breaking change.

**2. `RuntimeError: a Tensor with * elements cannot be converted to Scalar`**
It is expected to raise a `ValueError`. But, it raises a `RuntimeError`. This change is not mentioned anywhere in the release notes. Even in the torch [source code](https://github.com/pytorch/pytorch/blob/6c934a89a725fd5d171b52a37cbc58e198edf4d6/torch/_refs/__init__.py#L1857), it seems to raise a `ValueError`. 

**Solution:** Changing heat tests and `DNDarray` code to expect a `RuntimeError` fixes the failing tests. But I can't explain why.

**P.S.** The change in `setup.py` is not intentional. I can't seem to get rid of it either.
## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
Bug fix

## Due Diligence
- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
