### PR TITLE
Make `dataset.ishuffle` optional 

### DIFF
--- a/heat/utils/data/datatools.py
+++ b/heat/utils/data/datatools.py
@@ -83,7 +83,8 @@ class DataLoader:
                 f"dataset must be a torch Dataset, heat Dataset, heat PartialH5Dataset, currently: {type(dataset)}"
             )
         self.dataset = dataset
-        self.ishuffle = self.dataset.ishuffle
+        if hasattr(self.dataset, "ishuffle"):
+            self.ishuffle = self.dataset.ishuffle
         if isinstance(self.dataset, partial_dataset.PartialH5Dataset):
             drop_last = True
 
@@ -110,7 +111,7 @@ class DataLoader:
         """
         if isinstance(self.dataset, partial_dataset.PartialH5Dataset):
             return partial_dataset.PartialH5DataLoaderIter(self)
-        if hasattr(self, "_full_dataset_shuffle_iter"):
+        if hasattr(self, "_full_dataset_shuffle_iter") and hasattr(self.dataset, "ishuffle"):
             # if it is a normal heat dataset then this is defined
             self._full_dataset_shuffle_iter()
         return self.DataLoader.__iter__()


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  title of the PR is suitable to appear in the release notes
- Implementation:
    - [x] unit tests: no unit test added, so far datatools.py has no unit tests
    - [x] unit tests: no, same as above
    - [x] documentation updated where needed

## Description

So far, the Heat dataset requires the implementation of an ishuffle method that defines the shuffling of data between epochs. This is not compatible with the PyTorch dataset class. To enable the use of PyTorch dataset classes, ishuffle is now optional.

## Type of change
- New feature

#### Does this change modify the behaviour of other functions? If so, which?
 no
