### PR TITLE
Implement `to_sparse()` method for DNDarray conversion to DCSR_matrix

### DIFF
--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -61,6 +61,7 @@ __all__ = [
     "vstack",
 ]
 
+
 def balance(array: DNDarray, copy=False) -> DNDarray:
     """
     Out of place balance function. More information on the meaning of balance can be found in

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -9,9 +9,6 @@ import warnings
 
 from typing import Iterable, Type, List, Callable, Union, Tuple, Sequence, Optional
 
-from heat.sparse.dcsr_matrix import DCSR_matrix
-from heat.sparse.factories import sparse_csr_matrix
-
 from .communication import MPI
 from .dndarray import DNDarray
 
@@ -62,45 +59,7 @@ __all__ = [
     "unique",
     "vsplit",
     "vstack",
-    "to_sparse",
 ]
-
-
-def to_sparse(array: DNDarray) -> DCSR_matrix:
-    """
-    Convert the distributed array to a sparse DCSR_matrix representation.
-
-    Parameters
-    ----------
-    array : DNDarray
-        The distributed array to be converted to a sparse DCSR_matrix.
-
-    Returns
-    -------
-    DCSR_matrix
-        A sparse DCSR_matrix representation of the input DNDarray.
-
-    Notes
-    -----
-    This method allows for the conversion of a DNDarray into a sparse DCSR_matrix representation,
-    which is useful for handling large and sparse datasets efficiently.
-
-    Examples
-    --------
-    >>> dense_array = ht.array([[1, 0, 0], [0, 0, 2], [0, 3, 0]])
-    >>> sparse_matrix = dense_array.to_sparse()
-
-    """
-    array.balance_()
-    csr_matrices = [sparse_csr_matrix(tensor, is_split=array.split) for tensor in array.larray]
-    result = DCSR_matrix.from_csr_matrices(csr_matrices)
-
-    return result
-
-
-DNDarray.to_sparse: Callable[[DNDarray], DCSR_matrix] = lambda self: to_sparse(self)
-DNDarray.to_sparse.__doc__ = to_sparse.__doc__
-
 
 def balance(array: DNDarray, copy=False) -> DNDarray:
     """

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -97,8 +97,10 @@ def to_sparse(array: DNDarray) -> DCSR_matrix:
 
     return result
 
+
 DNDarray.to_sparse: Callable[[DNDarray], DCSR_matrix] = lambda self: to_sparse(self)
 DNDarray.to_sparse.__doc__ = to_sparse.__doc__
+
 
 def balance(array: DNDarray, copy=False) -> DNDarray:
     """

--- a/heat/sparse/manipulations.py
+++ b/heat/sparse/manipulations.py
@@ -40,7 +40,6 @@ def to_sparse(array: DNDarray) -> DCSR_matrix:
     """
     array.balance_()
     result = sparse_csr_matrix(array.larray, is_split=array.split)
-    print(result)
     return result
 
 

--- a/heat/sparse/manipulations.py
+++ b/heat/sparse/manipulations.py
@@ -12,6 +12,7 @@ __all__ = [
     "to_sparse",
 ]
 
+
 def to_sparse(array: DNDarray) -> DCSR_matrix:
     """
     Convert the distributed array to a sparse DCSR_matrix representation.
@@ -42,8 +43,10 @@ def to_sparse(array: DNDarray) -> DCSR_matrix:
     print(result)
     return result
 
+
 DNDarray.to_sparse = to_sparse
 DNDarray.to_sparse.__doc__ = to_sparse.__doc__
+
 
 def todense(sparse_matrix: DCSR_matrix, order="C", out: DNDarray = None) -> DNDarray:
     """

--- a/heat/sparse/manipulations.py
+++ b/heat/sparse/manipulations.py
@@ -39,7 +39,7 @@ def to_sparse(array: DNDarray) -> DCSR_matrix:
 
     """
     array.balance_()
-    result = sparse_csr_matrix(array.larray, is_split=array.split)
+    result = sparse_csr_matrix(array.larray, dtype=array.dtype, device=array.device, comm=array.comm, is_split=array.split)
     return result
 
 

--- a/heat/sparse/manipulations.py
+++ b/heat/sparse/manipulations.py
@@ -2,15 +2,48 @@
 from __future__ import annotations
 
 from heat.sparse.dcsr_matrix import DCSR_matrix
-
+from heat.sparse.factories import sparse_csr_matrix
 from ..core.memory import sanitize_memory_layout
 from ..core.dndarray import DNDarray
 from ..core.factories import empty
 
 __all__ = [
     "todense",
+    "to_sparse",
 ]
 
+def to_sparse(array: DNDarray) -> DCSR_matrix:
+    """
+    Convert the distributed array to a sparse DCSR_matrix representation.
+
+    Parameters
+    ----------
+    array : DNDarray
+        The distributed array to be converted to a sparse DCSR_matrix.
+
+    Returns
+    -------
+    DCSR_matrix
+        A sparse DCSR_matrix representation of the input DNDarray.
+
+    Notes
+    -----
+    This method allows for the conversion of a DNDarray into a sparse DCSR_matrix representation,
+    which is useful for handling large and sparse datasets efficiently.
+
+    Examples
+    --------
+    >>> dense_array = ht.array([[1, 0, 0], [0, 0, 2], [0, 3, 0]])
+    >>> sparse_matrix = dense_array.to_sparse()
+
+    """
+    array.balance_()
+    result = sparse_csr_matrix(array.larray, is_split=array.split)
+    print(result)
+    return result
+
+DNDarray.to_sparse = to_sparse
+DNDarray.to_sparse.__doc__ = to_sparse.__doc__
 
 def todense(sparse_matrix: DCSR_matrix, order="C", out: DNDarray = None) -> DNDarray:
     """

