### PR TITLE
Add `hermitian()` to matrix gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,4 @@ testing.py
 heat/datasets/MNISTDataset
 perun_results/
 bench_data/
+my_dev_stuff

--- a/heat/utils/data/matrixgallery.py
+++ b/heat/utils/data/matrixgallery.py
@@ -25,22 +25,22 @@ def hermitian(
     positive_definite: bool = False,
 ) -> DNDarray:
     """
-    Generates a random Hermitian matrix of size `(n,n)`. A Hermitian matrix is a complex square matrix that is equal to its conjugate transpose; for real data-types this routine 
-    returns a random symmetric matrix of size `(n,n)`. 
+    Generates a random Hermitian matrix of size `(n,n)`. A Hermitian matrix is a complex square matrix that is equal to its conjugate transpose; for real data-types this routine
+    returns a random symmetric matrix of size `(n,n)`.
 
     If `positive_definite=True`, the output is given by ::math`\frac{1}{n} R R^H` with ::math`R \in \mathbb{K}^{n\times n}` having entries distributed according to the standard normal distribution.
-    This corresponds to sampling a random matrix according to the so-called Wishart distribution; see, e.g., [2], and also [3] for additional information regarding the asymptotic distribution of 
-    the singular values. The output matrix will be positive definite with probability 1. 
-    
-    If `positive_definite=False`, the output is ::math`R+R^H` with ::math`R` generated as above. 
+    This corresponds to sampling a random matrix according to the so-called Wishart distribution; see, e.g., [2], and also [3] for additional information regarding the asymptotic distribution of
+    the singular values. The output matrix will be positive definite with probability 1.
+
+    If `positive_definite=False`, the output is ::math`R+R^H` with ::math`R` generated as above.
 
     Parameters
     ----------
     n : int
         size of the resulting square matrix
     dtype: Type[datatype], optional
-        The desired data-type for the array, defaults to ht.complex64; only floating-point data-types allowed. 
-        For real data-types, i.e. float32 and float64, a matrix with real entries (i.e. a symmetric one) is returned. 
+        The desired data-type for the array, defaults to ht.complex64; only floating-point data-types allowed.
+        For real data-types, i.e. float32 and float64, a matrix with real entries (i.e. a symmetric one) is returned.
     split: None or int, optional
         The axis along which the array content is split and distributed in memory.
     device: None or str or Device, optional
@@ -56,16 +56,16 @@ def hermitian(
     [2] https://en.wikipedia.org/wiki/Wishart_distribution
     [3] https://en.wikipedia.org/wiki/Marchenko%E2%80%93Pastur_distribution
     """
-    if heat_type_is_complexfloating(dtype): 
+    if heat_type_is_complexfloating(dtype):
         real_dtype = core.float32 if dtype is core.complex64 else core.float64
         matrix = randn(n, n, dtype=real_dtype, split=split, device=device, comm=comm)
         matrix += 1j * randn(n, n, dtype=real_dtype, split=split, device=device, comm=comm)
     elif not heat_type_is_exact(dtype):
         matrix = randn(n, n, dtype=dtype, split=split, device=device, comm=comm)
     else:
-        raise ValueError('dtype must be floating-point data-type but is ',dtype,'.')         
+        raise ValueError("dtype must be floating-point data-type but is ", dtype, ".")
     if positive_definite:
-        return 1/n*matrix @ core.conj(matrix).T
+        return 1 / n * matrix @ core.conj(matrix).T
 
     return matrix + core.conj(matrix).T.resplit_(split)
 

