### PR TITLE
Distributed `vmap` functionality for vectorization across split dimension 

### DIFF
--- a/heat/core/__init__.py
+++ b/heat/core/__init__.py
@@ -31,3 +31,4 @@ from .signal import *
 from .types import finfo, iinfo
 from . import version
 from .version import __version__
+from .vmap import *

--- a/heat/core/tests/test_vmap.py
+++ b/heat/core/tests/test_vmap.py
@@ -23,7 +23,7 @@ class TestVmap(TestCase):
             # inputs split along different axes, output split along same axis (one of them different to input split)
             x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
             x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=1)
-            out_dims = (0, 0)
+            out_dims = 0  # test with out_dims as int (tuple below)
 
             def func(x0, x1, k=2, scale=1e-2):
                 return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
@@ -60,6 +60,28 @@ class TestVmap(TestCase):
 
             self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
             self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+
+            # catch wrong number of output dimensions
+            with self.assertRaises(ValueError):
+                vfunc = ht.vmap(func, (0, 1, 2))
+                y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
+
+            # one output only
+            def func(x0, m=1, scale=2):
+                return (x0 - m) ** scale
+
+            vfunc = ht.vmap(func, out_dims=(0,))
+
+            x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+            y0 = vfunc(x0, m=2, scale=3)[0]
+
+            x0_torch = x0.resplit(None).larray
+            vfunc_torch = torch.vmap(func, (0,), (0,))
+            y0_torch = vfunc_torch(x0_torch, m=2, scale=3)
+
+            print(y0.resplit(None).larray, y0_torch)
+
+            self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
 
         def test_vmap_with_chunks(self):
             # same as before but now with prescribed chunk sizes for the vmap

--- a/heat/core/tests/test_vmap.py
+++ b/heat/core/tests/test_vmap.py
@@ -47,3 +47,64 @@ class TestVmap(TestCase):
 
         self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
         self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+
+    def test_vmap_with_chunks(self):
+        # same as before but now with prescribed chunk sizes for the vmap
+        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=1)
+        out_dims = (0, 0)
+
+        def func(x0, x1, k=2, scale=1e-2):
+            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+
+        vfunc = ht.vmap(func, out_dims, chunk_size=2)
+        y0, y1 = vfunc(x0, x1, k=2, scale=-2.2)
+
+        # compare with torch
+        x0_torch = x0.resplit(None).larray
+        x1_torch = x1.resplit(None).larray
+        vfunc_torch = torch.vmap(func, (0, 1), (0, 0))
+        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=-2.2)
+
+        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+
+        # two inputs (only one of them split), two outputs, including keyword arguments that are not vmapped
+        # output split along different axis
+        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=None)
+        out_dims = (0, 1)
+
+        def func(x0, x1, k=2, scale=1e-2):
+            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+
+        vfunc = ht.vmap(func, out_dims, chunk_size=1)
+        y0, y1 = vfunc(x0, x1, k=5, scale=2.2)
+
+        # compare with torch
+        x0_torch = x0.resplit(None).larray
+        x1_torch = x1.resplit(None).larray
+        vfunc_torch = torch.vmap(func, (0, None), (0, 1))
+        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=5, scale=2.2)
+
+        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+
+    def test_vmap_catch_errors(self):
+        # not a callable
+        with self.assertRaises(TypeError):
+            ht.vmap(1)
+        # invalid randomness
+        with self.assertRaises(ValueError):
+            ht.vmap(lambda x: x, randomness="random")
+        # invalid chunk_size
+        with self.assertRaises(TypeError):
+            ht.vmap(lambda x: x, chunk_size="1")
+        with self.assertRaises(ValueError):
+            ht.vmap(lambda x: x, chunk_size=0)
+        # not all inputs are DNDarrays
+        with self.assertRaises(TypeError):
+            ht.vmap(lambda x: x, out_dims=0)(ht.ones(10), 2)
+        # number of output DNDarrays does not match number of split dimensions
+        with self.assertRaises(ValueError):
+            ht.vmap(lambda x: x, out_dims=(0, 1))(ht.ones(10))

--- a/heat/core/tests/test_vmap.py
+++ b/heat/core/tests/test_vmap.py
@@ -5,106 +5,119 @@ from .test_suites.basic_test import TestCase
 
 
 class TestVmap(TestCase):
