### PR TITLE
hSVD: Concatenate arrays to reduce communication

### DIFF
--- a/heat/core/linalg/svdtools.py
+++ b/heat/core/linalg/svdtools.py
@@ -427,7 +427,7 @@ def hsvd(
             # A.comm.Send(U_loc, send_to[A.comm.rank], tag=A.comm.rank)
             # A.comm.Send(err_squared_loc, send_to[A.comm.rank], tag=2 * no_procs + A.comm.rank)
             # concatenate U_loc and err_squared_loc to avoid sending multiple messages
-            err_squared_loc = torch.full((1, U_loc.shape[1]), err_squared_loc)
+            err_squared_loc = torch.full((1, U_loc.shape[1]), err_squared_loc, device=U_loc.device)
             U_loc = torch.vstack([U_loc, err_squared_loc])
             # print("send_to[A.comm.rank], tag", send_to[A.comm.rank], A.comm.rank)
             A.comm.Send(U_loc, send_to[A.comm.rank], tag=A.comm.rank)
@@ -441,7 +441,7 @@ def hsvd(
     # print("DEBUGGING: rank ", A.comm.rank, "finished")
     # After completion of the SVD, distribute the result from process 0 to all processes again
     # stack U_loc and err_squared_loc to avoid sending multiple messages
-    err_squared_loc = torch.full((1, U_loc.shape[1]), err_squared_loc)
+    err_squared_loc = torch.full((1, U_loc.shape[1]), err_squared_loc, device=U_loc.device)
     U_loc = torch.vstack([U_loc, err_squared_loc])
     U_loc_shape = A.comm.bcast(U_loc.shape, root=0)
     if A.comm.rank != 0:

--- a/heat/core/linalg/tests/test_svdtools.py
+++ b/heat/core/linalg/tests/test_svdtools.py
@@ -84,7 +84,7 @@ class TestHSVD(TestCase):
                             )
                             / hsvd_rk**0.5
                         )
-                        print(U_orth_err)
+                        # print(U_orth_err)
                         self.assertTrue(U_orth_err <= dtype_tol)
                     if A.split == 0:
                         V_orth_err = (

--- a/heat/core/linalg/tests/test_svdtools.py
+++ b/heat/core/linalg/tests/test_svdtools.py
@@ -13,15 +13,15 @@ class TestHSVD(TestCase):
         nprocs = MPI.COMM_WORLD.Get_size()
         test_matrices = [
             ht.random.randn(50, 15 * nprocs, dtype=ht.float32, split=1),
-            ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=1),
-            ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=0),
-            ht.random.randn(15 * nprocs, 50, dtype=ht.float64, split=0),
-            ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=None),
-            ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=None),
-            ht.zeros((50, 15 * nprocs), dtype=ht.float32, split=1),
+            # ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=1),
+            # ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=0),
+            # ht.random.randn(15 * nprocs, 50, dtype=ht.float64, split=0),
+            # ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=None),
+            # ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=None),
+            # ht.zeros((50, 15 * nprocs), dtype=ht.float32, split=1),
         ]
-        rtols = [1e-1, 1e-2, 1e-3]
-        ranks = [5, 10, 15]
+        rtols = [1e-1]  # , 1e-2, 1e-3]
+        ranks = [5]  # , 10, 15]
 
         # check if hsvd yields "reasonable" results for random matrices, i.e.
         #    U (resp. V) is orthogonal for split=1 (resp. split=0)
@@ -67,7 +67,7 @@ class TestHSVD(TestCase):
                     self.assertEqual(ht.norm(sigma), 0)
                     self.assertEqual(ht.norm(V), 0)
 
-                # check if wrong parameter choice is catched
+                # check if wrong parameter choice is caught
                 with self.assertRaises(RuntimeError):
                     ht.linalg.hsvd_rank(A, r, maxmergedim=4)
 

--- a/heat/core/linalg/tests/test_svdtools.py
+++ b/heat/core/linalg/tests/test_svdtools.py
@@ -13,15 +13,15 @@ class TestHSVD(TestCase):
         nprocs = MPI.COMM_WORLD.Get_size()
         test_matrices = [
             ht.random.randn(50, 15 * nprocs, dtype=ht.float32, split=1),
-            # ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=1),
-            # ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=0),
-            # ht.random.randn(15 * nprocs, 50, dtype=ht.float64, split=0),
-            # ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=None),
-            # ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=None),
-            # ht.zeros((50, 15 * nprocs), dtype=ht.float32, split=1),
+            ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=1),
+            ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=0),
+            ht.random.randn(15 * nprocs, 50, dtype=ht.float64, split=0),
+            ht.random.randn(15 * nprocs, 50, dtype=ht.float32, split=None),
+            ht.random.randn(50, 15 * nprocs, dtype=ht.float64, split=None),
+            ht.zeros((50, 15 * nprocs), dtype=ht.float32, split=1),
         ]
-        rtols = [1e-1]  # , 1e-2, 1e-3]
-        ranks = [5]  # , 10, 15]
+        rtols = [1e-1, 1e-2, 1e-3]
+        ranks = [5, 10, 15]
 
         # check if hsvd yields "reasonable" results for random matrices, i.e.
         #    U (resp. V) is orthogonal for split=1 (resp. split=0)


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

A proposal to reduce communication in #1126 



## Changes proposed:
- for every iteration, add a row to `U_loc` and store `err_square_loc` in it.
- communicate `U_loc` and `err_square_loc` in one single MPI call instead of one each
- separate tensors again after communication
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
New feature 
## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measuremens can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
NA
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
my be illegible. It may be easiest to save the output of each to a file.
--->


## Due Diligence
- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
no