--- a/heat/sparse/manipulations.py
+++ b/heat/sparse/manipulations.py
@@ -8,7 +8,7 @@ from ..core.dndarray import DNDarray
 from ..core.factories import empty
 
 __all__ = [
-    "todense",
+    "to_dense",
     "to_sparse",
 ]
 
@@ -49,7 +49,7 @@ DNDarray.to_sparse = to_sparse
 DNDarray.to_sparse.__doc__ = to_sparse.__doc__
 
 
-def todense(sparse_matrix: DCSR_matrix, order="C", out: DNDarray = None) -> DNDarray:
+def to_dense(sparse_matrix: DCSR_matrix, order="C", out: DNDarray = None) -> DNDarray:
     """
     Convert :class:`~heat.sparse.DCSR_matrix` to a dense :class:`~heat.core.DNDarray`.
     Output follows the same distribution among processes as the input
@@ -112,5 +112,5 @@ def todense(sparse_matrix: DCSR_matrix, order="C", out: DNDarray = None) -> DNDa
     return out
 
 
-DCSR_matrix.todense = lambda self, order="C", out=None: todense(self, order, out)
-DCSR_matrix.to_dense = lambda self, order="C", out=None: todense(self, order, out)
+DCSR_matrix.todense = lambda self, order="C", out=None: to_dense(self, order, out)
+DCSR_matrix.to_dense = lambda self, order="C", out=None: to_dense(self, order, out)

--- a/heat/sparse/manipulations.py
+++ b/heat/sparse/manipulations.py
@@ -39,7 +39,9 @@ def to_sparse(array: DNDarray) -> DCSR_matrix:
 
     """
     array.balance_()
-    result = sparse_csr_matrix(array.larray, dtype=array.dtype, device=array.device, comm=array.comm, is_split=array.split)
+    result = sparse_csr_matrix(
+        array.larray, dtype=array.dtype, device=array.device, comm=array.comm, is_split=array.split
+    )
     return result
 
 

--- a/heat/sparse/tests/test_manipulations.py
+++ b/heat/sparse/tests/test_manipulations.py
@@ -38,7 +38,7 @@ class TestManipulations(TestCase):
 
         A = ht.array(arr, split=0)
         B = A.to_sparse()
-        
+
         dense_A = A.larray.to_dense()
         dense_B = B.larray.to_dense()
 

--- a/heat/sparse/tests/test_manipulations.py
+++ b/heat/sparse/tests/test_manipulations.py
@@ -33,6 +33,18 @@ class TestManipulations(TestCase):
             self.ref_indptr, self.ref_indices, self.ref_data, device=self.device.torch_device
         )
 
+    def test_to_sparse(self):
+        # Create a dense DNDarray
+        arr = [[0, 0, 1, 0, 2],
+               [0, 0, 0, 0, 0],
+               [0, 3, 0, 0, 0],
+               [4, 0, 0, 5, 0],
+               [0, 0, 0, 0, 6]]
+        
+        A = ht.array(arr, split=0)
+        B = A.to_sparse()
+        self.assertTrue(A.larray.to_sparse_csr() == B.larray)
+
     def test_todense(self):
         heat_sparse_csr = ht.sparse.sparse_csr_matrix(self.ref_torch_sparse_csr)
 

--- a/heat/sparse/tests/test_manipulations.py
+++ b/heat/sparse/tests/test_manipulations.py
@@ -34,7 +34,6 @@ class TestManipulations(TestCase):
         )
 
     def test_to_sparse(self):
-        # Create a dense DNDarray
         arr = [[0, 0, 1, 0, 2], [0, 0, 0, 0, 0], [0, 3, 0, 0, 0], [4, 0, 0, 5, 0], [0, 0, 0, 0, 6]]
 
         A = ht.array(arr, split=0)

--- a/heat/sparse/tests/test_manipulations.py
+++ b/heat/sparse/tests/test_manipulations.py
@@ -39,10 +39,24 @@ class TestManipulations(TestCase):
         A = ht.array(arr, split=0)
         B = A.to_sparse()
 
