### PR TITLE
Continuous benchmarks for linalg: try to separate data creation from the actual tests

### DIFF
--- a/benchmarks/cb/linalg.py
+++ b/benchmarks/cb/linalg.py
@@ -4,35 +4,52 @@ from perun.decorator import monitor
 
 
 @monitor()
-def matmul_cpu_split_0(n: int = 3000):
-    a = ht.random.random((n, n), split=0, device="cpu")
-    b = ht.random.random((n, n), split=0, device="cpu")
+def matmul_cpu_split_0(a, b):
     a @ b
 
 
 @monitor()
-def matmul_cpu_split_1(n: int = 3000):
-    a = ht.random.random((n, n), split=1, device="cpu")
-    b = ht.random.random((n, n), split=1, device="cpu")
+def matmul_cpu_split_1(a, b):
     a @ b
 
 
 @monitor()
-def qr_cpu(n: int = 2000):
+def qr_cpu_split_0(a):
     for t in range(1, 3):
-        for sp in range(2):
-            a = ht.random.random((n, n), split=sp)
-            qr = a.qr(tiles_per_proc=t)
+        qr = a.qr(tiles_per_proc=t)
 
 
 @monitor()
-def lanczos_cpu(n: int = 50):
-    A = ht.random.random((n, n), dtype=ht.float64, split=0)
-    B = A @ A.T
-    V, T = ht.lanczos(B, m=n)
+def qr_cpu_split_1(a):
+    for t in range(1, 3):
+        qr = a.qr(tiles_per_proc=t)
 
 
-matmul_cpu_split_0()
-matmul_cpu_split_1()
-qr_cpu()
-lanczos_cpu()
+@monitor()
+def lanczos_cpu(B):
+    V, T = ht.lanczos(B, m=B.shape[0])
+
+
+n = 3000
+a = ht.random.random((n, n), split=0, device="cpu")
+b = ht.random.random((n, n), split=0, device="cpu")
+matmul_cpu_split_0(a, b)
+del a, b
+
+a = ht.random.random((n, n), split=1, device="cpu")
+b = ht.random.random((n, n), split=1, device="cpu")
+matmul_cpu_split_1(a, b)
+del a, b
+
+n = 2000
+a_0 = ht.random.random((n, n), split=0)
+a_1 = ht.random.random((n, n), split=1)
+qr_cpu_split_0(a_0)
+qr_cpu_split_1(a_1)
+del a_0, a_1
+
+n = 50
+A = ht.random.random((n, n), dtype=ht.float64, split=0)
+B = A @ A.T
+lanczos_cpu(B)
+del B

--- a/benchmarks/cb/manipulations.py
+++ b/benchmarks/cb/manipulations.py
@@ -4,11 +4,14 @@ from perun.decorator import monitor
 
 
 @monitor()
-def reshape_cpu():
-    sizes = [10000, 20000, 40000]
-    for size in sizes:
-        st = ht.zeros((1000, size), split=1)
-        a = ht.reshape(st, (10000000, -1), new_split=1)
+def reshape_cpu(arrays):
+    for array in arrays:
+        a = ht.reshape(array, (10000000, -1), new_split=1)
 
 
-reshape_cpu()
+sizes = [10000, 20000, 40000]
+arrays = []
+for size in sizes:
+    arrays.append(ht.zeros((1000, size), split=1))
+
+reshape_cpu(arrays)


### PR DESCRIPTION
I tried to separate the creation of test data from the actual tests in the `linalg`-file of continuous benchmarking 
(see also #1157 )

For `reshape` I have no idea how to proceed so far... 