### PR TITLE
added names of non-core members in citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,6 +30,12 @@ authors:
   - family-names: Tarnawa
     given-names: Michael
 # release contributors - add as needed
+  - family-names: Osterfeld
+    given-names: Fynn
+  - family-names: Scheib
+    given-names: Lukas
+  - family-names: Siddiqui
+    given-names: Abdul Samad
 repository-code: 'https://github.com/helmholtz-analytics/heat'
 url: 'https://helmholtz-analytics.github.io/heat/'
 repository: 'https://heat.readthedocs.io/en/stable/'


### PR DESCRIPTION
Names of non-core team members have been added to CITATION.md file to be merged with first bugfix release 1.4.1