### PR TITLE
Backport 1363 to release/1.3.x

### DIFF
--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -323,7 +323,7 @@ def array(
             raise ValueError(
                 "argument `copy` is set to False, but copy of input object is necessary as the array is being copied across devices.\nUse the method `DNDarray.cpu()` or  `DNDarray.gpu()` to move the array to the desired device."
             )
-            
+
         # extract the internal tensor
         obj = obj.larray
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -308,6 +308,10 @@ def array(
     if device is not None:
         device = devices.sanitize_device(device)
 
+    # infer device from obj if not explicitly given
+    if device is None and hasattr(obj, "device"):
+        device = devices.sanitize_device(obj.device.type)
+
     # initialize the array
     if bool(copy):
         if isinstance(obj, torch.Tensor):
@@ -331,8 +335,8 @@ def array(
                 (dtype is None or dtype == types.canonical_heat_type(obj.dtype))
                 and (
                     device is None
-                    or device.torch_device
-                    == str(getattr(obj, "device", devices.get_device().torch_device))
+                    or device.torch_device.split(":")[0]
+                    == str(getattr(obj, "device", devices.get_device().torch_device)).split(":")[0]
                 )
             ):
                 raise ValueError(

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -420,7 +420,7 @@ def array(
     elif split is not None:
         # only keep local slice
         _, _, slices = comm.chunk(gshape, split)
-        _ = obj[slices].clone()
+        _ = obj[slices].contiguous()
         del obj
 
         obj = sanitize_memory_layout(_, order=order)

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -306,23 +306,24 @@ def array(
             and (is_split is None or is_split == obj.split)
             and (device is None or device == obj.device)
         ):
-            if not copy:
-                return obj
-            else:
+            if copy is True:
                 return memory_copy(obj)
+            else:
+                return obj
         elif split is not None and obj.split is not None and split != obj.split:
             raise ValueError(
-                f"'split' argument does not match existing 'split' dimention ({split} != {obj.split}).\nIf you are trying to resplit and existing DNDarray, use the method `resplit` instead."
+                f"'split' argument does not match existing 'split' dimention ({split} != {obj.split}).\nIf you are trying to create a new DNDarray with a new split from an existing DNDarray, use the function `ht.resplit()` instead."
             )
         elif is_split is not None and obj.split is not None and is_split != obj.split:
             raise ValueError(
-                f"'is_split' and the split axis of the object do not match ({is_split} != {obj.split}).\nIf you are trying to resplit and existing DNDarray, use the method `resplit` instead."
+                f"'is_split' and the split axis of the object do not match ({is_split} != {obj.split}).\nIf you are trying to resplit an existing DNDarray in-place, use the method `DNDarray.resplit_()` instead."
             )
-        elif device is not None and device != obj.device and not copy:
+        elif device is not None and device != obj.device and copy is False:
 
             raise ValueError(
-                "argument `copy` is set to False, but copy of input object is necessary as the array is being copied across devices.\nUse the method `use_device` to move the array to the desired device."
+                "argument `copy` is set to False, but copy of input object is necessary as the array is being copied across devices.\nUse the method `DNDarray.cpu()` or  `DNDarray.gpu()` to move the array to the desired device."
             )
+            
         # extract the internal tensor
         obj = obj.larray
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -358,12 +358,15 @@ def array(
                     "argument `copy` is set to False, but copy of input object is necessary. \n Set copy=None to reuse the memory buffer whenever possible and allow for copies otherwise."
                 )
         try:
-            obj = torch.as_tensor(
-                obj,
-                device=device.torch_device
-                if device is not None
-                else devices.get_device().torch_device,
-            )
+            if not isinstance(obj, torch.Tensor):
+                obj = torch.as_tensor(
+                    obj,
+                    device=(
+                        device.torch_device
+                        if device is not None
+                        else devices.get_device().torch_device
+                    ),
+                )
         except RuntimeError:
             raise TypeError("invalid data of type {}".format(type(obj)))
 

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -200,6 +200,26 @@ class TestFactories(TestCase):
             ).all()
         )
 
+        # distributed array, chunk local data (split), copy False, torch devices
+        array_2d = torch.tensor(
+            [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0]],
+            dtype=torch.double,
+            device=self.device.torch_device,
+        )
+        dndarray_2d = ht.array(array_2d, split=0, copy=False, dtype=ht.double)
+        self.assertIsInstance(dndarray_2d, ht.DNDarray)
+        self.assertEqual(dndarray_2d.dtype, ht.float64)
+        self.assertEqual(dndarray_2d.gshape, (3, 3))
+        self.assertEqual(len(dndarray_2d.lshape), 2)
+        self.assertLessEqual(dndarray_2d.lshape[0], 3)
+        self.assertEqual(dndarray_2d.lshape[1], 3)
+        self.assertEqual(dndarray_2d.split, 0)
+        self.assertTrue(
+            (
+                dndarray_2d.larray == torch.tensor([1.0, 2.0, 3.0], device=self.device.torch_device)
+            ).all()
+        )
+
         # distributed array, partial data (is_split)
         if ht.communication.MPI_WORLD.rank == 0:
             split_data = [[4.0, 5.0, 6.0], [1.0, 2.0, 3.0], [0.0, 0.0, 0.0]]

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -220,6 +220,44 @@ class TestFactories(TestCase):
             ).all()
         )
 
