### PR TITLE
Introduced a format for displaying the DCSR_matrix

### DIFF
--- a/heat/sparse/_operations.py
+++ b/heat/sparse/_operations.py
@@ -135,13 +135,10 @@ def __binary_op_csr(
     else:
         result = operation(t1.larray.to(promoted_type), t2.larray.to(promoted_type), **fn_kwargs)
 
+    output_gnnz = torch.tensor(result._nnz())
     if output_split is not None:
-        output_gnnz = torch.tensor(result._nnz())
         output_comm.Allreduce(MPI.IN_PLACE, output_gnnz, MPI.SUM)
         output_gnnz = output_gnnz.item()
-    else:
-        output_gnnz = torch.tensor(result._nnz())
-
     output_type = types.canonical_heat_type(result.dtype)
 
     if out is None:

--- a/heat/sparse/dcsr_matrix.py
+++ b/heat/sparse/dcsr_matrix.py
@@ -337,3 +337,21 @@ class DCSR_matrix:
         if self.comm.rank != 0:
             return ""
         return print_string
+
+    def __str__(self) -> str:
+        """
+        Computes a string representation of the passed ``DCSR_matrix``.
+        """
+        size = self.__gshape
+        nnz = self.__gnnz
+
+        print_string = (
+            f"indices={self.indices}, "
+            f"data={self.data}, DCSR_matrix(size={size}, "
+            f"nnz={nnz}, split={self.__split})"
+        )
+
+        if self.__comm.rank != 0:
+            return ""
+
+        return print_string

--- a/heat/sparse/dcsr_matrix.py
+++ b/heat/sparse/dcsr_matrix.py
@@ -347,8 +347,8 @@ class DCSR_matrix:
 
         print_string = (
             f"indices={self.indices}, "
-            f"data={self.data}, DCSR_matrix(size={size}, "
-            f"nnz={nnz}, split={self.__split})"
+            f"data={self.data}, "
+            f"size={size}, nnz={nnz}, split={self.__split})"
         )
 
         if self.__comm.rank != 0:

--- a/heat/sparse/dcsr_matrix.py
+++ b/heat/sparse/dcsr_matrix.py
@@ -351,7 +351,7 @@ class DCSR_matrix:
             f"size={size}, nnz={nnz}, split={self.__split})"
         )
 
-        if self.__comm.rank != 0:
+        if self.comm.rank != 0:
             return ""
 
         return print_string

--- a/heat/sparse/dcsr_matrix.py
+++ b/heat/sparse/dcsr_matrix.py
@@ -346,9 +346,9 @@ class DCSR_matrix:
         nnz = self.__gnnz
 
         print_string = (
-            f"indices={self.indices}, "
-            f"data={self.data}, "
-            f"size={size}, nnz={nnz}, split={self.__split})"
+            f"DCSR_matrix(indices={self.indices},\n"
+            f"            data={self.data},\n"
+            f"            size={size}, nnz={nnz}, split={self.__split})"
         )
 
         if self.comm.rank != 0:

--- a/heat/sparse/dcsr_matrix.py
+++ b/heat/sparse/dcsr_matrix.py
@@ -347,6 +347,7 @@ class DCSR_matrix:
 
         print_string = (
             f"DCSR_matrix(indices={self.indices},\n"
+            f"            indptr={self.indptr},\n"
             f"            data={self.data},\n"
             f"            size={size}, nnz={nnz}, split={self.__split})"
         )


### PR DESCRIPTION
## Description
Added a `__str__()` method for printing the DCSR_matrix.
PyTorch displays the `sparse tensors` in this format:
![image](https://github.com/helmholtz-analytics/heat/assets/87087741/a18489a1-fb78-43d9-8a20-010b5d86b66b)
The introduced format displays the following:
![image](https://github.com/helmholtz-analytics/heat/assets/87087741/509ac669-c946-4dd7-b3cc-fa58c46f0c97)


Issue/s resolved: #1040

## Changes proposed:
- Added a method for printing the DCSR_matrix.

## Type of change
- New feature (non-breaking change which adds functionality)


## Due Diligence
- [x] All split configurations tested
- [x] Multiple dtypes tested in relevant functions
- [x] Documentation updated (if needed)
- [x] Title of PR is suitable for corresponding CHANGELOG entry

#### Does this change modify the behaviour of other functions? If so, which?
No