### PR TITLE
Update outdated `changelog-updater.yml` workflow

### DIFF
--- a/.github/workflows/changelog-updater.yml
+++ b/.github/workflows/changelog-updater.yml
@@ -9,14 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: helmholtz-analytics/heat
           ref: ${{ github.event.release.target_commitish }}
       - name: Update Changelog
+        env:
+          NAME: ${{ github.event.release.name }}
+          BODY: ${{ github.event.release.body }}
         run: |
-          echo ${{ format('\# {0} - {1}', env.GITHUB_REF, github.event.release.name) }} > cl_title.md
-          echo ${{ github.event.release.body }} > cl_new_body.md
+          echo ${{ format('\# {0} - {1}', env.GITHUB_REF, "$NAME") }} > cl_title.md
+          echo "$BODY" > cl_new_body.md
           echo "" > newline.txt
           cat cl_title.md newline.txt cl_new_body.md newline.txt CHANGELOG.md > tmp
           mv tmp CHANGELOG.md

--- a/.github/workflows/changelog-updater.yml
+++ b/.github/workflows/changelog-updater.yml
@@ -9,19 +9,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          ref: main
-
+          repository: helmholtz-analytics/heat
+          ref: ${{ github.event.release.target_commitish }}
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
-        with:
-          release-notes: ${{ github.event.release.body }}
-          latest-version: ${{ github.event.release.name }}
-
+        run: |
+          echo ${{ format('\# {0} - {1}', env.GITHUB_REF, github.event.release.name) }} > cl_title.md
+          echo ${{ github.event.release.body }} > cl_new_body.md
+          echo "" > newline.txt
+          cat cl_title.md newline.txt cl_new_body.md newline.txt CHANGELOG.md > tmp
+          mv tmp CHANGELOG.md
+          rm cl_title.md
+          rm cl_new_body.md
+          rm newline.txt
+          cat CHANGELOG.md
       - name: Commit updated CHANGELOG
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: release/1.2.x
+          branch: ${{ github.event.release.target_commitish }}
           commit_message: Update CHANGELOG
           file_pattern: CHANGELOG.md


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **base branch** must be `main` for new features, latest release branch (e.g. `release/1.3.x`) for bug fixes
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [x] documentation updated where needed

## Description

Workflow file got fixed in main, but not in the release branch. 

Issue/s resolved: #

## Changes proposed:

- Update `.github/workflows/changelog-updater.yml` in release branch with previous changes from main. 

## Type of change
 - Workflow changes

#### Does this change modify the behaviour of other functions? If so, which?
no
