### PR TITLE
downgrade sphinx version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==8.0.2
+Sphinx==7.4.7
 sphinx-autoapi===3.2.1
 sphinx_rtd_theme==2.0.0
 sphinxcontrib-napoleon==0.7


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This fix downgrades the sphinx version back because sphinx_rtd_theme is not compatible with sphinx >= 8

## Changes proposed:

- set sphinx back to 7.4.7

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

Documentation / Fix