### PR TITLE
Fixed the ReadTheDocs link on ```release/1.2.x``` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Check out our Jupyter Notebook [tutorial](https://github.com/helmholtz-analytics
 right here on Github or in the /scripts directory.
 
 The complete documentation of the latest version is always deployed on
-[Read the Docs](https://heat.readthedocs.io/).
+[Read the Docs](https://heat.readthedocs.io/en/stable/).
 
 Support Channels
 ----------------

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Getting Started
 Check out our Jupyter Notebook [tutorial](https://github.com/helmholtz-analytics/heat/blob/main/scripts/tutorial.ipynb)
 right here on Github or in the /scripts directory.
 
-The complete documentation of the latest version is always deployed on
+The complete documentation of the **stable version** is always deployed on
 [Read the Docs](https://heat.readthedocs.io/en/stable/).
+
+You can checkout the documentation of the **latest version** [Here](https://heat.readthedocs.io/en/latest/).
 
 Support Channels
 ----------------


### PR DESCRIPTION
## Description
Updated the README file In the ```release/1.2.x``` branch, by adding links to both the [stable](https://heat.readthedocs.io/en/stable/) and [latest](https://heat.readthedocs.io/en/latest/) versions of the docs.

Issue/s resolved: #1101

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Due Diligence
- [ ] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
No.