### PR TITLE
support amd HIP

### DIFF
--- a/.github/workflows/CIBase.yml
+++ b/.github/workflows/CIBase.yml
@@ -16,6 +16,6 @@ jobs:
          curl -s -X POST \
            --fail \
            -F token=${{ secrets.CB_PIPELINE }} \
-           -F "ref=nvidiapytorch2211" \
+           -F "ref=pt113" \
            -F "variables[SHA]=$GITHUB_SHA" \
            https://codebase.helmholtz.cloud/api/v4/projects/7605/trigger/pipeline -o /dev/null

--- a/.github/workflows/CIBase.yml
+++ b/.github/workflows/CIBase.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'release/**'
+      - 'support/**'
 
 jobs:
   starter:

--- a/.github/workflows/CommentPR.yml
+++ b/.github/workflows/CommentPR.yml
@@ -66,6 +66,6 @@ jobs:
          curl -s -X POST \
            --fail \
            -F token=${{ secrets.CB_PIPELINE }} \
-           -F "ref=nvidiapytorch2211" \
+           -F "ref=pt113" \
            -F "variables[PR]=${{ needs.upload.outputs.PR_NR }}" \
            https://codebase.helmholtz.cloud/api/v4/projects/7605/trigger/pipeline -o /dev/null

--- a/.github/workflows/ReceivePR.yml
+++ b/.github/workflows/ReceivePR.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if:  !startsWith(github.head_ref, 'support/')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ReceivePR.yml
+++ b/.github/workflows/ReceivePR.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if:  !startsWith(github.head_ref, 'support/')
+    if: ${{ !startsWith(github.head_ref, 'support/') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/heat/core/linalg/tests/test_qr.py
+++ b/heat/core/linalg/tests/test_qr.py
@@ -14,6 +14,7 @@ else:
     extended_tests = False
 
 
+@unittest.skipIf(torch.cuda.is_available() and torch.version.hip, "not supported for HIP")
 class TestQR(TestCase):
     @unittest.skipIf(not extended_tests, "extended tests")
     def test_qr_sp0_ext(self):

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -1321,7 +1321,7 @@ class TestStatistics(TestCase):
         x = ht.zeros((2, 3, 4))
         with self.assertRaises(TypeError):
             ht.std(x, axis=0, ddof=1.0)
-        with self.assertRaises((ValueError,IndexError)):
+        with self.assertRaises((ValueError, IndexError)):
             ht.std(x, axis=10)
         with self.assertRaises(TypeError):
             ht.std(x, axis="01")

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -1321,7 +1321,7 @@ class TestStatistics(TestCase):
         x = ht.zeros((2, 3, 4))
         with self.assertRaises(TypeError):
             ht.std(x, axis=0, ddof=1.0)
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ValueError,IndexError)):
             ht.std(x, axis=10)
         with self.assertRaises(TypeError):
             ht.std(x, axis="01")


### PR DESCRIPTION
## Description

This Pull Request skips some tests such that it can be run on AMD GPU. Additionally branches starting with 'support/' are tested on push events.

Issue/s resolved: #694

## Changes proposed:
- skip tests using special cuda libraries
- push trigger event on support branch

## Type of change
- testing

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measuremens can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
my be illegible. It may be easiest to save the output of each to a file.
--->


## Due Diligence
- [ ] All split configurations tested
- [ ] Multiple dtypes tested in relevant functions
- [ ] Documentation updated (if needed)
- [ ] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
