### PR TITLE
Support batch 1-d convolution in `ht.signal.convolve`

### DIFF
--- a/heat/core/signal.py
+++ b/heat/core/signal.py
@@ -174,7 +174,7 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
         # all operations are local torch operations, only the last dimension is convolved
         local_a = a.larray
         local_v = v.larray
-        # flip filter for convolution as Pytorch conv1d computes correlations
+        # flip filter for convolution, as Pytorch conv1d computes correlations
         local_v = torch.flip(local_v, [-1])
         local_batch_dims = tuple(local_a.shape[:-1])
 

--- a/heat/core/signal.py
+++ b/heat/core/signal.py
@@ -196,7 +196,7 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
 
         # cast to single-precision float if on GPU
         if local_a.is_cuda:
-            float_type = promote_types(local_a.dtype, torch.float32)
+            float_type = torch.promote_types(local_a.dtype, torch.float32)
             local_a = local_a.to(float_type)
             local_v = local_v.to(float_type)
 

--- a/heat/core/signal.py
+++ b/heat/core/signal.py
@@ -123,6 +123,7 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
     if v.shape[-1] > a.shape[-1]:
         a, v = v, a
 
+    # assess whether to perform batch processing, default is False (no batch processing)
     batch_processing = False
     if a.ndim > 1:
         # batch processing requires 1D filter OR matching batch dimensions for signal and filter
@@ -145,6 +146,7 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
                 else:
                     v.resplit_(axis=a.split)
         batch_processing = True