-        dense_A = A.larray.to_dense()
-        dense_B = B.larray.to_dense()
+        indptr_B = [0, 2, 2, 3, 5, 6]
+        indices_B = [2, 4, 1, 0, 3, 4]
+        data_B = [1, 2, 3, 4, 5, 6]
 
-        self.assertTrue(torch.equal(dense_A, dense_B))
+        self.assertIsInstance(B, ht.sparse.DCSR_matrix)
+        self.assertTrue(
+            (B.indptr == torch.tensor(indptr_B, device=self.device.torch_device)).all()
+        )
+        self.assertTrue(
+            (B.indices == torch.tensor(indices_B, device=self.device.torch_device)).all()
+        )
+        self.assertTrue(
+            (B.data == torch.tensor(data_B, device=self.device.torch_device)).all()
+        )
+        self.assertEqual(B.nnz, len(data_B))
+        self.assertEqual(B.split, 0)
+        self.assertEqual(B.shape, A.shape)
+        self.assertEqual(B.dtype, A.dtype)
 
     def test_todense(self):
         heat_sparse_csr = ht.sparse.sparse_csr_matrix(self.ref_torch_sparse_csr)

--- a/heat/sparse/tests/test_manipulations.py
+++ b/heat/sparse/tests/test_manipulations.py
@@ -54,7 +54,7 @@ class TestManipulations(TestCase):
         self.assertEqual(B.shape, A.shape)
         self.assertEqual(B.dtype, A.dtype)
 
-    def test_todense(self):
+    def test_to_dense(self):
         heat_sparse_csr = ht.sparse.sparse_csr_matrix(self.ref_torch_sparse_csr)
 
         ref_dense_array = ht.array(

--- a/heat/sparse/tests/test_manipulations.py
+++ b/heat/sparse/tests/test_manipulations.py
@@ -44,15 +44,11 @@ class TestManipulations(TestCase):
         data_B = [1, 2, 3, 4, 5, 6]
 
         self.assertIsInstance(B, ht.sparse.DCSR_matrix)
-        self.assertTrue(
-            (B.indptr == torch.tensor(indptr_B, device=self.device.torch_device)).all()
-        )
+        self.assertTrue((B.indptr == torch.tensor(indptr_B, device=self.device.torch_device)).all())
         self.assertTrue(
             (B.indices == torch.tensor(indices_B, device=self.device.torch_device)).all()
         )
-        self.assertTrue(
-            (B.data == torch.tensor(data_B, device=self.device.torch_device)).all()
-        )
+        self.assertTrue((B.data == torch.tensor(data_B, device=self.device.torch_device)).all())
         self.assertEqual(B.nnz, len(data_B))
         self.assertEqual(B.split, 0)
         self.assertEqual(B.shape, A.shape)

--- a/heat/sparse/tests/test_manipulations.py
+++ b/heat/sparse/tests/test_manipulations.py
@@ -35,12 +35,8 @@ class TestManipulations(TestCase):
 
     def test_to_sparse(self):
         # Create a dense DNDarray
-        arr = [[0, 0, 1, 0, 2],
-               [0, 0, 0, 0, 0],
-               [0, 3, 0, 0, 0],
-               [4, 0, 0, 5, 0],
-               [0, 0, 0, 0, 6]]
-        
+        arr = [[0, 0, 1, 0, 2], [0, 0, 0, 0, 0], [0, 3, 0, 0, 0], [4, 0, 0, 5, 0], [0, 0, 0, 0, 6]]
+
         A = ht.array(arr, split=0)
         B = A.to_sparse()
         self.assertTrue(A.larray.to_sparse_csr() == B.larray)

--- a/heat/sparse/tests/test_manipulations.py
+++ b/heat/sparse/tests/test_manipulations.py
@@ -38,7 +38,11 @@ class TestManipulations(TestCase):
 
         A = ht.array(arr, split=0)
         B = A.to_sparse()
-        self.assertTrue(A.larray.to_sparse_csr() == B.larray)
+        
+        dense_A = A.larray.to_dense()
+        dense_B = B.larray.to_dense()
+
+        self.assertTrue(torch.equal(dense_A, dense_B))
 
     def test_todense(self):
         heat_sparse_csr = ht.sparse.sparse_csr_matrix(self.ref_torch_sparse_csr)


### PR DESCRIPTION
worked on [Feature-384 Sparse] to_sparse() method for DNDarray class 
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [X]  **base branch** must be `main` for new features, latest release branch (e.g. `release/1.3.x`) for bug fixes
    - [X]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [x] documentation updated where needed

## Description
Implemented `to_sparse()` method for DNDarray class conversion to DCSR_matrix representation
<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #1054 

## Changes proposed:

- Added the to_sparse() method to the DNDarray class for converting to a DCSR_matrix representation.

## Type of change
New feature (non-breaking change which adds functionality)

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
Memory requirements for this change have not been profiled at this time.

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->
Performance metrics for this change have not been measured at this time.

#### Does this change modify the behaviour of other functions? If so, which?
no
