### PR TITLE
Introduce `DNDarray.__array__()` method

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -461,9 +461,10 @@ class DNDarray:
 
     def __array__(self) -> np.ndarray:
         """
-        Returns a view of the process-local array as a numpy ndarray.
+        Returns a view of the process-local array as a numpy ndarray, if the array resides on CPU.
+        Otherwise, it returns a copy of the process-local array as numpy ndarray on CPU.
         """
-        return self.larray.__array__()
+        return self.larray.cpu().__array__()
 
     def astype(self, dtype, copy=True) -> DNDarray:
         """

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1114,8 +1114,8 @@ class DNDarray:
 
     def numpy(self) -> np.array:
         """
-        Convert :class:`DNDarray` to numpy array. If the ``DNDarray`` is distributed it will be merged beforehand. If the ``DNDarray``
-        resides on the GPU, it will be copied to the CPU first.
+        Returns a copy of the :class:`DNDarray` as numpy ndarray. If the ``DNDarray`` is distributed, an MPI Allgather operation will be performed beforehand, i.e. each MPI process will end up holding a copy of the entire array in memory.  Make sure single-process memory is sufficient! If the ``DNDarray``
+        resides on the GPU, the underlying data will be copied to the CPU first.
 
         Examples
         --------

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1115,7 +1115,7 @@ class DNDarray:
         """
         Returns a copy of the :class:`DNDarray` as numpy ndarray. If the ``DNDarray`` resides on the GPU, the underlying data will be copied to the CPU first.
 
-        If the ``DNDarray`` is distributed, an MPI Allgather operation will be performed before converting to np.ndarray, i.e. each MPI process will end up holding a copy of the entire array in memory.  Make sure single-process memory is sufficient!
+        If the ``DNDarray`` is distributed, an MPI Allgather operation will be performed before converting to np.ndarray, i.e. each MPI process will end up holding a copy of the entire array in memory.  Make sure process memory is sufficient!
 
         Examples
         --------

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -1114,8 +1114,9 @@ class DNDarray:
 
     def numpy(self) -> np.array:
         """
-        Returns a copy of the :class:`DNDarray` as numpy ndarray. If the ``DNDarray`` is distributed, an MPI Allgather operation will be performed beforehand, i.e. each MPI process will end up holding a copy of the entire array in memory.  Make sure single-process memory is sufficient! If the ``DNDarray``
-        resides on the GPU, the underlying data will be copied to the CPU first.
+        Returns a copy of the :class:`DNDarray` as numpy ndarray. If the ``DNDarray`` resides on the GPU, the underlying data will be copied to the CPU first.
+
+        If the ``DNDarray`` is distributed, an MPI Allgather operation will be performed before converting to np.ndarray, i.e. each MPI process will end up holding a copy of the entire array in memory.  Make sure single-process memory is sufficient!
 
         Examples
         --------

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -459,6 +459,12 @@ class DNDarray:
             dim=self.split,
         )
 
+    def __array__(self) -> np.ndarray:
+        """
+        Returns a view of the process-local array as a numpy ndarray.
+        """
+        return self.larray.__array__()
+
     def astype(self, dtype, copy=True) -> DNDarray:
         """
         Returns a casted version of this array.
@@ -468,7 +474,7 @@ class DNDarray:
         Parameters
         ----------
         dtype : datatype
-            HeAT type to which the array is cast
+            Heat type to which the array is cast
         copy : bool, optional
             By default the operation returns a copy of this array. If copy is set to ``False`` the cast is performed
             in-place and this array is returned

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -461,8 +461,7 @@ class DNDarray:
 
     def __array__(self) -> np.ndarray:
         """