--- a/heat/utils/data/matrixgallery.py
+++ b/heat/utils/data/matrixgallery.py
@@ -18,10 +18,11 @@ __all__ = ["hermitian", "parter", "random_known_singularvalues", "random_known_r
 
 def hermitian(
     n: int,
+    dtype: Type[datatype] = core.complex64,
     split: Union[None, int] = None,
     device: Union[None, str, Device] = None,
     comm: Union[None, Communication] = None,
-    dtype: Type[datatype] = core.complex64,
+    positive_definite: bool = False,
 ) -> DNDarray:
     """
     Generates a Hermitian matrix of size `(n,n)`. A Hermitian matrix is a  complex square matrix that is equal to its conjugate transpose.
@@ -30,23 +31,28 @@ def hermitian(
     ----------
     n : int
         size of the resulting square matrix
+    dtype: Type[datatype], optional
+        The desired data-type for the array, defaults to ht.complex64.
     split: None or int, optional
         The axis along which the array content is split and distributed in memory.
     device: None or str or Device, optional
         Specifies the device the tensor shall be allocated on, defaults globally set default device.
     comm : Communication, optional
         Handle to the nodes holding distributed parts or copies of this array.
-    dtype: Type[datatype], optional
-        The desired data-type for the array, defaults to ht.complex64.
+    positive_definite : bool, optional
+        If True, the resulting matrix is positive definite, defaults to False.
 
     References
     ----------
     [1] https://en.wikipedia.org/wiki/Hermitian_matrix
     """
     real_dtype = core.float32 if dtype is core.complex64 else core.float64
-    matrix = randn(n, n, dtype=real_dtype, split=split, device=device)
-    matrix += 1j * randn(n, n, dtype=real_dtype, split=split, device=device)
-    return matrix @ core.conj(matrix).T
+    matrix = randn(n, n, dtype=real_dtype, split=split, device=device, comm=comm)
+    matrix += 1j * randn(n, n, dtype=real_dtype, split=split, device=device, comm=comm)
+    if positive_definite:
+        return matrix @ core.conj(matrix).T
+
+    return matrix + core.conj(matrix).T.resplit_(split)
 
 
 def parter(

--- a/heat/utils/data/matrixgallery.py
+++ b/heat/utils/data/matrixgallery.py
@@ -13,7 +13,40 @@ from ...core.manipulations import diag, sort
 from ...core.exponential import log
 from typing import Type, Union, Tuple, Callable
 
-__all__ = ["parter", "random_known_singularvalues", "random_known_rank"]
+__all__ = ["hermitian", "parter", "random_known_singularvalues", "random_known_rank"]
+
+
+def hermitian(
+    n: int,
+    split: Union[None, int] = None,
+    device: Union[None, str, Device] = None,
+    comm: Union[None, Communication] = None,
+    dtype: Type[datatype] = core.complex64,
+) -> DNDarray:
+    """
+    Generates a Hermitian matrix of size `(n,n)`. A Hermitian matrix is a  complex square matrix that is equal to its conjugate transpose.
+
+    Parameters
+    ----------
+    n : int
+        size of the resulting square matrix
+    split: None or int, optional
+        The axis along which the array content is split and distributed in memory.
+    device: None or str or Device, optional
+        Specifies the device the tensor shall be allocated on, defaults globally set default device.
+    comm : Communication, optional
+        Handle to the nodes holding distributed parts or copies of this array.
+    dtype: Type[datatype], optional
+        The desired data-type for the array, defaults to ht.complex64.
+
+    References
+    ----------
+    [1] https://en.wikipedia.org/wiki/Hermitian_matrix
+    """
+    real_dtype = core.float32 if dtype is core.complex64 else core.float64
+    matrix = randn(n, n, dtype=real_dtype, split=split, device=device)
+    matrix += 1j * randn(n, n, dtype=real_dtype, split=split, device=device)
+    return matrix @ core.conj(matrix).T
 
 
 def parter(

--- a/heat/utils/data/matrixgallery.py
+++ b/heat/utils/data/matrixgallery.py
@@ -6,7 +6,7 @@ from heat import core
 from ...core.dndarray import DNDarray
 from ...core.communication import Communication
 from ...core.devices import Device
-from ...core.types import datatype
+from ...core.types import datatype, heat_type_is_complexfloating, heat_type_is_exact
 from ...core.random import randn, rand
 from ...core.linalg import qr, matmul
 from ...core.manipulations import diag, sort
@@ -25,14 +25,22 @@ def hermitian(
     positive_definite: bool = False,
 ) -> DNDarray:
     """
-    Generates a Hermitian matrix of size `(n,n)`. A Hermitian matrix is a  complex square matrix that is equal to its conjugate transpose.
+    Generates a random Hermitian matrix of size `(n,n)`. A Hermitian matrix is a complex square matrix that is equal to its conjugate transpose; for real data-types this routine 
+    returns a random symmetric matrix of size `(n,n)`. 
+
+    If `positive_definite=True`, the output is given by ::math`\frac{1}{n} R R^H` with ::math`R \in \mathbb{K}^{n\times n}` having entries distributed according to the standard normal distribution.
+    This corresponds to sampling a random matrix according to the so-called Wishart distribution; see, e.g., [2], and also [3] for additional information regarding the asymptotic distribution of 
+    the singular values. The output matrix will be positive definite with probability 1. 
+    
+    If `positive_definite=False`, the output is ::math`R+R^H` with ::math`R` generated as above. 
 
     Parameters
     ----------
     n : int
         size of the resulting square matrix
     dtype: Type[datatype], optional
-        The desired data-type for the array, defaults to ht.complex64.
+        The desired data-type for the array, defaults to ht.complex64; only floating-point data-types allowed. 
+        For real data-types, i.e. float32 and float64, a matrix with real entries (i.e. a symmetric one) is returned. 
     split: None or int, optional
         The axis along which the array content is split and distributed in memory.
     device: None or str or Device, optional
@@ -45,12 +53,19 @@ def hermitian(
     References
     ----------
     [1] https://en.wikipedia.org/wiki/Hermitian_matrix
+    [2] https://en.wikipedia.org/wiki/Wishart_distribution
+    [3] https://en.wikipedia.org/wiki/Marchenko%E2%80%93Pastur_distribution
     """
-    real_dtype = core.float32 if dtype is core.complex64 else core.float64
-    matrix = randn(n, n, dtype=real_dtype, split=split, device=device, comm=comm)
-    matrix += 1j * randn(n, n, dtype=real_dtype, split=split, device=device, comm=comm)
+    if heat_type_is_complexfloating(dtype): 
+        real_dtype = core.float32 if dtype is core.complex64 else core.float64
+        matrix = randn(n, n, dtype=real_dtype, split=split, device=device, comm=comm)
+        matrix += 1j * randn(n, n, dtype=real_dtype, split=split, device=device, comm=comm)
+    elif not heat_type_is_exact(dtype):
+        matrix = randn(n, n, dtype=dtype, split=split, device=device, comm=comm)
+    else:
+        raise ValueError('dtype must be floating-point data-type but is ',dtype,'.')         
     if positive_definite:
-        return matrix @ core.conj(matrix).T
+        return 1/n*matrix @ core.conj(matrix).T
 
     return matrix + core.conj(matrix).T.resplit_(split)
 

--- a/heat/utils/data/matrixgallery.py
+++ b/heat/utils/data/matrixgallery.py
@@ -24,15 +24,15 @@ def hermitian(
     comm: Union[None, Communication] = None,
     positive_definite: bool = False,
 ) -> DNDarray:
-    """
+    r"""
     Generates a random Hermitian matrix of size `(n,n)`. A Hermitian matrix is a complex square matrix that is equal to its conjugate transpose; for real data-types this routine
     returns a random symmetric matrix of size `(n,n)`.
 
-    If `positive_definite=True`, the output is given by ::math`\frac{1}{n} R R^H` with ::math`R \in \mathbb{K}^{n\times n}` having entries distributed according to the standard normal distribution.
+    If `positive_definite=True`, the output is given by :math:`\frac{1}{n} R R^H` with :math:`R\in\mathbb{K}^{n\times n}` having entries distributed according to the standard normal distribution.
     This corresponds to sampling a random matrix according to the so-called Wishart distribution; see, e.g., [2], and also [3] for additional information regarding the asymptotic distribution of
     the singular values. The output matrix will be positive definite with probability 1.
 
-    If `positive_definite=False`, the output is ::math`R+R^H` with ::math`R` generated as above.
+    If `positive_definite=False`, the output is :math:`R+R^H` with :math:`R` generated as above.
 
     Parameters
     ----------

--- a/heat/utils/data/tests/test_matrixgallery.py
+++ b/heat/utils/data/tests/test_matrixgallery.py
@@ -26,20 +26,24 @@ class TestMatrixgallery(TestCase):
         with self.assertRaises(ValueError):
             ht.utils.data.matrixgallery.hermition(20, split=0, dtype=ht.int32)
 
-        # test default: complex single precision, not positive definite 
+        # test default: complex single precision, not positive definite
         A = ht.utils.data.matrixgallery.hermitian(20, split=1)
         A_err = ht.norm(A - A.T.conj().resplit_(A.split)) / ht.norm(A)
         self.assertTrue(A_err <= 1e-6)
-        
-        for posdef in [True, False]: 
+
+        for posdef in [True, False]:
             # test complex double precision
-            A = ht.utils.data.matrixgallery.hermitian(20, dtype=ht.complex128, split=0,positive_definite=posdef)
+            A = ht.utils.data.matrixgallery.hermitian(
+                20, dtype=ht.complex128, split=0, positive_definite=posdef
+            )
             A_err = ht.norm(A - A.T.conj().resplit_(A.split)) / ht.norm(A)
             self.assertTrue(A.dtype == ht.complex128)
             self.assertTrue(A_err <= 1e-12)
-    
+
             # test real datatype
-            A = ht.utils.data.matrixgallery.hermitian(20, dtype=ht.float32, split=0,positive_definite=posdef)
+            A = ht.utils.data.matrixgallery.hermitian(
+                20, dtype=ht.float32, split=0, positive_definite=posdef
+            )
             A_err = ht.norm(A - A.T.conj().resplit_(A.split)) / ht.norm(A)
             self.assertTrue(A_err <= 1e-6)
             self.assertTrue(A.dtype == ht.float32)

--- a/heat/utils/data/tests/test_matrixgallery.py
+++ b/heat/utils/data/tests/test_matrixgallery.py
@@ -25,8 +25,13 @@ class TestMatrixgallery(TestCase):
             ht.utils.data.matrixgallery.hermitian(10, 20)
 
         A = ht.utils.data.matrixgallery.hermitian(20, split=1)
-        A_err = ht.norm(A - A.T.conj().resplit_(1)) / ht.norm(A)
+        A_err = ht.norm(A - A.T.conj().resplit_(A.split)) / ht.norm(A)
         self.assertTrue(A_err <= 1e-6)
+
+        # test double precision
+        A = ht.utils.data.matrixgallery.hermitian(20, dtype=ht.complex128, split=0)
+        A_err = ht.norm(A - A.T.conj().resplit_(A.split)) / ht.norm(A)
+        self.assertTrue(A_err <= 1e-12)
 
     def test_parter(self):
         parter = ht.utils.data.matrixgallery.parter(20)

--- a/heat/utils/data/tests/test_matrixgallery.py
+++ b/heat/utils/data/tests/test_matrixgallery.py
@@ -23,15 +23,26 @@ class TestMatrixgallery(TestCase):
     def test_hermitian(self):
         with self.assertRaises(ValueError):
             ht.utils.data.matrixgallery.hermitian(10, 20)
+        with self.assertRaises(ValueError):
+            ht.utils.data.matrixgallery.hermition(20, split=0, dtype=ht.int32)
 
+        # test default: complex single precision, not positive definite 
         A = ht.utils.data.matrixgallery.hermitian(20, split=1)
         A_err = ht.norm(A - A.T.conj().resplit_(A.split)) / ht.norm(A)
         self.assertTrue(A_err <= 1e-6)
-
-        # test double precision
-        A = ht.utils.data.matrixgallery.hermitian(20, dtype=ht.complex128, split=0)
-        A_err = ht.norm(A - A.T.conj().resplit_(A.split)) / ht.norm(A)
-        self.assertTrue(A_err <= 1e-12)
+        
+        for posdef in [True, False]: 
+            # test complex double precision
+            A = ht.utils.data.matrixgallery.hermitian(20, dtype=ht.complex128, split=0,positive_definite=posdef)
+            A_err = ht.norm(A - A.T.conj().resplit_(A.split)) / ht.norm(A)
+            self.assertTrue(A.dtype == ht.complex128)
+            self.assertTrue(A_err <= 1e-12)
+    
+            # test real datatype
+            A = ht.utils.data.matrixgallery.hermitian(20, dtype=ht.float32, split=0,positive_definite=posdef)
+            A_err = ht.norm(A - A.T.conj().resplit_(A.split)) / ht.norm(A)
+            self.assertTrue(A_err <= 1e-6)
+            self.assertTrue(A.dtype == ht.float32)
 
     def test_parter(self):
         parter = ht.utils.data.matrixgallery.parter(20)

--- a/heat/utils/data/tests/test_matrixgallery.py
+++ b/heat/utils/data/tests/test_matrixgallery.py
@@ -25,7 +25,7 @@ class TestMatrixgallery(TestCase):
             ht.utils.data.matrixgallery.hermitian(10, 20)
 
         A = ht.utils.data.matrixgallery.hermitian(20, split=1)
-        A_err = ht.norm(A - A.T.conj()) / ht.norm(A)
+        A_err = ht.norm(A - A.T.conj().resplit_(1)) / ht.norm(A)
         self.assertTrue(A_err <= 1e-6)
 
     def test_parter(self):

--- a/heat/utils/data/tests/test_matrixgallery.py
+++ b/heat/utils/data/tests/test_matrixgallery.py
@@ -20,6 +20,14 @@ class TestMatrixgallery(TestCase):
             dtype_tol = 1e-6
         self.assertTrue(U_orth_err <= dtype_tol)
 
+    def test_hermitian(self):
+        with self.assertRaises(ValueError):
+            ht.utils.data.matrixgallery.hermitian(10, 20)
+
+        A = ht.utils.data.matrixgallery.hermitian(20, split=1)
+        A_err = ht.norm(A - A.T.conj()) / ht.norm(A)
+        self.assertTrue(A_err <= 1e-6)
+
     def test_parter(self):
         parter = ht.utils.data.matrixgallery.parter(20)
         self.__check_parter(parter)

--- a/heat/utils/data/tests/test_matrixgallery.py
+++ b/heat/utils/data/tests/test_matrixgallery.py
@@ -24,7 +24,7 @@ class TestMatrixgallery(TestCase):
         with self.assertRaises(ValueError):
             ht.utils.data.matrixgallery.hermitian(10, 20)
         with self.assertRaises(ValueError):
-            ht.utils.data.matrixgallery.hermition(20, split=0, dtype=ht.int32)
+            ht.utils.data.matrixgallery.hermitian(20, split=0, dtype=ht.int32)
 
         # test default: complex single precision, not positive definite
         A = ht.utils.data.matrixgallery.hermitian(20, split=1)


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **base branch** must be `main` for new features, latest release branch (e.g. `release/1.3.x`) for bug fixes
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [x] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Creating a new PR to add tests for the Hermitian test matrix implemented in #1086.

Workflow: 
- merge #1086 into this PR ✅ 
- merge this PR into main

Issue/s resolved: #1073 

## Changes proposed:

-
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no
