### PR TITLE
Trigger Benchmark Corrections

### DIFF
--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -29,7 +29,7 @@ jobs:
           --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_CB_API_TOKEN }}" \
           --output report.txt \
           "https://codebase.helmholtz.cloud/api/v4/projects/7930/jobs/${{ inputs.job_id }}/artifacts/heat/bench_data/report.txt"
-          cat report.txt
+          cat report.txt >> $GITHUB_STEP_SUMMARY
       - name: Compare and Save Benchmark Results
         if: ${{github.ref == 'refs/heads/main'}}
         uses: benchmark-action/github-action-benchmark@v1
@@ -48,13 +48,17 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/main' }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
-      - uses: LouisBrunner/checks-action@v1.3.1
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: report_benchmarks
-          conclusion: ${{ job.status }}
-          details_url: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines
-          output: |
-            {"title": "${{ github.ref }} Benchmarking results", "summary": "Heat benchmark results obtained from gitlab and perun"}
-          output_text_description_file: report.txt
+      - run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/$OWNER/$REPO/statuses/$GITHUB_SHA \
+            -f state='${{ job.status }}' \
+            -f target_url='https://github.com/$OWNER/$REPO/actions/runs/${{ github.run_id }}' \
+            -f description='Benchmark results are here!' \
+            -f context='continuous-benchmarking/report'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -48,12 +48,12 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/main' }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
-      - run: |
-          gh api \
-            --method POST \
+      - name: Update commit status
+        run: |
+          gh api --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/$OWNER/$REPO/statuses/$GITHUB_SHA \
+            /repos/$REPO/statuses/$GITHUB_SHA \
             -f state='${{ job.status }}' \
             -f target_url='https://github.com/$OWNER/$REPO/actions/runs/${{ github.run_id }}' \
             -f description='Benchmark results are here!' \

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -29,7 +29,7 @@ jobs:
           --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_CB_API_TOKEN }}" \
           --output report.txt \
           "https://codebase.helmholtz.cloud/api/v4/projects/7930/jobs/${{ inputs.job_id }}/artifacts/heat/bench_data/report.txt"
-          echo "Pipeline URL: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines/${{ inputs.job_id}}" >> $GITHUB_STEP_SUMMARY
+          echo "Pipeline URL: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/jobs/${{ inputs.job_id}}" >> $GITHUB_STEP_SUMMARY
           cat report.txt >> $GITHUB_STEP_SUMMARY
       - name: Compare and Save Benchmark Results
         id: action_bench

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -29,8 +29,10 @@ jobs:
           --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_CB_API_TOKEN }}" \
           --output report.txt \
           "https://codebase.helmholtz.cloud/api/v4/projects/7930/jobs/${{ inputs.job_id }}/artifacts/heat/bench_data/report.txt"
+          echo "Pipeline URL: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines/${{ inputs.job_id}}" >> $GITHUB_STEP_SUMMARY
           cat report.txt >> $GITHUB_STEP_SUMMARY
       - name: Compare and Save Benchmark Results
+        id: action_bench
         if: ${{github.ref == 'refs/heads/main'}}
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -50,13 +52,12 @@ jobs:
           benchmark-data-dir-path: dev/bench
       - name: Update commit status
         run: |
