### PR TITLE
Resolve assertion error in tests of Batch-parallel clustering

### DIFF
--- a/heat/cluster/tests/test_batchparallelclustering.py
+++ b/heat/cluster/tests/test_batchparallelclustering.py
@@ -121,8 +121,8 @@ class TestBatchParallelKCluster(TestCase):
                                 self.assertEqual(labels.split, 0)
                                 self.assertEqual(labels.shape, (data.shape[0], 1))
                                 self.assertEqual(labels.dtype, ht.int32)
-                                self.assertEqual(labels.max(), n_clusters - 1)
-                                self.assertEqual(labels.min(), 0)
+                                self.assertTrue(labels.max() <= n_clusters - 1)
+                                self.assertTrue(labels.min() >= 0)
 
     def test_if_errors_thrown(self):
         for ParallelClusterer in [ht.cluster.BatchParallelKMeans, ht.cluster.BatchParallelKMedians]:


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [X]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [X] unit tests: all split configurations tested
    - [X] unit tests: multiple dtypes tested
    - [X] documentation updated where needed

## Description

Issue/s resolved: #1612 

## Changes proposed:
The problem was that the way how the test had been formulated; it had been checked that labels.min()==0 and labels.max()==n_clusters-1. In very rare cases empty clusters might occur and if this empty cluster got the label 0 or n_clusters-1 the tests failed by construction although there's actually no error. 

Tests have been adapted to  labels.min()>=0 and labels.max()<=n_clusters-1. 

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
