### PR TITLE
Increase tolerance for `ht.allclose` on `ht.inv` operations for all torch versions

### DIFF
--- a/heat/core/linalg/tests/test_solver.py
+++ b/heat/core/linalg/tests/test_solver.py
@@ -65,15 +65,8 @@ class TestSolver(TestCase):
         lanczos_B = V_out @ T_out @ V_inv
         self.assertTrue(ht.allclose(lanczos_B, B))
 
-        # single precision tolerance
-        if (
-            int(torch.__version__.split(".")[0]) == 1
-            and int(torch.__version__.split(".")[1]) >= 13
-            or int(torch.__version__.split(".")[0]) > 1
-        ):
-            tolerance = 1e-3
-        else:
-            tolerance = 1e-4
+        # single precision tolerance if torch.inv() is pretty bad
+        tolerance = 1e-3
 
         # float32, pre_defined v0, split mismatch
         A = ht.random.randn(n, n, dtype=ht.float32, split=0)

--- a/heat/core/linalg/tests/test_solver.py
+++ b/heat/core/linalg/tests/test_solver.py
@@ -65,7 +65,7 @@ class TestSolver(TestCase):
         lanczos_B = V_out @ T_out @ V_inv
         self.assertTrue(ht.allclose(lanczos_B, B))
 
-        # single precision tolerance if torch.inv() is pretty bad
+        # single precision tolerance for torch.inv() is pretty bad
         tolerance = 1e-3
 
         # float32, pre_defined v0, split mismatch


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **base branch** must be `main` for new features, latest release branch (e.g. `release/1.3.x`) for bug fixes
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [x] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: CI matrix stuck for days

## Changes proposed:

- increase tolerance in Lanczos tests for single-precision `allclose` checks. Now applies to all PyTorch versions, not just >=1.13
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue)
## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
NA
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->
NA
#### Does this change modify the behaviour of other functions? If so, which?
no