-          gh api --method POST \
+          json=$(jo state="${{ steps.action_bench.outcome }}" target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" description="Benchmarks results are here!" context="cb/report")
+          curl -L -X POST \
             -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/$REPO/statuses/$GITHUB_SHA \
-            -f state='${{ job.status }}' \
-            -f target_url='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
-            -f description='Benchmark results are here!' \
-            -f context='continuous-benchmarking/report'
+            https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
+            -d "$json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -59,4 +59,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-            -d '{ "state":"$STEP_STATE", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'
+            -d "{ \"state\":\"$STEP_STATE\", \"target_url\":\"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\", \"description\":\"The results are here!\", \"context\":\"cb/report\" }"

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -33,7 +33,6 @@ jobs:
           cat report.txt >> $GITHUB_STEP_SUMMARY
       - name: Compare and Save Benchmark Results
         id: action_bench
-        if: ${{github.ref == 'refs/heads/main'}}
         uses: benchmark-action/github-action-benchmark@v1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -52,7 +52,7 @@ jobs:
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Running Benchmarks
+          name: Trigger Benchmarks / Running Benchmarks
           conclusion: ${{ job.status }}
           details_url: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines
           output: |

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -59,5 +59,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-            -d '{ "state":"$STEP_STATE", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }' \
-            -o /dev/null
+            -d '{ "state":"$STEP_STATE", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -52,7 +52,7 @@ jobs:
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Trigger Benchmarks / Running Benchmarks
+          name: report_benchmarks
           conclusion: ${{ job.status }}
           details_url: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines
           output: |

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -52,12 +52,11 @@ jobs:
           benchmark-data-dir-path: dev/bench
       - name: Update commit status
         run: |
-          json=$(jo state="${{ steps.action_bench.outcome }}" target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" description="Benchmarks results are here!" context="cb/report")
           curl -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
-            -d '{ "status":"${{ steps.action_bench.outcome }}", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'
+            -d '{ "state":"${{ steps.action_bench.outcome }}", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "Collect Gitlab Benchmarks"
         run: |
           curl --location \
@@ -56,7 +56,5 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
+            https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
             -d '{ "state":"${{ steps.action_bench.outcome }}", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -55,10 +55,8 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/$REPO/statuses/$GITHUB_SHA \
             -f state='${{ job.status }}' \
-            -f target_url='https://github.com/$OWNER/$REPO/actions/runs/${{ github.run_id }}' \
+            -f target_url='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
             -f description='Benchmark results are here!' \
             -f context='continuous-benchmarking/report'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.repository }}

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -59,4 +59,5 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-            -d '{ "state":"${STEP_STATE}", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'
+            -d '{ "state":"$STEP_STATE", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }' \
+            -o /dev/null

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -50,10 +50,12 @@ jobs:
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
       - name: Update commit status
+        if: always()
         run: |
+          if [[ "${{ steps.action_bench.outcome }}" == "success|failure" ]]; then stepState="${{ steps.action_bench.outcome }}"; else stepState=error; fi
           curl -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-            -d '{ "state":"${{ steps.action_bench.outcome }}", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'
+            -d '{ "state":"${stepState}", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -58,6 +58,6 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
-            -d "$json"
+            -d '{ "status":"${{ steps.action_bench.outcome }}", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench_report.yml
+++ b/.github/workflows/bench_report.yml
@@ -52,10 +52,11 @@ jobs:
       - name: Update commit status
         if: always()
         run: |
-          if [[ "${{ steps.action_bench.outcome }}" == "success|failure" ]]; then stepState="${{ steps.action_bench.outcome }}"; else stepState=error; fi
+          if [[ "${{ steps.action_bench.outcome }}" =~ success|failure ]]; then export STEP_STATE="${{ steps.action_bench.outcome }}" && echo "then $STEP_STATE"; else export STEP_STATE=error && echo "else $STEP_STATE"; fi
+          echo "$STEP_STATE"
           curl -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-            -d '{ "state":"${stepState}", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'
+            -d '{ "state":"${STEP_STATE}", "target_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}", "description":"The results are here!", "context":"cb/report" }'

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [synchronize]
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get short sha
         id: get_short_sha
         run: |

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -8,16 +8,23 @@ on:
 
 jobs:
   trigger-benchmark:
-    name: Trigger Benchmark
+    name: Trigger Benchmarks
     runs-on: ubuntu-latest
     steps:
+      - name: Create pending check
+        uses: LouisBrunner/checks-action@v1.6.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Trigger Benchmarks / Running Benchmarks
+          status: in_progress
+          details_url: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines
       - name: Checkout
         uses: actions/checkout@v4
       - name: Get short sha
         id: get_short_sha
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
-          echo "::set-output name=short_sha::$calculatedSha"
+          echo "short_sha=$calculatedSha" >> $GITHUB_OUTPUT
       - name: Trigger benchmarks (PR)
         id: setup_pr
         if: contains(github.event.pull_request.labels.*.name, 'benchmark PR')
