### PR TITLE
replaced version numbers from docker docs with placeholders

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,12 +3,12 @@
 There is some flexibility to building the Docker images of Heat.
 
 Firstly, one can build from the released version taken from PyPI. This will either be
-the latest release or the version set through the `--build-arg=HEAT_VERSION=1.2.0`
+the latest release or the version set through the `--build-arg=HEAT_VERSION=X.Y.Z`
 argument.
 
 Secondly one can build a docker image from the GitHub sources, selected through
 `--build-arg=INSTALL_TYPE=source`. The default branch to be built is main, other
-branches can be specified using `--build-arg=HEAT_BRANCH=branchname`.
+branches can be specified using `--build-arg=HEAT_BRANCH=<branch-name>`.
 
 ## General build
 
@@ -18,13 +18,13 @@ The [Dockerfile](./Dockerfile) guiding the build of the Docker image is located 
 directory. It is typically most convenient to `cd` over here and run the Docker build as:
 
 ```console
-$ docker build --build-args HEAT_VERSION=1.2.2 --PYTORCH_IMG=22.05-py3 -t heat:local .
+$ docker build --build-args HEAT_VERSION=X.Y.Z --PYTORCH_IMG=<nvcr-tag> -t heat .
 ```
 
 We also offer prebuilt images in our [Package registry](https://github.com/helmholtz-analytics/heat/pkgs/container/heat) from which you can pull existing images:
 
 ```console
-$ docker pull ghcr.io/helmholtz-analytics/heat:1.2.0-dev_torch1.12_cuda11.7_py3.8
+$ docker pull ghcr.io/helmholtz-analytics/heat:<version-tag>
 ```
 
 ### Building for HPC
@@ -37,24 +37,24 @@ image also for HPC systems, such as the ones available at [Jülich Supercomputin
 
 To use one of the existing images from our registry:
 
-	$ apptainer build heat.sif docker://ghcr.io/helmholtz-analytics/heat:1.2.0-dev_torch1.12_cuda11.7_py3.8
+	$ apptainer build heat.sif docker://ghcr.io/helmholtz-analytics/heat:<version-tag>
 
 Building the image can require root access in some systems. If that is the case, we recommend building the image on a local machine, and then upload it to the desired HPC system.
 
 If you see an error indicating that there is not enough space, use the --tmpdir flag of the build command. [Apptainer docs](https://apptainer.org/docs/user/latest/build_a_container.html)
 
-#### SIB (Singularity Image Builder)
+#### SIB (Singularity Image Builder) for Apptainer images
 
 A simple `Dockerfile` (in addition to the one above) to be used with SIB could look like
 this:
 
-	FROM ghcr.io/helmholtz-analytics/heat:1.2.0_torch1.12_cuda11.7_py3.8
+	FROM ghcr.io/helmholtz-analytics/heat:<version-tag>
 
 The invocation to build the image would be:
 
-	$ sib upload ./Dockerfile heat_1.2.0_torch1.12_cuda11.7_py3.8
-	$ sib build --recipe-name heat_1.2.0_torch1.12_cuda11.7_py3.8
-	$ sib download --recipe-name heat_1.2.0_torch1.12_cuda11.7_py3.8
+	$ sib upload ./Dockerfile heat
+	$ sib build --recipe-name heat
+	$ sib download --recipe-name heat
 
 However, SIB is capable of using just about any available Docker image from any
 registry, such that a specific Singularity image can be built by simply referencing the
@@ -62,7 +62,7 @@ available image. SIB is thus used as a conversion tool.
 
 ## Running on HPC
 
-	$ singularity run --nv heat_1.2.0_torch.11_cuda11.5_py3.9.sif /bin/bash
+	$ apptainer run --nv heat /bin/bash
 	$ python
 	Python 3.8.13 (default, Mar 28 2022, 11:38:47)
 	[GCC 7.5.0] :: Anaconda, Inc. on linux
@@ -70,12 +70,12 @@ available image. SIB is thus used as a conversion tool.
 	>>> import heat as ht
 	...
 
-The `--nv` argument to `singularity`enables NVidia GPU support, which is desired for
+The `--nv` argument to `apptainer` enables NVidia GPU support, which is desired for
 Heat.
 
 ### Multi-node example
 
-The following file can be used as an example to use the singularity file together with SLURM, which allows heat to work in a multi-node environment.
+The following file can be used as an example to use the apptainer file together with SLURM, which allows heat to work in a multi-node environment.
 
 ```bash
 #!/bin/bash
@@ -85,5 +85,5 @@ The following file can be used as an example to use the singularity file togethe
 
 ...
 
-srun --mpi="pmi2" singularity exec --nv heat_1.2.0_torch.11_cuda11.5_py3.9.sif bash -c "cd ~/code/heat/examples/lasso; python demo.py"
+srun --mpi="pmi2" apptainer exec --nv heat_1.2.0_torch.11_cuda11.5_py3.9.sif bash -c "cd ~/code/heat/examples/lasso; python demo.py"
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,6 +21,8 @@ directory. It is typically most convenient to `cd` over here and run the Docker 
 $ docker build --build-args HEAT_VERSION=X.Y.Z --PYTORCH_IMG=<nvcr-tag> -t heat .
 ```
 
+The heat image is based on the nvidia pytorch container. You can find exisiting tags in the [nvidia container catalog](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch/tags).
+
 We also offer prebuilt images in our [Package registry](https://github.com/helmholtz-analytics/heat/pkgs/container/heat) from which you can pull existing images:
 
 ```console

--- a/quick_start.md
+++ b/quick_start.md
@@ -50,6 +50,8 @@ cd heat/docker
 docker build --build-args HEAT_VERSION=X.Y.Z --PYTORCH_IMG=<nvcr-tag> -t heat:latest .
 ```
 
+`<nvcr-tag>` should be replaced with an existing version of the official Nvidia pytorch container image. Information and existing tags can be found on the [here](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch)
+
 See [our docker README](https://github.com/helmholtz-analytics/heat/tree/main/docker/README.md) for other details.
 
 ### Test

--- a/quick_start.md
+++ b/quick_start.md
@@ -39,7 +39,7 @@ pip install heat[hdf5,netcdf]
 Get the docker image from our package repository
 
 ```
-docker pull ghcr.io/helmholtz-analytics/heat:1.2.0-dev_torch1.12_cuda11.7_py3.8
+docker pull ghcr.io/helmholtz-analytics/heat:<version-tag>
 ```
 
 or build it from our Dockerfile
@@ -47,7 +47,7 @@ or build it from our Dockerfile
 ```
 git clone https://github.com/helmholtz-analytics/heat.git
 cd heat/docker
-docker build -t heat:latest .
+docker build --build-args HEAT_VERSION=X.Y.Z --PYTORCH_IMG=<nvcr-tag> -t heat:latest .
 ```
 
 See [our docker README](https://github.com/helmholtz-analytics/heat/tree/main/docker/README.md) for other details.


### PR DESCRIPTION
## Description

Removed specific version numbers and image tags from docker documentation, to avoid constant changes with each version.