### PR TITLE
Introduce `manipulations.collect(target_rank)` function and in-place `DNDarray.collect_(target_rank)` method

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -574,7 +574,7 @@ class DNDarray:
         Parameters
         ----------
         target_rank : int, optional
-            The rank to which the tensor will be collected. Default: 0.
+            The rank to which the DNDarray will be collected. Default: 0.
 
         Raises
         ------
@@ -585,7 +585,7 @@ class DNDarray:
 
         Examples
         --------
-        >>> a = st = ht.ones((50, 81, 67), split=2)
+        >>> st = ht.ones((50, 81, 67), split=2)
         >>> print(st.lshape)
         [0/2] (50, 81, 23)
         [1/2] (50, 81, 22)

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -599,10 +599,10 @@ class DNDarray:
         [1/2] (50, 81, 67)
         [2/2] (50, 81, 0)
         """
-        if not self.is_distributed():
-            return
         if target_rnk >= self.comm.size:
             raise ValueError("target rank is out of bounds")
+        if not self.is_distributed():
+            return
 
         target_map = torch.zeros((self.comm.size, self.ndim), dtype=torch.int64)
         target_map[target_rnk, self.split] = self.gshape[self.split]

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -569,7 +569,7 @@ class DNDarray:
     def collect_(self, target_rank: Optional[int] = 0) -> None:
         """
         A method collecting a distributed DNDarray to one MPI rank, chosen by the `target_rank` variable.
-        It is a specific case of the redistribute_ method.
+        It is a specific case of the ``redistribute_`` method.
 
         Parameters
         ----------

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -574,7 +574,7 @@ class DNDarray:
         Parameters
         ----------
         target_rank : int, optional
-            The rank to which the tensor will be collected.
+            The rank to which the tensor will be collected. Default: 0.
 
         Raises
         ------

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -578,6 +578,8 @@ class DNDarray:
 
         Raises
         ------
+        TypeError
+            If the target rank is not an integer.
         ValueError
             If the target rank is out of bounds.
 
@@ -599,6 +601,8 @@ class DNDarray:
         [1/2] (50, 81, 67)
         [2/2] (50, 81, 0)
         """
+        if not isinstance(target_rnk, int):
+            raise TypeError(f"target rank must be of type int , but was {type(target_rnk)}")
         if target_rnk >= self.comm.size:
             raise ValueError("target rank is out of bounds")
         if not self.is_distributed():

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -568,7 +568,7 @@ class DNDarray:
 
     def collect_(self, target_rank: Optional[int] = 0) -> None:
         """
-        A method collecting a distributed tensor to one rank, chosen by the target_rnk variable, and zero by default.
+        A method collecting a distributed DNDarray to one MPI rank, chosen by the `target_rank` variable.
         It is a specific case of the redistribute_ method.
 
         Parameters

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -609,9 +609,8 @@ class DNDarray:
             return
 
         target_map = self.lshape_map.clone()
-        for i in range(self.comm.size):
-            # branchless way of putting 0 in all entries except for the target rank
-            target_map[i, self.split] = self.gshape[self.split] * (i == target_rank)
+        target_map[:, self.split] = 0
+        target_map[target_rank, self.split] = self.gshape[self.split]
         self.redistribute_(target_map=target_map)
 
     def __complex__(self) -> DNDarray:

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -244,6 +244,52 @@ def broadcast_to(x: DNDarray, shape: Tuple[int, ...]) -> DNDarray:
     return broadcasted
 
 