@@ -46,9 +53,10 @@ jobs:
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
       - name: Create pending check
         uses: LouisBrunner/checks-action@v1.6.1
-        if: steps.setup_pr.outcome == 'success' || steps.setup_push.outcome == 'success'
+        if: steps.setup_pr.outcome == 'failure' || steps.setup_push.outcome == 'failure'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Running Benchmarks
-          status: in_progress
+          name: Trigger Benchmarks / Running Benchmarks
+          status: completed
+          conclusion: failure
           details_url: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -13,35 +13,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Get short sha
-        id: get_short_sha
-        run: |
-          calculatedSha=$(git rev-parse --short ${{ github.sha }})
-          echo "short_sha=$calculatedSha" >> $GITHUB_OUTPUT
       - name: Trigger benchmarks (PR)
         id: setup_pr
         if: contains(github.event.pull_request.labels.*.name, 'benchmark PR')
         run: |
+          SHORT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
           curl -s -X POST \
             --fail \
             -F token=${{ secrets.BENCH_PIPE_TRIGGER }} \
             -F "ref=main" \
-            -F "variables[SHA]=$GITHUB_SHA" \
-            -F "variables[SHORT_SHA]=${{ steps.get_short_sha.outputs.short_sha }}" \
+            -F "variables[SHA]=${{ github.event.pull_request.head.sha }}" \
+            -F "variables[SHORT_SHA]=${SHORT_SHA}" \
             -F "variables[BRANCH]=${{ github.head_ref }}" \
             -F "variables[PR]=${{ github.event.pull_request.number }}" \
             -F "variables[AUTHOR]=${{ github.event.pull_request.assignee.login }}" \
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
+          echo sha
       - name: Trigger benchmarks (Push main)
         id: setup_push
         if: ${{ github.event_name == 'push' }}
         run: |
+          SHORT_SHA=$(git rev-parse --short $GITHUB_SHA)
           curl -s -X POST \
             --fail \
             -F "token=${{ secrets.BENCH_PIPE_TRIGGER }}" \
             -F "ref=main" \
             -F "variables[SHA]=$GITHUB_SHA" \
-            -F "variables[SHORT_SHA]=${{ steps.get_short_sha.outputs.short_sha }}" \
+            -F "variables[SHORT_SHA]=${SHORT_SHA}" \
             -F "variables[AUTHOR]=${{ github.event.head_commit.committer.username }}" \
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
       - name: Create status
@@ -50,8 +48,9 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
-            -d '{ "state":"pending", "target_url":"https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines", "description":"Waiting for benchmarks to execute.", "context":"cb/report" }'
+            https://api.github.com/repos/$REPO/statuses/$SHA \
+            -d '{ "state":"pending", "target_url":"https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines", "description":"Waiting for benchmarks to execute.", "context":"cb/report" }' \
+            -o /dev/null
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -32,12 +32,12 @@ jobs:
             -F "variables[PR]=${{ github.event.pull_request.number }}" \
             -F "variables[AUTHOR]=${{ github.event.pull_request.assignee.login }}" \
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
-      - run: |
-          gh api \
-            --method POST \
+      - name: Create status
+        run: |
+          gh api --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/$OWNER/$REPO/statuses/$GITHUB_SHA \
+            /repos/$REPO/statuses/$GITHUB_SHA \
             -f state='pending' \
             -f target_url='https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines' \
             -f description='Waiting for benchmark results.' \

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -32,6 +32,18 @@ jobs:
             -F "variables[PR]=${{ github.event.pull_request.number }}" \
             -F "variables[AUTHOR]=${{ github.event.pull_request.assignee.login }}" \
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
+      - name: Trigger benchmarks (Push main)
+        id: setup_push
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          curl -s -X POST \
+            --fail \
+            -F "token=${{ secrets.BENCH_PIPE_TRIGGER }}" \
+            -F "ref=main" \
+            -F "variables[SHA]=$GITHUB_SHA" \
+            -F "variables[SHORT_SHA]=${{ steps.get_short_sha.outputs.short_sha }}" \
+            -F "variables[AUTHOR]=${{ github.event.head_commit.committer.username }}" \
+            https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
       - name: Create status
         run: |
           curl -L -X POST \

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -11,12 +11,6 @@ jobs:
     name: Trigger Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: LouisBrunner/checks-action@v1.6.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: report_benchmarks
