### PR TITLE
Added `ht.broadcast_shapes`

### DIFF
--- a/heat/core/__init__.py
+++ b/heat/core/__init__.py
@@ -22,6 +22,7 @@ from .relational import *
 from .rounding import *
 from .sanitation import *
 from .statistics import *
+from .stride_tricks import *
 from .dndarray import *
 from .tiling import *
 from .trigonometrics import *

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -109,9 +109,7 @@ def broadcast_shapes(*shapes: Tuple[int, ...]) -> Tuple[int, ...]:
         resulting_shape = max(len(shape) for shape in shapes) * [None]
         for i, values in enumerate(it):
             # if any value is 0, or if there is a mix of 1s and non-1s
-            if any(val == 0 for val in values) or any(
-                val != 1 and val != values[0] for val in values
-            ):
+            if any(val == 0 or (val != 1 and val != values[0]) for val in values):
                 raise ValueError(f"operands could not be broadcast, input shapes {shapes}")
             else:
                 resulting_shape[i] = max(values)

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -104,16 +104,6 @@ def broadcast_shapes(*shapes: Tuple[int, ...]) -> Tuple[int, ...]:
     """
     try:
         resulting_shape = torch.broadcast_shapes(*shapes)
-    except AttributeError:  # torch < 1.8
-        it = itertools.zip_longest(*shapes[::-1], fillvalue=1)
-        resulting_shape = max(len(shape) for shape in shapes) * [None]
-        for i, values in enumerate(it):
-            # if any value is 0, or if there is a mix of 1s and non-1s
-            if any(val == 0 or (val != 1 and val != values[0]) for val in values):
-                raise ValueError(f"operands could not be broadcast, input shapes {shapes}")
-            else:
-                resulting_shape[i] = max(values)
-        return tuple(resulting_shape[::-1])
     except TypeError:
         raise TypeError(f"operands must be tuples of ints, not {shapes}")
     except RuntimeError:

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -66,6 +66,7 @@ def broadcast_shape(shape_a: Tuple[int, ...], shape_b: Tuple[int, ...]) -> Tuple
 
     return tuple(resulting_shape)
 
+
 def broadcast_shapes(*shapes: Tuple[int, ...]) -> Tuple[int, ...]:
     """
     Infers, if possible, the broadcast output shape of multiple operands.
@@ -108,7 +109,9 @@ def broadcast_shapes(*shapes: Tuple[int, ...]) -> Tuple[int, ...]:
         resulting_shape = max(len(shape) for shape in shapes) * [None]
         for i, values in enumerate(it):
             # if any value is 0, or if there is a mix of 1s and non-1s
-            if any(val == 0 for val in values) or any(val != 1 and val != values[0] for val in values):
+            if any(val == 0 for val in values) or any(
+                val != 1 and val != values[0] for val in values
+            ):
                 raise ValueError(f"operands could not be broadcast, input shapes {shapes}")
             else:
                 resulting_shape[i] = max(values)
@@ -119,6 +122,7 @@ def broadcast_shapes(*shapes: Tuple[int, ...]) -> Tuple[int, ...]:
         raise ValueError(f"operands could not be broadcast, input shapes {shapes}")
 
     return tuple(resulting_shape)