+def collect(arr: DNDarray, target_rank: Optional[int] = 0) -> DNDarray:
+    """
+    A method collecting a distributed tensor to one rank, chosen by the target_rnk variable, and zero by default.
+    It is a specific case of the redistribute_ method.
+
+    Parameters
+    ----------
+    arr : DNDarray
+        The distributed tensor to be collected.
+    target_rank : int, optional
+        The rank to which the tensor will be collected.
+
+    Raises
+    ------
+    TypeError
+        If the target rank is not an integer.
+    ValueError
+        If the target rank is out of bounds.
+
+    Examples
+    --------
+    >>> a = st = ht.ones((50, 81, 67), split=2)
+    >>> print(st.lshape)
+    [0/2] (50, 81, 23)
+    [1/2] (50, 81, 22)
+    [2/2] (50, 81, 22)
+    >>> collected_st = collect(st)
+    >>> print(collected_st)
+    [0/2] (50, 81, 67)
+    [1/2] (50, 81, 0)
+    [2/2] (50, 81, 0)
+    >>> collected_st = collect(collected_st, 1)
+    >>> print(st.lshape)
+    [0/2] (50, 81, 0)
+    [1/2] (50, 81, 67)
+    [2/2] (50, 81, 0)
+    """
+    arr2 = arr.copy()
+    arr2.collect_(target_rank=target_rank)
+    return arr2
+
+
+DNDarray.collect = lambda arr, target_rank=0: redistribute(arr, target_rank)
+DNDarray.collect.__doc__ = collect.__doc__
+
+
 def column_stack(arrays: Sequence[DNDarray, ...]) -> DNDarray:
     """
     Stack 1-D or 2-D `DNDarray`s as columns into a 2-D `DNDarray`.

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -26,6 +26,7 @@ __all__ = [
     "balance",
     "broadcast_arrays",
     "broadcast_to",
+    "collect",
     "column_stack",
     "concatenate",
     "diag",

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -255,7 +255,7 @@ def collect(arr: DNDarray, target_rank: Optional[int] = 0) -> DNDarray:
     arr : DNDarray
         The DNDarray to be collected.
     target_rank : int, optional
-        The rank to which the tensor will be collected.
+        The rank to which the DNDarray will be collected. Default: 0.
 
     Raises
     ------

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -253,7 +253,7 @@ def collect(arr: DNDarray, target_rank: Optional[int] = 0) -> DNDarray:
     Parameters
     ----------
     arr : DNDarray
-        The distributed tensor to be collected.
+        The DNDarray to be collected.
     target_rank : int, optional
         The rank to which the tensor will be collected.
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -247,8 +247,8 @@ def broadcast_to(x: DNDarray, shape: Tuple[int, ...]) -> DNDarray:
 
 def collect(arr: DNDarray, target_rank: Optional[int] = 0) -> DNDarray:
     """
-    A function collecting a distributed DNDarray to one rank, chosen by the target_rank variable.
-    It is a specific case of the redistribute_ method.
+    A function collecting a distributed DNDarray to one rank, chosen by the `target_rank` variable.
+    It is a specific case of the ``redistribute_`` method.
 
     Parameters
     ----------
@@ -266,7 +266,7 @@ def collect(arr: DNDarray, target_rank: Optional[int] = 0) -> DNDarray:
 
     Examples
     --------
-    >>> a = st = ht.ones((50, 81, 67), split=2)
+    >>> st = ht.ones((50, 81, 67), split=2)
     >>> print(st.lshape)
     [0/2] (50, 81, 23)
     [1/2] (50, 81, 22)

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -247,7 +247,7 @@ def broadcast_to(x: DNDarray, shape: Tuple[int, ...]) -> DNDarray:
 
 def collect(arr: DNDarray, target_rank: Optional[int] = 0) -> DNDarray:
     """
-    A method collecting a distributed tensor to one rank, chosen by the target_rnk variable, and zero by default.
+    A function collecting a distributed DNDarray to one rank, chosen by the target_rank variable.
     It is a specific case of the redistribute_ method.
 
     Parameters

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -436,6 +436,12 @@ class TestDNDarray(TestCase):
             self.assertEqual(st.lshape, st.gshape)
 
         st = ht.zeros((50, 81, 67), split=0)
+        with self.assertRaises(TypeError):
+            st.collect_("st.comm.size + 1")
+        with self.assertRaises(TypeError):
+            st.collect_(1.0)
+        with self.assertRaises(TypeError):
+            st.collect_((1, 3))
         with self.assertRaises(ValueError):
             st.collect_(st.comm.size + 1)
 


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **base branch** must be `main` for new features, latest release branch (e.g. `release/1.3.x`) for bug fixes
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [x] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
As per title, added the collect method which brings all data of a distributed tensor to a single rank, which can be specified by the user. Uses the redistribute method.

Issue/s resolved: [implement a collect method #480](https://github.com/helmholtz-analytics/heat/issues/480)

## Changes proposed:


## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- New feature (non-breaking change which adds functionality)

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no
