### PR TITLE
Bugs/1592  Resolved two bugs in BatchParallel Clustering

### DIFF
--- a/heat/cluster/batchparallelclustering.py
+++ b/heat/cluster/batchparallelclustering.py
@@ -30,8 +30,8 @@ def _initialize_plus_plus(X, n_clusters, p, random_state=None, max_samples=2**24
         torch.manual_seed(random_state)
     if X.shape[0] > max_samples:  # torch's multinomial is limited to 2^24 categories
         idxs_subsampling = torch.randint(0, X.shape[0], (max_samples,))
-        X = X[idxs_subsampling] 
-    # actual K-Means++ 
+        X = X[idxs_subsampling]
+    # actual K-Means++
     idxs = torch.zeros(n_clusters, dtype=torch.long, device=X.device)
     idxs[0] = torch.randint(0, X.shape[0], (1,))
     for i in range(1, n_clusters):
@@ -39,6 +39,7 @@ def _initialize_plus_plus(X, n_clusters, p, random_state=None, max_samples=2**24
         dist = torch.min(dist, dim=1)[0]
         idxs[i] = torch.multinomial(dist, 1)
     return X[idxs]
+
 
 def _kmex(X, p, n_clusters, init, max_iter, tol, random_state=None):
     """

--- a/heat/cluster/batchparallelclustering.py
+++ b/heat/cluster/batchparallelclustering.py
@@ -19,20 +19,24 @@ Auxiliary single-process functions and base class for batch-parallel k-clusterin
 """
 
 
-def _initialize_plus_plus(X, n_clusters, p, random_state=None):
+def _initialize_plus_plus(X, n_clusters, p, random_state=None, max_samples=2**24 - 1):
     """
     Auxiliary function: single-process k-means++/k-medians++ initialization in pytorch
     p is the norm used for computing distances
     """
     if random_state is not None:
         torch.manual_seed(random_state)
-    idxs = torch.zeros(n_clusters, dtype=torch.long, device=X.device)
-    idxs[0] = torch.randint(0, X.shape[0], (1,))
-    for i in range(1, n_clusters):
-        dist = torch.cdist(X, X[idxs[:i]], p=p)
-        dist = torch.min(dist, dim=1)[0]
-        idxs[i] = torch.multinomial(dist, 1)
-    return X[idxs]
+    if X.shape[0] <= max_samples:  # torch's multinomial is limited to 2^24 categories
+        idxs = torch.zeros(n_clusters, dtype=torch.long, device=X.device)
+        idxs[0] = torch.randint(0, X.shape[0], (1,))
+        for i in range(1, n_clusters):
+            dist = torch.cdist(X, X[idxs[:i]], p=p)
+            dist = torch.min(dist, dim=1)[0]
+            idxs[i] = torch.multinomial(dist, 1)
+        return X[idxs]
+    else:  # if X is too large for the 2^24-bound, use a random subset of X
+        idxs = torch.randint(0, X.shape[0], (max_samples,))
+        return _initialize_plus_plus(X[idxs], n_clusters, p, random_state)
 
 
 def _kmex(X, p, n_clusters, init, max_iter, tol, random_state=None):

--- a/heat/cluster/batchparallelclustering.py
+++ b/heat/cluster/batchparallelclustering.py
@@ -289,11 +289,11 @@ class _BatchParallelKCluster(ht.ClusteringMixin, ht.BaseEstimator):
 
         local_labels = _parallel_batched_kmex_predict(
             x.larray, self._cluster_centers.larray, self._p
-        )
+        ).to(torch.int32)
         labels = DNDarray(
             local_labels,
             gshape=(x.shape[0], 1),
-            dtype=ht.int64,
+            dtype=ht.int32,
             device=x.device,
             comm=x.comm,
             split=x.split,

--- a/heat/cluster/batchparallelclustering.py
+++ b/heat/cluster/batchparallelclustering.py
@@ -23,8 +23,8 @@ def _initialize_plus_plus(X, n_clusters, p, random_state=None, max_samples=2**24
     """
     Auxiliary function: single-process k-means++/k-medians++ initialization in pytorch
     p is the norm used for computing distances
-    The value max_samples=2**24 - 1 is necessary as PyTorchs multinomial currently only 
-    supports this number of different categories. 
+    The value max_samples=2**24 - 1 is necessary as PyTorchs multinomial currently only
+    supports this number of different categories.
     """
     if random_state is not None:
         torch.manual_seed(random_state)

--- a/heat/cluster/batchparallelclustering.py
+++ b/heat/cluster/batchparallelclustering.py
@@ -293,7 +293,7 @@ class _BatchParallelKCluster(ht.ClusteringMixin, ht.BaseEstimator):
         labels = DNDarray(
             local_labels,
             gshape=(x.shape[0], 1),
-            dtype=ht.int32,
+            dtype=ht.int64,
             device=x.device,
             comm=x.comm,
             split=x.split,

--- a/heat/cluster/batchparallelclustering.py
+++ b/heat/cluster/batchparallelclustering.py
@@ -23,6 +23,8 @@ def _initialize_plus_plus(X, n_clusters, p, random_state=None, max_samples=2**24
     """
     Auxiliary function: single-process k-means++/k-medians++ initialization in pytorch
     p is the norm used for computing distances
+    The value max_samples=2**24 - 1 is necessary as PyTorchs multinomial currently only 
+    supports this number of different categories. 
     """
     if random_state is not None:
         torch.manual_seed(random_state)

--- a/heat/cluster/tests/test_batchparallelclustering.py
+++ b/heat/cluster/tests/test_batchparallelclustering.py
@@ -7,7 +7,7 @@ from heat.utils.data.spherical import create_spherical_dataset
 from mpi4py import MPI
 
 from ...core.tests.test_suites.basic_test import TestCase
-from ..batchparallelclustering import _kmex, _BatchParallelKCluster
+from ..batchparallelclustering import _kmex, _initialize_plus_plus, _BatchParallelKCluster
 
 # test BatchParallelKCluster base class and auxiliary functions
 
@@ -31,6 +31,10 @@ class TestAuxiliaryFunctions(TestCase):
         # test initialization with prescribed centers
         init = torch.rand(2, 3)
         _kmex(X, 2, 2, init, max_iter, tol)
+
+    def test_initialize_plus_plus(self):
+        X = torch.rand(100, 3)
+        _initialize_plus_plus(X, 3, 2, random_state=None, max_samples=50)
 
     def test_BatchParallelKClustering(self):
         with self.assertRaises(TypeError):

--- a/heat/cluster/tests/test_batchparallelclustering.py
+++ b/heat/cluster/tests/test_batchparallelclustering.py
@@ -120,7 +120,7 @@ class TestBatchParallelKCluster(TestCase):
                                 self.assertIsInstance(labels, ht.DNDarray)
                                 self.assertEqual(labels.split, 0)
                                 self.assertEqual(labels.shape, (data.shape[0], 1))
-                                self.assertEqual(labels.dtype, ht.int64)
+                                self.assertEqual(labels.dtype, ht.int32)
                                 self.assertEqual(labels.max(), n_clusters - 1)
                                 self.assertEqual(labels.min(), 0)
 

--- a/heat/cluster/tests/test_batchparallelclustering.py
+++ b/heat/cluster/tests/test_batchparallelclustering.py
@@ -120,7 +120,7 @@ class TestBatchParallelKCluster(TestCase):
                                 self.assertIsInstance(labels, ht.DNDarray)
                                 self.assertEqual(labels.split, 0)
                                 self.assertEqual(labels.shape, (data.shape[0], 1))
-                                self.assertEqual(labels.dtype, ht.int32)
+                                self.assertEqual(labels.dtype, ht.int64)
                                 self.assertEqual(labels.max(), n_clusters - 1)
                                 self.assertEqual(labels.min(), 0)
 


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [X]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [X] unit tests: all split configurations tested
    - [X] unit tests: multiple dtypes tested
    - [X] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #1592 

## Changes proposed:

- output labels had int32-data type as Heat-arrays, but internally they were int64-floats in torch; this causes problems when going on with computations after clustering. Now, the torch labels are cast to int32; this is no problem as nobody will have more than int32 cluster centers. 
- torch.multinomial used for K-Means++ initialization on each MPI-process has a limit of 2^24 elements (at least on GPU). Thus, if there are more than 2^24 elements to cluster on each process, we now take a uniform subsample before doing K-Means++. 


## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