+        # The array should not change as all properties match
+        dndarray_2d_new = ht.array(dndarray_2d, split=0, copy=False, dtype=ht.double)
+        self.assertIsInstance(dndarray_2d_new, ht.DNDarray)
+        self.assertEqual(dndarray_2d_new.dtype, ht.float64)
+        self.assertEqual(dndarray_2d_new.gshape, (3, 3))
+        self.assertEqual(len(dndarray_2d_new.lshape), 2)
+        self.assertLessEqual(dndarray_2d_new.lshape[0], 3)
+        self.assertEqual(dndarray_2d_new.lshape[1], 3)
+        self.assertEqual(dndarray_2d_new.split, 0)
+        self.assertTrue(
+            (
+                dndarray_2d.larray == torch.tensor([1.0, 2.0, 3.0], device=self.device.torch_device)
+            ).all()
+        )
+
+        # Should throw exeception because of resplit it causes a resplit
+        with self.assertRaises(ValueError):
+            dndarray_2d_new = ht.array(dndarray_2d, split=1, copy=False, dtype=ht.double)
+
+        # The array should not change as all properties match
+        dndarray_2d_new = ht.array(dndarray_2d, is_split=0, copy=False, dtype=ht.double)
+        self.assertIsInstance(dndarray_2d_new, ht.DNDarray)
+        self.assertEqual(dndarray_2d_new.dtype, ht.float64)
+        self.assertEqual(dndarray_2d_new.gshape, (3, 3))
+        self.assertEqual(len(dndarray_2d_new.lshape), 2)
+        self.assertLessEqual(dndarray_2d_new.lshape[0], 3)
+        self.assertEqual(dndarray_2d_new.lshape[1], 3)
+        self.assertEqual(dndarray_2d_new.split, 0)
+        self.assertTrue(
+            (
+                dndarray_2d.larray == torch.tensor([1.0, 2.0, 3.0], device=self.device.torch_device)
+            ).all()
+        )
+
+        # Should throw exeception because of array is split along another dimension
+        with self.assertRaises(ValueError):
+            dndarray_2d_new = ht.array(dndarray_2d, is_split=1, copy=False, dtype=ht.double)
+
         # distributed array, partial data (is_split)
         if ht.communication.MPI_WORLD.rank == 0:
             split_data = [[4.0, 5.0, 6.0], [1.0, 2.0, 3.0], [0.0, 0.0, 0.0]]

--- a/heat/core/tests/test_factories.py
+++ b/heat/core/tests/test_factories.py
@@ -219,6 +219,9 @@ class TestFactories(TestCase):
                 dndarray_2d.larray == torch.tensor([1.0, 2.0, 3.0], device=self.device.torch_device)
             ).all()
         )
+        # Check that the array is not a copy, (only really works when the array is not split)
+        if ht.communication.MPI_WORLD.size == 1:
+            self.assertIs(dndarray_2d.larray, array_2d)
 
         # The array should not change as all properties match
         dndarray_2d_new = ht.array(dndarray_2d, split=0, copy=False, dtype=ht.double)
@@ -234,6 +237,8 @@ class TestFactories(TestCase):
                 dndarray_2d.larray == torch.tensor([1.0, 2.0, 3.0], device=self.device.torch_device)
             ).all()
         )
+        # Reuse the same array
+        self.assertIs(dndarray_2d_new.larray, dndarray_2d.larray)
 
         # Should throw exeception because of resplit it causes a resplit
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #

## Changes proposed:

-
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no