+
     if not batch_processing and v.ndim > 1:
         raise ValueError(
             f"1-D convolution only supported for 1-dimensional signal and kernel. Signal: {a.shape}, Filter: {v.shape}"

--- a/heat/core/signal.py
+++ b/heat/core/signal.py
@@ -146,6 +146,7 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
         local_batch_dims = tuple(local_a.shape[:-1])
 
         # reshape signal and filter to 3D for Pytorch conv1d function
+        # see https://pytorch.org/docs/stable/generated/torch.nn.functional.conv1d.html
         local_a = local_a.reshape(
             torch.prod(torch.tensor(local_batch_dims, device=local_a.device), dim=0).item(),
             local_a.shape[-1],

--- a/heat/core/signal.py
+++ b/heat/core/signal.py
@@ -88,8 +88,22 @@ def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
     a = a.astype(promoted_type)
     v = v.astype(promoted_type)
 
-    if len(a.shape) != 1 or len(v.shape) != 1:
-        raise ValueError("Only 1-dimensional input DNDarrays are allowed")
+    batch_processing = False
+    if a.ndim > 1:
+        # batch processing requires 1D filter OR matching batch dimensions for signal and filter
+        batch_dims = a.shape[:-1]
+        # verify that the filter shape is consistent with the signal
+        if v.ndim > 1:
+            if v.shape[:-1] != batch_dims:
+                raise ValueError(
+                    f"Batch dimensions of signal and filter must match. Signal: {a.shape}, Filter: {v.shape}"
+                )
+        batch_processing = True
+    if not batch_processing and v.ndim > 1:
+        raise ValueError(
+            f"1-D convolution only supported for 1-dimensional signal and kernel. Signal: {a.shape}, Filter: {v.shape}"
+        )
+
     if mode == "same" and v.shape[0] % 2 == 0:
         raise ValueError("Mode 'same' cannot be used with even-sized kernel")
     if not v.is_balanced():

--- a/heat/core/signal.py
+++ b/heat/core/signal.py
@@ -16,15 +16,15 @@ __all__ = ["convolve"]
 def convolve(a: DNDarray, v: DNDarray, mode: str = "full") -> DNDarray:
     """
     Returns the discrete, linear convolution of two one-dimensional `DNDarray`s or scalars.
-    If the input ``DNDarray``s have more than one dimension, batch-convolution along the last dimension will be attempted. See below for details.
+    Unlike `numpy.signal.convolve`, if ``a`` and/or ``v`` have more than one dimension, batch-convolution along the last dimension will be attempted. See `Examples` below.
 
     Parameters
     ----------
     a : DNDarray or scalar
-        One-dimensional signal `DNDarray` of shape (N,), or scalar. If ``a`` is more than 1D, it will be treated as a batch of 1D signals.
+        One- or N-dimensional signal ``DNDarray`` of shape (..., N), or scalar. If ``a`` has more than one dimension, it will be treated as a batch of 1D signals.
         Distribution along the batch dimension is required for distributed batch processing. See the examples for details.
     v : DNDarray or scalar
-        One-dimensional filter weight `DNDarray` of shape (M,), or scalar. If ``v`` is more than 1D, it will be treated as a batch of 1D filter weights.
+        One- or N-dimensional filter weight `DNDarray` of shape (..., M), or scalar. If ``v`` has more than one dimension, it will be treated as a batch of 1D filter weights.
         The batch dimension(s) of ``v`` must match the batch dimension(s) of ``a``.
     mode : str
         Can be 'full', 'valid', or 'same'. Default is 'full'.

--- a/heat/core/tests/test_signal.py
+++ b/heat/core/tests/test_signal.py
@@ -36,9 +36,10 @@ class TestSignal(TestCase):
             ht.convolve(dis_signal, filter_wrong_type, mode="full")
         with self.assertRaises(ValueError):
             ht.convolve(dis_signal, kernel_odd, mode="invalid")
-        with self.assertRaises(ValueError):
-            s = dis_signal.reshape((2, -1)).resplit(axis=1)
-            ht.convolve(s, kernel_odd)
+        if dis_signal.comm.size > 1:
+            with self.assertRaises(ValueError):
+                s = dis_signal.reshape((2, -1)).resplit(axis=1)
+                ht.convolve(s, kernel_odd)
         with self.assertRaises(ValueError):
             k = ht.eye(3)
             ht.convolve(dis_signal, k)

--- a/heat/core/tests/test_signal.py
+++ b/heat/core/tests/test_signal.py
@@ -36,9 +36,9 @@ class TestSignal(TestCase):
             ht.convolve(dis_signal, filter_wrong_type, mode="full")
         with self.assertRaises(ValueError):
             ht.convolve(dis_signal, kernel_odd, mode="invalid")
-        # with self.assertRaises(ValueError):
-        #     s = dis_signal.reshape((2, -1))
-        #     ht.convolve(s, kernel_odd)
+        with self.assertRaises(ValueError):
+            s = dis_signal.reshape((2, -1)).resplit(axis=1)
+            ht.convolve(s, kernel_odd)
         with self.assertRaises(ValueError):
             k = ht.eye(3)
             ht.convolve(dis_signal, k)

--- a/heat/core/tests/test_signal.py
+++ b/heat/core/tests/test_signal.py
@@ -36,9 +36,9 @@ class TestSignal(TestCase):
             ht.convolve(dis_signal, filter_wrong_type, mode="full")
         with self.assertRaises(ValueError):
             ht.convolve(dis_signal, kernel_odd, mode="invalid")
-        with self.assertRaises(ValueError):
-            s = dis_signal.reshape((2, -1))
-            ht.convolve(s, kernel_odd)
+        # with self.assertRaises(ValueError):
+        #     s = dis_signal.reshape((2, -1))
+        #     ht.convolve(s, kernel_odd)
         with self.assertRaises(ValueError):
             k = ht.eye(3)
             ht.convolve(dis_signal, k)
@@ -119,3 +119,11 @@ class TestSignal(TestCase):
 
         conv = ht.convolve(1, 5)
         self.assertTrue(ht.equal(ht.array([5]), conv))
+
+        # test batched convolutions, distributed along the first axis
+        signal = ht.random.randn(1000, dtype=ht.float64)
+        batch_signal = ht.empty((10, 1000), dtype=ht.float64, split=0)
+        batch_signal.larray[:] = signal.larray
+        kernel = ht.random.randn(19, dtype=ht.float64)
+        batch_convolved = ht.convolve(batch_signal, kernel, mode="same")
+        self.assertTrue(ht.equal(ht.convolve(signal, kernel, mode="same"), batch_convolved[0]))

--- a/heat/core/tests/test_signal.py
+++ b/heat/core/tests/test_signal.py
@@ -138,11 +138,17 @@ class TestSignal(TestCase):
         batch_convolved = ht.convolve(batch_signal, batch_kernel, mode="full")
         self.assertTrue(ht.equal(ht.convolve(signal, kernel, mode="full"), batch_convolved[0]))
 
+        # n-D batch convolution
+        batch_signal = ht.empty((4, 3, 1000), dtype=ht.float64, split=1)
+        batch_signal.larray[:, :] = signal.larray
+        batch_convolved = ht.convolve(batch_signal, kernel, mode="valid")
+        self.assertTrue(ht.equal(ht.convolve(signal, kernel, mode="valid"), batch_convolved[1, 2]))
+
         # test batch-convolve exceptions
         batch_kernel_wrong_shape = ht.random.randn(3, 19, dtype=ht.float64)
         with self.assertRaises(ValueError):
             ht.convolve(batch_signal, batch_kernel_wrong_shape)
         if kernel.comm.size > 1:
-            batch_signal_wrong_split = batch_signal.resplit(1)
+            batch_signal_wrong_split = batch_signal.resplit(2)
             with self.assertRaises(ValueError):
                 ht.convolve(batch_signal_wrong_split, kernel)

--- a/heat/core/tests/test_signal.py
+++ b/heat/core/tests/test_signal.py
@@ -139,16 +139,18 @@ class TestSignal(TestCase):
         self.assertTrue(ht.equal(ht.convolve(signal, kernel, mode="full"), batch_convolved[0]))
 
         # n-D batch convolution
-        batch_signal = ht.empty((4, 3, 1000), dtype=ht.float64, split=1)
-        batch_signal.larray[:, :] = signal.larray
+        batch_signal = ht.empty((4, 3, 3, 1000), dtype=ht.float64, split=1)
+        batch_signal.larray[:, :, :] = signal.larray
         batch_convolved = ht.convolve(batch_signal, kernel, mode="valid")
-        self.assertTrue(ht.equal(ht.convolve(signal, kernel, mode="valid"), batch_convolved[1, 2]))
+        self.assertTrue(
+            ht.equal(ht.convolve(signal, kernel, mode="valid"), batch_convolved[1, 2, 0])
+        )
 
         # test batch-convolve exceptions
         batch_kernel_wrong_shape = ht.random.randn(3, 19, dtype=ht.float64)
         with self.assertRaises(ValueError):
             ht.convolve(batch_signal, batch_kernel_wrong_shape)
         if kernel.comm.size > 1:
-            batch_signal_wrong_split = batch_signal.resplit(2)
+            batch_signal_wrong_split = batch_signal.resplit(-1)
             with self.assertRaises(ValueError):
                 ht.convolve(batch_signal_wrong_split, kernel)


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [x] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
This PR expands `ht.signal.convolve` to perform 1-D convolutions on a batch of 1-D arrays, i.e. 

- if `signal.shape = (..., n)` and `kernel.shape = (m,)`:  `signal`'s last dimension will be convolved with `kernel`. 

- if e.g. `signal.shape = (i, j,  n)` and `kernel.shape = (i, j,  m,)`: each element `signal[i, j]` of size `n`  will be convolved with the corresponding element `kernel[i,j]` of size `m`. 

- Signal and kernel can be any number of dimensions, as long as the batch dimensions match.

- Signal and kernel can be distributed along any of the batch dimensions.

Issue/s resolved: #1514 
Related: #1396 

## Changes proposed:

- enable batch 1-D convolution
- expand documentation, examples
- expand tests
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- New feature (non-breaking change which adds functionality)

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes, instead of returning `ValueError` when `signal` is n-D, `ht.convolve` now raises a ValueError only if batch convolution isn't possible (shapes mismatch, unsuitable distribution)