-    def test_vmap(self):
-        # two inputs (both split), two outputs, including keyword arguments that are not vmapped
-        # inputs split along different axes, output split along same axis (one of them different to input split)
-        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
-        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=1)
-        out_dims = (0, 0)
+    if torch.__version__ < "2.0.0":
 
-        def func(x0, x1, k=2, scale=1e-2):
-            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+        def test_vmap(self):
+            out_dims = (0, 0)
 
-        vfunc = ht.vmap(func, out_dims)
-        y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
+            def func(x0, x1, k=2, scale=1e-2):
+                return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
 
-        # compare with torch
-        x0_torch = x0.resplit(None).larray
-        x1_torch = x1.resplit(None).larray
-        vfunc_torch = torch.vmap(func, (0, 1), (0, 0))
-        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
+            with self.assertRaises(RuntimeError):
+                vfunc = ht.vmap(func, out_dims)  # noqa: F841
 
-        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
-        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+    else:
 
-        # two inputs (only one of them split), two outputs, including keyword arguments that are not vmapped
-        # output split along different axis, one output has different data type than input
-        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
-        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=None)
-        out_dims = (0, 1)
+        def test_vmap(self):
+            # two inputs (both split), two outputs, including keyword arguments that are not vmapped
+            # inputs split along different axes, output split along same axis (one of them different to input split)
+            x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+            x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=1)
+            out_dims = (0, 0)
 
-        def func(x0, x1, k=2, scale=1e-2):
-            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, (scale * x0 @ x1).int()
+            def func(x0, x1, k=2, scale=1e-2):
+                return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
 
-        vfunc = ht.vmap(func, out_dims)
-        y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
+            vfunc = ht.vmap(func, out_dims)
+            y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
 
-        # compare with torch
-        x0_torch = x0.resplit(None).larray
-        x1_torch = x1.resplit(None).larray
-        vfunc_torch = torch.vmap(func, (0, None), (0, 1))
-        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
+            # compare with torch
+            x0_torch = x0.resplit(None).larray
+            x1_torch = x1.resplit(None).larray
+            vfunc_torch = torch.vmap(func, (0, 1), (0, 0))
+            y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
 
-        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
-        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+            self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+            self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
 
-    def test_vmap_with_chunks(self):
-        # same as before but now with prescribed chunk sizes for the vmap
-        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
-        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=1)
-        out_dims = (0, 0)
+            # two inputs (only one of them split), two outputs, including keyword arguments that are not vmapped
+            # output split along different axis, one output has different data type than input
+            x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+            x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=None)
+            out_dims = (0, 1)
 
-        def func(x0, x1, k=2, scale=1e-2):
-            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+            def func(x0, x1, k=2, scale=1e-2):
+                return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, (scale * x0 @ x1).int()
 
-        vfunc = ht.vmap(func, out_dims, chunk_size=2)
-        y0, y1 = vfunc(x0, x1, k=2, scale=-2.2)
+            vfunc = ht.vmap(func, out_dims)
+            y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
 
-        # compare with torch
-        x0_torch = x0.resplit(None).larray
-        x1_torch = x1.resplit(None).larray
-        vfunc_torch = torch.vmap(func, (0, 1), (0, 0))
-        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=-2.2)
+            # compare with torch
+            x0_torch = x0.resplit(None).larray
+            x1_torch = x1.resplit(None).larray
+            vfunc_torch = torch.vmap(func, (0, None), (0, 1))
+            y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
 
-        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
-        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+            self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+            self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
 
-        # two inputs (only one of them split), two outputs, including keyword arguments that are not vmapped
-        # output split along different axis
-        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
-        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=None)
-        out_dims = (0, 1)
+        def test_vmap_with_chunks(self):
+            # same as before but now with prescribed chunk sizes for the vmap
+            x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+            x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=1)
+            out_dims = (0, 0)
 
-        def func(x0, x1, k=2, scale=1e-2):
-            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+            def func(x0, x1, k=2, scale=1e-2):
+                return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
 
-        vfunc = ht.vmap(func, out_dims, chunk_size=1)
-        y0, y1 = vfunc(x0, x1, k=5, scale=2.2)
+            vfunc = ht.vmap(func, out_dims, chunk_size=2)
+            y0, y1 = vfunc(x0, x1, k=2, scale=-2.2)
 