-          status: in_progress
-          details_url: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines
       - name: Checkout
         uses: actions/checkout@v4
       - name: Get short sha
@@ -38,24 +32,17 @@ jobs:
             -F "variables[PR]=${{ github.event.pull_request.number }}" \
             -F "variables[AUTHOR]=${{ github.event.pull_request.assignee.login }}" \
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
-      - name: Trigger benchmarks (Push main)
-        id: setup_push
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          curl -s -X POST \
-            --fail \
-            -F "token=${{ secrets.BENCH_PIPE_TRIGGER }}" \
-            -F "ref=main" \
-            -F "variables[SHA]=$GITHUB_SHA" \
-            -F "variables[SHORT_SHA]=${{ steps.get_short_sha.outputs.short_sha }}" \
-            -F "variables[AUTHOR]=${{ github.event.head_commit.committer.username }}" \
-            https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
-      - name: Create pending check
-        uses: LouisBrunner/checks-action@v1.6.1
-        if: steps.setup_pr.outcome == 'failure' || steps.setup_push.outcome == 'failure'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: report_benchmarks
-          status: completed
-          conclusion: failure
-          details_url: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines
+      - run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/$OWNER/$REPO/statuses/$GITHUB_SHA \
+            -f state='pending' \
+            -f target_url='https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines' \
+            -f description='Waiting for benchmark results.' \
+            -f context='continuous-benchmarking/report'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -39,9 +39,8 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
-            -d '{"state":"success","target_url":"$URL","description":"Waiting for benchmark results.","context":"continuous-benchmarking/report"}'
+            -d '{"state":"pending","target_url":"https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines","description":"Waiting for benchmark results.","context":"cb/report"}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.repository }}
-          URL: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -11,11 +11,10 @@ jobs:
     name: Trigger Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - name: Create pending check
-        uses: LouisBrunner/checks-action@v1.6.1
+      - uses: LouisBrunner/checks-action@v1.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Trigger Benchmarks / Running Benchmarks
+          name: report_benchmarks
           status: in_progress
           details_url: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines
       - name: Checkout
@@ -56,7 +55,7 @@ jobs:
         if: steps.setup_pr.outcome == 'failure' || steps.setup_push.outcome == 'failure'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Trigger Benchmarks / Running Benchmarks
+          name: report_benchmarks
           status: completed
           conclusion: failure
           details_url: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -34,13 +34,13 @@ jobs:
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
       - name: Create status
         run: |
+          json=$(jo state="pending" target_url="https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines" description="Waiting for benchmarks to execute." context="cb/report")
           curl -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
-            -d '{"state":"pending","target_url":"https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines","description":"Waiting for benchmark results.","context":"cb/report"}'
+            -d "$json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -34,13 +34,12 @@ jobs:
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
       - name: Create status
         run: |
-          json=$(jo state="pending" target_url="https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines" description="Waiting for benchmarks to execute." context="cb/report")
           curl -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
-            -d "$json"
+            -d '{ "status":"pending", "target_url":"https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines", "description":"Waiting for benchmarks to execute.", "context":"cb/report" }'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -39,7 +39,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
-            -d '{ "status":"pending", "target_url":"https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines", "description":"Waiting for benchmarks to execute.", "context":"cb/report" }'
+            -d '{ "state":"pending", "target_url":"https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines", "description":"Waiting for benchmarks to execute.", "context":"cb/report" }'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -34,15 +34,14 @@ jobs:
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
       - name: Create status
         run: |
-          gh api --method POST \
+          curl -L -X POST \
             -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/$REPO/statuses/$GITHUB_SHA \