-        Returns a view of the process-local array as a numpy ndarray, if the array resides on CPU.
-        Otherwise, it returns a copy of the process-local array as numpy ndarray on CPU.
+        Returns a view of the process-local slice of the :class:`DNDarray` as a numpy ndarray, if the ``DNDarray`` resides on CPU. Otherwise, it returns a copy, on CPU, of the process-local slice of ``DNDarray`` as numpy ndarray.
         """
         return self.larray.cpu().__array__()
 

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -234,18 +234,20 @@ class TestDNDarray(TestCase):
     def test_array(self):
         # undistributed case
         x = ht.arange(6 * 7 * 8).reshape((6, 7, 8))
+        x_np = np.arange(6 * 7 * 8, dtype=np.int32).reshape((6, 7, 8))
 
         self.assertTrue((x.__array__() == x.numpy()).all())
         self.assertIsInstance(x.__array__(), np.ndarray)
-        self.assertIsInstance(x.__array__().dtype, "int32")
+        self.assertIsInstance(x.__array__().dtype, x_np.dtype)
         self.assertEqual(x.__array__().shape, x.gshape)
 
         # distributed case
         x = ht.arange(6 * 7 * 8, dtype=ht.float64, split=0).reshape((6, 7, 8))
+        x_np = np.arange(6 * 7 * 8, dtype=np.float64).reshape((6, 7, 8))
 
         self.assertTrue((x.__array__() == x.larray.numpy()).all())
         self.assertIsInstance(x.__array__(), np.ndarray)
-        self.assertIsInstance(x.__array__().dtype, "float64")
+        self.assertIsInstance(x.__array__().dtype, x_np.dtype)
         self.assertEqual(x.__array__().shape, x.lshape)
 
     def test_larray(self):

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -231,6 +231,21 @@ class TestDNDarray(TestCase):
             self.assertTrue(data.halo_prev is prev_halo or (data.halo_prev == prev_halo).all())
             self.assertTrue(data.halo_next is next_halo or (data.halo_next == next_halo).all())
 
+    def test_array(self):
+        # undistributed case
+        x = ht.arange(6 * 7 * 8).reshape((6, 7, 8))
+
+        self.assertTrue((x.__array__() == x.numpy()).all())
+        self.assertIsInstance(x.__array__(), np.ndarray)
+        self.assertEqual(x.__array__().shape, x.gshape)
+
+        # distributed case
+        x = ht.arange(6 * 7 * 8, dtype=ht.float64, split=0).reshape((6, 7, 8))
+
+        self.assertTrue((x.__array__() == x.larray.numpy()).all())
+        self.assertIsInstance(x.__array__(), np.ndarray)
+        self.assertEqual(x.__array__().shape, x.lshape)
+
     def test_larray(self):
         # undistributed case
         x = ht.arange(6 * 7 * 8).reshape((6, 7, 8))

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -236,7 +236,7 @@ class TestDNDarray(TestCase):
         x = ht.arange(6 * 7 * 8).reshape((6, 7, 8))
         x_np = np.arange(6 * 7 * 8, dtype=np.int32).reshape((6, 7, 8))
 
-        self.assertTrue((x.__array__() == x.numpy()).all())
+        self.assertTrue((x.__array__() == x_np).all())
         self.assertIsInstance(x.__array__(), np.ndarray)
         self.assertEqual(x.__array__().dtype, x_np.dtype)
         self.assertEqual(x.__array__().shape, x.gshape)
@@ -245,7 +245,7 @@ class TestDNDarray(TestCase):
         x = ht.arange(6 * 7 * 8, dtype=ht.float64, split=0).reshape((6, 7, 8))
         x_np = np.arange(6 * 7 * 8, dtype=np.float64).reshape((6, 7, 8))
 
-        self.assertTrue((x.__array__() == x.larray.numpy()).all())
+        self.assertTrue((x.__array__() == x.larray.cpu().numpy()).all())
         self.assertIsInstance(x.__array__(), np.ndarray)
         self.assertEqual(x.__array__().dtype, x_np.dtype)
         self.assertEqual(x.__array__().shape, x.lshape)

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -238,7 +238,7 @@ class TestDNDarray(TestCase):
 
         self.assertTrue((x.__array__() == x.numpy()).all())
         self.assertIsInstance(x.__array__(), np.ndarray)
-        self.assertIsInstance(x.__array__().dtype, x_np.dtype)
+        self.assertEqual(x.__array__().dtype, x_np.dtype)
         self.assertEqual(x.__array__().shape, x.gshape)
 
         # distributed case
@@ -247,7 +247,7 @@ class TestDNDarray(TestCase):
 
         self.assertTrue((x.__array__() == x.larray.numpy()).all())
         self.assertIsInstance(x.__array__(), np.ndarray)
-        self.assertIsInstance(x.__array__().dtype, x_np.dtype)
+        self.assertEqual(x.__array__().dtype, x_np.dtype)
         self.assertEqual(x.__array__().shape, x.lshape)
 
     def test_larray(self):

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -237,6 +237,7 @@ class TestDNDarray(TestCase):
 
         self.assertTrue((x.__array__() == x.numpy()).all())
         self.assertIsInstance(x.__array__(), np.ndarray)
+        self.assertIsInstance(x.__array__().dtype, "int32")
         self.assertEqual(x.__array__().shape, x.gshape)
 
         # distributed case
@@ -244,6 +245,7 @@ class TestDNDarray(TestCase):
 
         self.assertTrue((x.__array__() == x.larray.numpy()).all())
         self.assertIsInstance(x.__array__(), np.ndarray)
+        self.assertIsInstance(x.__array__().dtype, "float64")
         self.assertEqual(x.__array__().shape, x.lshape)
 
     def test_larray(self):


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This method returns **a view** of the underlying process-local array as numpy ndarray. If the DNDarray is on GPU, the array is copied to CPU first.

With this change, passing a DNDarray to `np.asarray()` returns a valid np.ndarray. This is needed for interoperability with other libraries in the numpy ecosystem.

Basic example with `xarray`:

```
>>> import xarray as xr
>>> import heat as ht
>>> a = ht.arange(10).reshape(5,2)
>>> a
DNDarray([[0, 1],
          [2, 3],
          [4, 5],
          [6, 7],
          [8, 9]], dtype=ht.int32, device=cpu:0, split=None)
>>> xr_a = xr.DataArray(a)
>>> xr_a
<xarray.DataArray (dim_0: 5, dim_1: 2)>
array([[0, 1],
       [2, 3],
       [4, 5],
       [6, 7],
       [8, 9]], dtype=int32)
Dimensions without coordinates: dim_0, dim_1
```

If the DNDarray is distributed, the example above will return an xarray of the local slice of data on each MPI process.

Related: #1031  




Issue/s resolved: #1153 

## Changes proposed:
- Implement `DNDarray.__array__()` method
- Update documentation of `DNDarray.numpy()` method
- Implement tests
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- New feature (non-breaking change which adds functionality)

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measuremens can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
NA
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
my be illegible. It may be easiest to save the output of each to a file.
--->
NA

## Due Diligence
- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
no