-        # compare with torch
-        x0_torch = x0.resplit(None).larray
-        x1_torch = x1.resplit(None).larray
-        vfunc_torch = torch.vmap(func, (0, None), (0, 1))
-        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=5, scale=2.2)
+            # compare with torch
+            x0_torch = x0.resplit(None).larray
+            x1_torch = x1.resplit(None).larray
+            vfunc_torch = torch.vmap(func, (0, 1), (0, 0))
+            y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=-2.2)
 
-        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
-        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+            self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+            self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
 
-    def test_vmap_catch_errors(self):
-        # not a callable
-        with self.assertRaises(TypeError):
-            ht.vmap(1)
-        # invalid randomness
-        with self.assertRaises(ValueError):
-            ht.vmap(lambda x: x, randomness="random")
-        # invalid chunk_size
-        with self.assertRaises(TypeError):
-            ht.vmap(lambda x: x, chunk_size="1")
-        with self.assertRaises(ValueError):
-            ht.vmap(lambda x: x, chunk_size=0)
-        # not all inputs are DNDarrays
-        with self.assertRaises(TypeError):
-            ht.vmap(lambda x: x, out_dims=0)(ht.ones(10), 2)
-        # number of output DNDarrays does not match number of split dimensions
-        with self.assertRaises(ValueError):
-            ht.vmap(lambda x: x, out_dims=(0, 1))(ht.ones(10))
+            # two inputs (only one of them split), two outputs, including keyword arguments that are not vmapped
+            # output split along different axis
+            x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+            x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=None)
+            out_dims = (0, 1)
+
+            def func(x0, x1, k=2, scale=1e-2):
+                return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+
+            vfunc = ht.vmap(func, out_dims, chunk_size=1)
+            y0, y1 = vfunc(x0, x1, k=5, scale=2.2)
+
+            # compare with torch
+            x0_torch = x0.resplit(None).larray
+            x1_torch = x1.resplit(None).larray
+            vfunc_torch = torch.vmap(func, (0, None), (0, 1))
+            y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=5, scale=2.2)
+
+            self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+            self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+
+        def test_vmap_catch_errors(self):
+            # not a callable
+            with self.assertRaises(TypeError):
+                ht.vmap(1)
+            # invalid randomness
+            with self.assertRaises(ValueError):
+                ht.vmap(lambda x: x, randomness="random")
+            # invalid chunk_size
+            with self.assertRaises(TypeError):
+                ht.vmap(lambda x: x, chunk_size="1")
+            with self.assertRaises(ValueError):
+                ht.vmap(lambda x: x, chunk_size=0)
+            # not all inputs are DNDarrays
+            with self.assertRaises(TypeError):
+                ht.vmap(lambda x: x, out_dims=0)(ht.ones(10), 2)
+            # number of output DNDarrays does not match number of split dimensions
+            with self.assertRaises(ValueError):
+                ht.vmap(lambda x: x, out_dims=(0, 1))(ht.ones(10))

--- a/heat/core/tests/test_vmap.py
+++ b/heat/core/tests/test_vmap.py
@@ -28,13 +28,13 @@ class TestVmap(TestCase):
         self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
 
         # two inputs (only one of them split), two outputs, including keyword arguments that are not vmapped
-        # output split along different axis
+        # output split along different axis, one output has different data type than input
         x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
         x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=None)
         out_dims = (0, 1)
 
         def func(x0, x1, k=2, scale=1e-2):
-            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, (scale * x0 @ x1).int()
 
         vfunc = ht.vmap(func, out_dims)
         y0, y1 = vfunc(x0, x1, k=2, scale=2.2)

--- a/heat/core/tests/test_vmap.py
+++ b/heat/core/tests/test_vmap.py
@@ -6,4 +6,44 @@ from .test_suites.basic_test import TestCase
 
 class TestVmap(TestCase):
     def test_vmap(self):
