### PR TITLE
Add `ht.concatenate` to Continuous Benchmarks

### DIFF
--- a/benchmarks/cb/manipulations.py
+++ b/benchmarks/cb/manipulations.py
@@ -4,6 +4,12 @@ from perun import monitor
 
 
 @monitor()
+def concatenate(arrays):
+    # benchmark concatenation of 3 arrays with split 1, None, 1 respectively
+    a = ht.concatenate(arrays, axis=1)
+
+
+@monitor()
 def reshape(arrays):
     for array in arrays:
         a = ht.reshape(array, (10000000, -1), new_split=1)
@@ -14,5 +20,13 @@ def run_manipulation_benchmarks():
     arrays = []
     for size in sizes:
         arrays.append(ht.zeros((1000, size), split=1))
-
     reshape(arrays)
+
+    arrays = []
+    for i, size in enumerate(sizes):
+        if i == 1:
+            split = None
+        else:
+            split = 1
+        arrays.append(ht.zeros((1000, size), split=split))
+    concatenate(arrays)


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **base branch** must be `main` for new features, latest release branch (e.g. `release/1.3.x`) for bug fixes
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [x] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #1207 


## Changes proposed:

- added concatenation along split axis to `manipulations` benchmarks
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- New feature (non-breaking change which adds functionality)

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
NA
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->
NA
#### Does this change modify the behaviour of other functions? If so, which?
 no