+
 
 def sanitize_axis(
     shape: Tuple[int, ...], axis: Union[int, None, Tuple[int, ...]]

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -66,6 +66,59 @@ def broadcast_shape(shape_a: Tuple[int, ...], shape_b: Tuple[int, ...]) -> Tuple
 
     return tuple(resulting_shape)
 
+def broadcast_shapes(*shapes: Tuple[int, ...]) -> Tuple[int, ...]:
+    """
+    Infers, if possible, the broadcast output shape of multiple operands.
+
+    Parameters
+    ----------
+    *shapes : Tuple[int,...]
+        Shapes of operands.
+
+    Returns
+    -------
+    Tuple[int, ...]
+        The broadcast output shape.
+
+    Raises
+    -------
+    ValueError
+        If the shapes cannot be broadcast.
+
+    Examples
+    --------
+    >>> import heat as ht
+    >>> ht.broadcast_shapes((5,4),(4,))
+    (5, 4)
+    >>> ht.broadcast_shapes((1,100,1),(10,1,5))
+    (10, 100, 5)
+    >>> ht.broadcast_shapes((8,1,6,1),(7,1,5,))
+    (8,7,6,5))
+    >>> ht.broadcast_shapes((2,1),(8,4,3))
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "heat/core/stride_tricks.py", line 100, in broadcast_shapes
+        "operands could not be broadcast, input shapes {}".format(shapes))
+    ValueError: operands could not be broadcast, input shapes ((2, 1), (8, 4, 3))
+    """
+    try:
+        resulting_shape = torch.broadcast_shapes(*shapes)
+    except AttributeError:  # torch < 1.8
+        it = itertools.zip_longest(*shapes[::-1], fillvalue=1)  # Use zip_longest with fillvalue=1
+        resulting_shape = max(len(shape) for shape in shapes) * [None]
+        for i, values in enumerate(it):
+            # if any value is 0, or if there is a mix of 1s and non-1s
+            if any(val == 0 for val in values) or any(val != 1 and val != values[0] for val in values):
+                raise ValueError(f"operands could not be broadcast, input shapes {shapes}")
+            else:
+                resulting_shape[i] = max(values)
+        return tuple(resulting_shape[::-1])
+    except TypeError:
+        raise TypeError(f"operands must be tuples of ints, not {shapes}")
+    except RuntimeError:
+        raise ValueError(f"operands could not be broadcast, input shapes {shapes}")
+
+    return tuple(resulting_shape)
 
 def sanitize_axis(
     shape: Tuple[int, ...], axis: Union[int, None, Tuple[int, ...]]

--- a/heat/core/stride_tricks.py
+++ b/heat/core/stride_tricks.py
@@ -104,7 +104,7 @@ def broadcast_shapes(*shapes: Tuple[int, ...]) -> Tuple[int, ...]:
     try:
         resulting_shape = torch.broadcast_shapes(*shapes)
     except AttributeError:  # torch < 1.8
-        it = itertools.zip_longest(*shapes[::-1], fillvalue=1)  # Use zip_longest with fillvalue=1
+        it = itertools.zip_longest(*shapes[::-1], fillvalue=1)
         resulting_shape = max(len(shape) for shape in shapes) * [None]
         for i, values in enumerate(it):
             # if any value is 0, or if there is a mix of 1s and non-1s

--- a/heat/core/tests/test_stride_tricks.py
+++ b/heat/core/tests/test_stride_tricks.py
@@ -22,6 +22,29 @@ class TestStrideTricks(TestCase):
         with self.assertRaises(ValueError):
             ht.core.stride_tricks.broadcast_shape((2, 1), (8, 4, 3))
 
+    def test_broadcast_shapes(self):
+        self.assertEqual(ht.core.stride_tricks.broadcast_shapes((5, 4), (4,)), (5, 4))
+        self.assertEqual(
+            ht.core.stride_tricks.broadcast_shapes((1, 100, 1), (10, 1, 5)), (10, 100, 5)
+        )
+        self.assertEqual(
+            ht.core.stride_tricks.broadcast_shapes((8, 1, 6, 1), (7, 1, 5)), (8, 7, 6, 5)
+        )
+        self.assertEqual(
+        ht.core.stride_tricks.broadcast_shapes((6, 7), (5, 6, 1), (7,), (5, 1, 7)), (5, 6, 7)
+        )
+
+        # invalid value ranges
+        with self.assertRaises(ValueError):
+            ht.core.stride_tricks.broadcast_shapes((5, 4), (5,))
+        with self.assertRaises(ValueError):
+            ht.core.stride_tricks.broadcast_shapes((5, 4), (2, 3))
+        with self.assertRaises(ValueError):
+            ht.core.stride_tricks.broadcast_shapes((5, 2), (5, 2, 3))
+        with self.assertRaises(ValueError):
+            ht.core.stride_tricks.broadcast_shapes((2, 1), (8, 4, 3))
+
+
     def test_sanitize_axis(self):
         self.assertEqual(ht.core.stride_tricks.sanitize_axis((5, 4, 4), 1), 1)
         self.assertEqual(ht.core.stride_tricks.sanitize_axis((5, 4, 4), -1), 2)

--- a/heat/core/tests/test_stride_tricks.py
+++ b/heat/core/tests/test_stride_tricks.py
@@ -31,7 +31,7 @@ class TestStrideTricks(TestCase):
             ht.core.stride_tricks.broadcast_shapes((8, 1, 6, 1), (7, 1, 5)), (8, 7, 6, 5)
         )
         self.assertEqual(
-        ht.core.stride_tricks.broadcast_shapes((6, 7), (5, 6, 1), (7,), (5, 1, 7)), (5, 6, 7)
+            ht.core.stride_tricks.broadcast_shapes((6, 7), (5, 6, 1), (7,), (5, 1, 7)), (5, 6, 7)
         )
 
         # invalid value ranges
@@ -43,7 +43,6 @@ class TestStrideTricks(TestCase):
             ht.core.stride_tricks.broadcast_shapes((5, 2), (5, 2, 3))
         with self.assertRaises(ValueError):
             ht.core.stride_tricks.broadcast_shapes((2, 1), (8, 4, 3))
-
 
     def test_sanitize_axis(self):
         self.assertEqual(ht.core.stride_tricks.sanitize_axis((5, 4, 4), 1), 1)


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [X]  **base branch** must be `main` for new features, latest release branch (e.g. `release/1.3.x`) for bug fixes
    - [X]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [X] unit tests: all split configurations tested
    - [X] unit tests: multiple dtypes tested
    - [X] documentation updated where needed

## Description
This PR addresses issue #904  by implementing `ht.broadcast_shapes`to align with numpy and torch counterparts in terms of naming, calling, and handling multiple shapes.
<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #904 

## Changes proposed:
- Added ht.broadcast_shapes with the desired behavior.

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
New feature (non-breaking change which adds functionality)
## Memory requirements
Memory requirements for this change have not been profiled at this time.

<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
Performance metrics for this change have not been measured at this time.


<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no