-        pass
+        # two inputs (both split), two outputs, including keyword arguments that are not vmapped
+        # inputs split along different axes, output split along same axis (one of them different to input split)
+        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=1)
+        out_dims = (0, 0)
+
+        def func(x0, x1, k=2, scale=1e-2):
+            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+
+        vfunc = ht.vmap(func, out_dims)
+        y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
+
+        # compare with torch
+        x0_torch = x0.resplit(None).larray
+        x1_torch = x1.resplit(None).larray
+        vfunc_torch = torch.vmap(func, (0, 1), (0, 0))
+        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
+
+        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+
+        # two inputs (only one of them split), two outputs, including keyword arguments that are not vmapped
+        # output split along different axis
+        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=None)
+        out_dims = (0, 1)
+
+        def func(x0, x1, k=2, scale=1e-2):
+            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+
+        vfunc = ht.vmap(func, out_dims)
+        y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
+
+        # compare with torch
+        x0_torch = x0.resplit(None).larray
+        x1_torch = x1.resplit(None).larray
+        vfunc_torch = torch.vmap(func, (0, None), (0, 1))
+        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
+
+        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))

--- a/heat/core/tests/test_vmap.py
+++ b/heat/core/tests/test_vmap.py
@@ -1,0 +1,9 @@
+import heat as ht
+import torch
+
+from .test_suites.basic_test import TestCase
+
+
+class TestVmap(TestCase):
+    def test_vmap(self):
+        pass

--- a/heat/core/vmap.py
+++ b/heat/core/vmap.py
@@ -1,3 +1,108 @@
 """
 This implements a functionality similar to PyTorchs vmap function.
 """
+
+import torch
+from .dndarray import DNDarray
+from .factories import array
+
+__all__ = ["vmap"]
+
+
+def vmap(func, in_dims=0, out_dims=0, randomness="error", *, chunk_size=None):
+    """
+    This function is used to apply a function to a DNDarray in a vectorized way.
+    `heat.vmap` return a callable that can be applied to a DNDarray.
+    Vectorization needs to take place at least along the split axis.
+
+    Parameters
+    ----------
+    func : callable
+        The function to apply to the DNDarray. It must take a DNDarray as its first argument.
+    in_dims : str or sequence of str
+        The dimensions of the input DNDarray that should be mapped over.
+        Default is 0.
+    out_dims : str or sequence of str
+        The dimensions of the output DNDarray that should be mapped over.
+        Default is 0.
+    randomness : {'error', 'different', 'same'}, optional
+        Determines how to handle randomness in the function to be vmapped.
+        If 'error' (default), an error is raised if the function to be mapped contains randomness.
+        If 'different', randomness will be different for each batch; if 'same', randomness will be the same for each batch.
+        (This argument is directly passed to the underlying PyTorch vmaps; see the corresponding PyTorch documentation for more information.)
+    chunk_size : int or sequence of int, optional
+        The size of the chunks to use for the process-local computation.
+        If None (default), apply a single PyTorch vmap over the process-local chunks of data. If not None, then compute the process-local PyTorch vmap `chunk_size`
+        many samples at a time. Note that `chunk_size=1` is equivalent to computing the process-local PyTorch vmap's with a for-loop.
+        If you run into memory issues computing the vmap, please try a non-None chunk_size.
+
+    Note
+    ------
+    This function is a wrapper around PyTorch's `torch.vmap` function. In essence, a PyTorch vmap is applied to the input function `func` on each MPI process separately.
+    This process-local PyTorch-vmapped function is then applied to the process-local chunks of the input DNDarray.
+    """
+    # rough check of input argument types
+    if not isinstance(func, callable):
+        raise TypeError("The input function `func` must be callable.")
+    if not isinstance(in_dims, (int, tuple)):
+        raise TypeError("The input argument `in_dims` must be an integer or a tuple of integers.")
+    if not isinstance(out_dims, (int, tuple)):
+        raise TypeError("The input argument `out_dims` must be an integer or a tuple of integers.")
+    if not isinstance(chunk_size, (int, tuple, type(None))):
+        raise TypeError(
+            "The input argument `chunk_size` must be an integer, a tuple of integers, or None."
+        )
+    # check input argument values
+    if isinstance(in_dims, int):
+        in_dims = (in_dims,)
+    for dim in in_dims:
+        if not isinstance(dim, int) or dim < 0:
+            raise ValueError("`in_dims` may only contain *non-negative integers*.")
+    if isinstance(out_dims, int):
+        out_dims = (out_dims,)
+    for dim in out_dims:
+        if not isinstance(dim, int) or dim < 0:
+            raise ValueError("`out_dims` may only contain *non-negative integers*.")
+    if not len(in_dims) == len(out_dims):
+        raise ValueError("The input arguments `in_dims` and `out_dims` must have the same length.")
+    if randomness not in ["error", "different", "same"]:
+        raise ValueError(
+            "The input argument `randomness` must be one of the strings 'error', 'different', or 'same'."
+        )
+    if chunk_size is not None:
+        if isinstance(chunk_size, int):
+            chunk_size = (chunk_size,)
+        for size in chunk_size:
+            if not isinstance(size, int) or size < 1:
+                raise ValueError(
+                    "If a tuple, the input argument `chunk_size` must be a tuple of *positive integers*."
+                )
+        if not len(chunk_size) == len(in_dims):
+            raise ValueError(
+                "If not None, the input argument `chunk_size` must have the same length as `in_dims`."
+            )
+
+    def vmapped_func(x: DNDarray):
+        if not isinstance(x, DNDarray):
+            raise TypeError("The input to the vmapped-version of your function must be a DNDarray.")
+        if x.split is None:
+            # if the input DNDarray is not split
+            new_is_split = False
+            new_split = None
+        else:
+            # if input DNDarray is split, check if split axis is in in_dims and determine split axis of output DNDarray
+            if x.split not in in_dims:
+                raise ValueError(
+                    'The split axis of the input DNDarray to your vmapped function must be in the dimensions mapped over by vmap ("`in_dims`").'
+                )
+            new_is_split = True
+            new_split = out_dims[in_dims.index(x.split)]
+        # apply Torch vmap to the input function and the result to the local arrays of the input DNDarray
+        torch_vmap_func = torch.vmap(
+            func, in_dims, out_dims, randomness=randomness, chunk_size=chunk_size
+        )
+        y_larray = torch_vmap_func(x.larray)
+        y = array(y_larray, is_split=new_is_split, split=new_split)
+        return y
+
+    return vmapped_func

