### PR TITLE
Features/1455 add decomposition module and pca interface

### DIFF
--- a/heat/decomposition/pca.py
+++ b/heat/decomposition/pca.py
@@ -217,13 +217,7 @@ class PCA(ht.TransformMixin, ht.BaseEstimator):
                 # hierarchical SVD with prescribed upper bound on relative error
                 # note: "upper bound on relative error" (hsvd_rtol) is "1 - lower bound" (PCA)
                 _, S, V, info = ht.linalg.hsvd_rtol(
-                    X_centered,
-                    (1 - self.n_components_) ** 0.5,
-                    compute_sv=True,
-                    safetyshift=0,
-                    1 - self.n_components_,
-                    compute_sv=True,
-                    safetyshift=self.n_oversamples,
+                    X_centered, (1 - self.n_components_) ** 0.5, compute_sv=True, safetyshift=0
                 )
             else:
                 # hierarchical SVD with prescribed, fixed rank

--- a/heat/decomposition/pca.py
+++ b/heat/decomposition/pca.py
@@ -76,7 +76,6 @@ class PCA(ht.TransformMixin, ht.BaseEstimator):
     ------------
     Hieararchical SVD (`svd_solver = "hierarchical"`) computes and approximate, truncated SVD. Thus, the results are not exact, in general, unless the
     truncation rank chose is larger than the actual rank (matrix rank) of the underlying data; see :func:`ht.linalg.hsvd_rank` and :func:`ht.linalg.hsvd_rtol` for details.
-    Note that under certain conditions also the corresponding error estimate might perform poorly, resulting in a negative lower bound on the total explained variance ratio.
     """
 
     def __init__(

--- a/heat/decomposition/pca.py
+++ b/heat/decomposition/pca.py
@@ -41,7 +41,6 @@ class PCA(ht.TransformMixin, ht.BaseEstimator):
     iterated_power : {'auto', int}, default='auto'
         if svd_solver='randomized', ... (not yet supported)
     n_oversamples : int, default=10
-        if svd_solver='hierarchical', this parameter specifies the argument `safetyshift` of the underlying algorithm.
         if svd_solver='randomized', ... (not yet supported)
     power_iteration_normalizer : {'qr'}, default='qr'
         if svd_solver='randomized', ... (not yet supported)
@@ -77,6 +76,7 @@ class PCA(ht.TransformMixin, ht.BaseEstimator):
     ------------
     Hieararchical SVD (`svd_solver = "hierarchical"`) computes and approximate, truncated SVD. Thus, the results are not exact, in general, unless the
     truncation rank chose is larger than the actual rank (matrix rank) of the underlying data; see :func:`ht.linalg.hsvd_rank` and :func:`ht.linalg.hsvd_rtol` for details.
+    Note that under certain conditions also the corresponding error estimate might perform poorly, resulting in a negative lower bound on the total explained variance ratio.
     """
 
     def __init__(
@@ -179,20 +179,21 @@ class PCA(ht.TransformMixin, ht.BaseEstimator):
             self.n_components_ = self.n_components
 
         # compute SVD via "full" SVD
-        if self.svd_solver == "full":
+        if self.svd_solver == "full" or not X.is_distributed():
             _, S, V = ht.linalg.svd(X_centered, full_matrices=False)
             if isinstance(self.n_components_, int):
                 # prescribed truncation rank (including no truncation)
                 self.components_ = V[:, : self.n_components_].T
                 self.singular_values_ = S[: self.n_components_]
-                self.explained_variance_ = (S**2)[: self.n_components_]
-                self.explained_variance_ratio_ = self.explained_variance_ / (S**2).sum()
+                self.explained_variance_ = (S**2)[: self.n_components_] / (X.shape[0] - 1)
+                total_variance = (S**2).sum() / (X.shape[0] - 1)
+                self.explained_variance_ratio_ = self.explained_variance_ / total_variance
 
             else:
                 # truncation w.r.t. prescribed bound on explained variance
-                total_variance = (S**2).sum()
+                total_variance = (S**2).sum() / (X.shape[0] - 1)
                 explained_variance_threshold = self.n_components_ * total_variance.larray.item()
-                explained_variance_cumsum = (S**2).larray.cumsum(0)
+                explained_variance_cumsum = (S**2).larray.cumsum(0) / (X.shape[0] - 1)
                 self.n_components_ = (
                     len(
                         explained_variance_cumsum[
@@ -203,7 +204,7 @@ class PCA(ht.TransformMixin, ht.BaseEstimator):
                 )
                 self.components_ = V[:, : self.n_components_].T
                 self.singular_values_ = S[: self.n_components_]
-                self.explained_variance_ = (S**2)[: self.n_components_]
+                self.explained_variance_ = (S**2)[: self.n_components_] / (X.shape[0] - 1)
                 self.explained_variance_ratio_ = self.explained_variance_ / total_variance
             self.total_explained_variance_ratio_ = self.explained_variance_ratio_.sum().item()
         # compute SVD via "hierarchical" SVD
@@ -217,18 +218,18 @@ class PCA(ht.TransformMixin, ht.BaseEstimator):
                 # note: "upper bound on relative error" (hsvd_rtol) is "1 - lower bound" (PCA)
                 _, S, V, info = ht.linalg.hsvd_rtol(
                     X_centered,
-                    1 - self.n_components_,
+                    (1 - self.n_components_) ** 0.5,
                     compute_sv=True,
-                    safetyshift=self.n_oversamples,
+                    safetyshift=0,
                 )
             else:
                 # hierarchical SVD with prescribed, fixed rank
                 _, S, V, info = ht.linalg.hsvd_rank(
-                    X_centered, self.n_components_, compute_sv=True, safetyshift=self.n_oversamples
+                    X_centered, self.n_components_, compute_sv=True, safetyshift=0
                 )
             self.n_components_ = V.shape[1]
             self.components_ = V.T
-            self.total_explained_variance_ratio_ = 1 - info.larray.item()
+            self.total_explained_variance_ratio_ = 1 - info.larray.item() ** 2
 
         else:
             # here one could add other computational backends

--- a/heat/decomposition/pca.py
+++ b/heat/decomposition/pca.py
@@ -181,7 +181,6 @@ class PCA(ht.TransformMixin, ht.BaseEstimator):
         # compute SVD via "full" SVD
         if self.svd_solver == "full":
             _, S, V = ht.linalg.svd(X_centered, full_matrices=False)
-            print(self.n_components_)
             if isinstance(self.n_components_, int):
                 # prescribed truncation rank (including no truncation)
                 self.components_ = V[:, : self.n_components_].T


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #

## Changes proposed:

-
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
