### PR TITLE
Fix for MPI_ERR_TRUNCATE in QR with split=1 

### DIFF
--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -898,7 +898,7 @@ def __split1_qr_loop(
         except AttributeError:
             q1, r1 = r_tiles[dcol, dcol].qr(some=False)
 
-        r_tiles.arr.comm.Bcast(q1.clone(), root=diag_process)
+        r_tiles.arr.comm.Bcast(q1.clone(memory_format=torch.contiguous_format), root=diag_process)
         r_tiles[dcol, dcol] = r1
         # apply q1 to the trailing matrix (other processes)
 


### PR DESCRIPTION
see #1324 and #1317 