--- a/heat/core/vmap.py
+++ b/heat/core/vmap.py
@@ -1,0 +1,3 @@
+"""
+This implements a functionality similar to PyTorchs vmap function.
+"""

--- a/heat/core/vmap.py
+++ b/heat/core/vmap.py
@@ -29,7 +29,8 @@ def vmap(
     ----------
     func : callable
         The function to apply in a vmapped way to the DNDarray(s). It must take PyTorch tensor(s) as positional arguments.
-        Additional parameters, not to be vmapped over, can be passed as keyword arguments.
+        Additional parameters, not to be vmapped over, can be passed as keyword arguments. The callable returned by
+        by `heat.vmap` will also accept these keyword arguments.
     out_dims : int or tuple of int, optional
         The dimensions of the output(s) that are mapped over; identical to the split dimension(s) of the output(s).
         Default is 0.

--- a/heat/core/vmap.py
+++ b/heat/core/vmap.py
@@ -5,31 +5,28 @@ This implements a functionality similar to PyTorchs vmap function.
 import torch
 from .dndarray import DNDarray
 from .factories import array
+from .communication import MPI_WORLD
 
 __all__ = ["vmap"]
 
 
-def vmap(func, in_dims=0, out_dims=0, randomness="error", *, chunk_size=None):
+def vmap(func, out_dims=0, randomness="error", *, chunk_size=None):
     """
     This function is used to apply a function to a DNDarray in a vectorized way.
-    `heat.vmap` return a callable that can be applied to a DNDarray.
-    Vectorization needs to take place at least along the split axis.
+    `heat.vmap` return a callable that can be applied to DNDarrays.
+    Vectorization will automatically take place along the split axis/axes; therefore, unlike in PyTorch, there is no argument `in_dims`.
 
     Parameters
     ----------
     func : callable
         The function to apply to the DNDarray. It must take a DNDarray as its first argument.
-    in_dims : str or sequence of str
-        The dimensions of the input DNDarray that should be mapped over.
-        Default is 0.
-    out_dims : str or sequence of str
-        The dimensions of the output DNDarray that should be mapped over.
+    out_dims : int or sequence of int, optional
+        The dimensions of the output(s) that are mapped over; identical to the split dimension(s) of the output(s).
         Default is 0.
     randomness : {'error', 'different', 'same'}, optional
-        Determines how to handle randomness in the function to be vmapped.
+        Determines how to handle randomness in the function to be vmapped. This argument is directly passed to the underlying PyTorch vmaps;
+        see the corresponding PyTorch documentation for more information and the note below.
         If 'error' (default), an error is raised if the function to be mapped contains randomness.
-        If 'different', randomness will be different for each batch; if 'same', randomness will be the same for each batch.
-        (This argument is directly passed to the underlying PyTorch vmaps; see the corresponding PyTorch documentation for more information.)
     chunk_size : int or sequence of int, optional
         The size of the chunks to use for the process-local computation.
         If None (default), apply a single PyTorch vmap over the process-local chunks of data. If not None, then compute the process-local PyTorch vmap `chunk_size`
@@ -39,70 +36,49 @@ def vmap(func, in_dims=0, out_dims=0, randomness="error", *, chunk_size=None):
     Note
     ------
     This function is a wrapper around PyTorch's `torch.vmap` function. In essence, a PyTorch vmap is applied to the input function `func` on each MPI process separately.
-    This process-local PyTorch-vmapped function is then applied to the process-local chunks of the input DNDarray.
+    This process-local PyTorch-vmapped function is then applied to the process-local chunks of the input DNDarray(s).
+
+    Please note that the options 'same' and 'different' for `randomness` will result in behaviour different from the one known by PyTorch as (at least currently)
+    no actions are taken to synchronize randomness across the MPI processes.
     """
     # rough check of input argument types
-    if not isinstance(func, callable):
+    if not callable(func):
         raise TypeError("The input function `func` must be callable.")
-    if not isinstance(in_dims, (int, tuple)):
-        raise TypeError("The input argument `in_dims` must be an integer or a tuple of integers.")
-    if not isinstance(out_dims, (int, tuple)):
-        raise TypeError("The input argument `out_dims` must be an integer or a tuple of integers.")
-    if not isinstance(chunk_size, (int, tuple, type(None))):
-        raise TypeError(
-            "The input argument `chunk_size` must be an integer, a tuple of integers, or None."
-        )
-    # check input argument values
-    if isinstance(in_dims, int):
-        in_dims = (in_dims,)
-    for dim in in_dims:
-        if not isinstance(dim, int) or dim < 0:
-            raise ValueError("`in_dims` may only contain *non-negative integers*.")
-    if isinstance(out_dims, int):
-        out_dims = (out_dims,)
-    for dim in out_dims:
-        if not isinstance(dim, int) or dim < 0:
-            raise ValueError("`out_dims` may only contain *non-negative integers*.")
-    if not len(in_dims) == len(out_dims):
-        raise ValueError("The input arguments `in_dims` and `out_dims` must have the same length.")
     if randomness not in ["error", "different", "same"]:
         raise ValueError(
             "The input argument `randomness` must be one of the strings 'error', 'different', or 'same'."
         )
-    if chunk_size is not None:
-        if isinstance(chunk_size, int):
-            chunk_size = (chunk_size,)
-        for size in chunk_size:
-            if not isinstance(size, int) or size < 1:
-                raise ValueError(
-                    "If a tuple, the input argument `chunk_size` must be a tuple of *positive integers*."
-                )
-        if not len(chunk_size) == len(in_dims):
-            raise ValueError(
-                "If not None, the input argument `chunk_size` must have the same length as `in_dims`."
-            )
 
-    def vmapped_func(x: DNDarray):
-        if not isinstance(x, DNDarray):
-            raise TypeError("The input to the vmapped-version of your function must be a DNDarray.")
-        if x.split is None:
-            # if the input DNDarray is not split
-            new_is_split = False
-            new_split = None
-        else:
-            # if input DNDarray is split, check if split axis is in in_dims and determine split axis of output DNDarray
-            if x.split not in in_dims:
-                raise ValueError(
-                    'The split axis of the input DNDarray to your vmapped function must be in the dimensions mapped over by vmap ("`in_dims`").'
+    def vmapped_func(*args, **kwargs):
+        for arg in args:
+            if not isinstance(arg, DNDarray):
+                raise TypeError(
+                    f"All inputs to the vmapped-version of your function must be DNDarrays, but one is {type(arg)}."
                 )
-            new_is_split = True
-            new_split = out_dims[in_dims.index(x.split)]
+        in_dims = tuple([arg.split for arg in args])
+        print(in_dims)
+
         # apply Torch vmap to the input function and the result to the local arrays of the input DNDarray
         torch_vmap_func = torch.vmap(
             func, in_dims, out_dims, randomness=randomness, chunk_size=chunk_size
         )
-        y_larray = torch_vmap_func(x.larray)
-        y = array(y_larray, is_split=new_is_split, split=new_split)
-        return y
+        out_larrays = torch_vmap_func(*[arg.larray for arg in args], **kwargs)
+
+        if isinstance(out_larrays, torch.Tensor):
+            # circumvent misinterpretation of the following call of len() in case of a single output
+            out_larrays = [out_larrays]
+        if isinstance(out_dims, int):
+            out_split = [out_dims] * len(out_larrays)
+        else:
+            out_split = out_dims
+            if len(out_split) != len(out_larrays):
+                raise ValueError(
+                    f"The number of output DNDarrays ({len(out_larrays)}) must match the number of their split dimensions provided in `out_dims` ({len(out_split)})."
+                )
+        # generate output DNDarray(s)
+        out_dndarrays = [
+            array(out_larrays[k], is_split=out_split[k]) for k in range(len(out_larrays))
+        ]
+        return tuple(out_dndarrays)
 
     return vmapped_func

--- a/heat/core/vmap.py
+++ b/heat/core/vmap.py
@@ -1,8 +1,10 @@
 """
 This implements a functionality similar to PyTorchs vmap function.
+Requires PyTorch 2.0.0 or higher.
 """
 
 import torch
+
 from .dndarray import DNDarray
 from .factories import array
 from .communication import MPI_WORLD
@@ -52,6 +54,9 @@ def vmap(
     Please note that the options 'same' and 'different' for `randomness` will result in behaviour different from the one known by PyTorch as (at least currently)
     no actions are taken to synchronize randomness across the MPI processes.
     """
+    # check PyTorch version, return error if not 2.0.0 or higher
+    if torch.__version__ < "2.0.0":
+        raise RuntimeError("The function `heat.vmap` requires PyTorch 2.0.0 or higher.")
     # rough check of input argument types
     if not callable(func):
         raise TypeError("The input function `func` must be callable.")

--- a/heat/core/vmap.py
+++ b/heat/core/vmap.py
@@ -6,21 +6,31 @@ import torch
 from .dndarray import DNDarray
 from .factories import array
 from .communication import MPI_WORLD
+from typing import Union, Tuple, Optional, Callable
 
 __all__ = ["vmap"]
 
 
-def vmap(func, out_dims=0, randomness="error", *, chunk_size=None):
+def vmap(
+    func: Callable[[Tuple[torch.Tensor]], Tuple[torch.Tensor]],
+    out_dims: Union[Tuple[int], int] = 0,
+    randomness: str = "error",
+    *,
+    chunk_size: int = None,
+) -> Callable[[Tuple[DNDarray]], Tuple[DNDarray]]:
     """
     This function is used to apply a function to a DNDarray in a vectorized way.
     `heat.vmap` return a callable that can be applied to DNDarrays.
-    Vectorization will automatically take place along the split axis/axes; therefore, unlike in PyTorch, there is no argument `in_dims`.
+    Vectorization will automatically take place along the split axis/axes of the DNDarray(s);
+    therefore, unlike in PyTorch, there is no argument `in_dims`.
+    What we here refer to as "split axis/dimension" in the Heat terminology is often referred to as "batch axis/dimension" in the PyTorch terminology.
 
     Parameters
     ----------
     func : callable
-        The function to apply to the DNDarray. It must take a DNDarray as its first argument.
-    out_dims : int or sequence of int, optional
+        The function to apply in a vmapped way to the DNDarray(s). It must take PyTorch tensor(s) as positional arguments.
+        Additional parameters, not to be vmapped over, can be passed as keyword arguments.
+    out_dims : int or tuple of int, optional
         The dimensions of the output(s) that are mapped over; identical to the split dimension(s) of the output(s).
         Default is 0.
     randomness : {'error', 'different', 'same'}, optional


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [x] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #1383 
The implemented vmap-functionality is similar to the one of PyTorch. It allows vectorized application of PyTorch-functions to one or multiple DNDarrays with vectorization taking place along the respective split axes. 

An artificial example, how vmap does work, is found in the tests. 

## Type of change
new feature

#### Does this change modify the behaviour of other functions? If so, which?
no