-            -f state='pending' \
-            -f target_url='https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines' \
-            -f description='Waiting for benchmark results.' \
-            -f context='continuous-benchmarking/report'
+            https://api.github.com/repos/$REPO/statuses/$GITHUB_SHA \
+            -d '{"state":"success","target_url":"$URL","description":"Waiting for benchmark results.","context":"continuous-benchmarking/report"}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.repository }}
+          URL: https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -27,7 +27,7 @@ jobs:
             -F "variables[BRANCH]=${{ github.head_ref }}" \
             -F "variables[PR]=${{ github.event.pull_request.number }}" \
             -F "variables[AUTHOR]=${{ github.event.pull_request.assignee.login }}" \
-            https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
+            https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline
           echo sha
       - name: Trigger benchmarks (Push main)
         id: setup_push
@@ -41,7 +41,7 @@ jobs:
             -F "variables[SHA]=$GITHUB_SHA" \
             -F "variables[SHORT_SHA]=${SHORT_SHA}" \
             -F "variables[AUTHOR]=${{ github.event.head_commit.committer.username }}" \
-            https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
+            https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline
       - name: Create status
         run: |
           curl -L -X POST \
@@ -49,8 +49,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$REPO/statuses/$SHA \
-            -d '{ "state":"pending", "target_url":"https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines", "description":"Waiting for benchmarks to execute.", "context":"cb/report" }' \
-            -o /dev/null
+            -d '{ "state":"pending", "target_url":"https://codebase.helmholtz.cloud/helmholtz-analytics/cb/-/pipelines", "description":"Waiting for benchmarks to execute.", "context":"cb/report" }'
         env:
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -30,7 +30,7 @@ jobs:
             -F "variables[SHORT_SHA]=${{ steps.get_short_sha.outputs.short_sha }}" \
             -F "variables[BRANCH]=${{ github.base_ref }}" \
             -F "variables[PR]=${{ github.event.pull_request.number }}" \
-            -F "variables[AUTHOR]=${{ github.event.pull_request.head.user.login }}" \
+            -F "variables[AUTHOR]=${{ github.event.pull_request.user.login }}" \
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
       - name: Trigger benchmarks (Push main)
         id: setup_push
@@ -42,11 +42,11 @@ jobs:
             -F "ref=main" \
             -F "variables[SHA]=$GITHUB_SHA" \
             -F "variables[SHORT_SHA]=${{ steps.get_short_sha.outputs.short_sha }}" \
-            -F "variables[BRANCH]=${{ github.base_ref }}" \
-            -F "variables[AUTHOR]=${{ github.event.pull_request.head.user.login }}" \
+            -F "variables[AUTHOR]=${{ github.event.head_commit.committer.username }}" \
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
       - name: Create pending check
         uses: LouisBrunner/checks-action@v1.6.1
+        if: steps.setup_pr.outcome == 'success' || steps.setup_push.outcome == 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Running Benchmarks

--- a/.github/workflows/bench_trigger.yml
+++ b/.github/workflows/bench_trigger.yml
@@ -28,9 +28,9 @@ jobs:
             -F "ref=main" \
             -F "variables[SHA]=$GITHUB_SHA" \
             -F "variables[SHORT_SHA]=${{ steps.get_short_sha.outputs.short_sha }}" \
-            -F "variables[BRANCH]=${{ github.base_ref }}" \
+            -F "variables[BRANCH]=${{ github.head_ref }}" \
             -F "variables[PR]=${{ github.event.pull_request.number }}" \
-            -F "variables[AUTHOR]=${{ github.event.pull_request.user.login }}" \
+            -F "variables[AUTHOR]=${{ github.event.pull_request.assignee.login }}" \
             https://codebase.helmholtz.cloud/api/v4/projects/7930/trigger/pipeline -o /dev/null
       - name: Trigger benchmarks (Push main)
         id: setup_push


### PR DESCRIPTION
## Description

Misconceptions about some github variables from the pull_request and push events lead to triggering the benchmarks with wrong values. This aims to correct it, while also avoiding to create an endless check that waits for the benchmark to finish.

Issue/s resolved: #1219 

## Changes proposed:
- Small corrections to trigger benchmark action

## Type of change
- Changes to CB actions.
