### PR TITLE
Raise Error for batched vector inputs on matmul

### DIFF
--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -430,9 +430,9 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
     Parameters
     -----------
     a : DNDarray
-        matrix :math:`L \\times P` or vector :math:`P` or batch of matrices/vectors: :math:`B_1 \\times ... \\times B_k [\\times L] \\times P`
+        matrix :math:`L \\times P` or vector :math:`P` or batch of matrices: :math:`B_1 \\times ... \\times B_k \\times L \\times P`
     b : DNDarray
-        matrix :math:`P \\times Q` or vector :math:`P` or batch of matrices/vectors: :math:`B_1 \\times ... \\times B_k \\times P [\\times Q]`
+        matrix :math:`P \\times Q` or vector :math:`P` or batch of matrices: :math:`B_1 \\times ... \\times B_k \\times P \\times Q`
     allow_resplit : bool, optional
         Whether to distribute ``a`` in the case that both ``a.split is None`` and ``b.split is None``.
         Default is ``False``. If ``True``, if both are not split then ``a`` will be distributed in-place along axis 0.
@@ -440,7 +440,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
     Notes
     -----------
     - For batched inputs, batch dimensions must coincide and if one matrix is split along a batch axis the other must be split along the same axis.
-    - If ``a`` or ``b`` is a (possibly batched) vector the result will also be a (possibly batched) vector.
+    - If ``a`` or ``b`` is a vector the result will also be a vector.
     - We recommend to avoid the particular split combinations ``1``-``0``, ``None``-``0``, and ``1``-``None`` (for ``a.split``-``b.split``) due to their comparably high memory consumption, if possible. Applying ``DNDarray.resplit_`` or ``heat.resplit`` on one of the two factors before calling ``matmul`` in these situations might improve performance of your code / might avoid memory bottlenecks.
 
     References
@@ -528,6 +528,10 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         ) and a.split != b.split:  # not the same batch axis for split
             raise NotImplementedError(
                 "Both input matrices have to be split along the same batch axis!"
+            )
+        if vector_flag:  # batched matrix vector multiplication not supported
+            raise NotImplementedError(
+                "Batched matrix-vector multiplication is not supported, try using expand_dims to make it a batched matrix-matrix multiplication."
             )
 
     comm = a.comm

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -827,14 +827,16 @@ class TestLinalgBasics(TestCase):
                 a = ht.zeros((3, 3, 3), split=0)
                 b = ht.zeros((4, 3, 3), split=0)
                 ht.matmul(a, b)
-            # not implemented split
-            """
-            todo
+            # split along different batch dimension
             with self.assertRaises(NotImplementedError):
-                a = ht.zeros((3, 3, 3))
-                b = ht.zeros((3, 3, 3))
+                a = ht.zeros((4, 3, 3, 3), split=0)
+                b = ht.zeros((4, 3, 3, 3), split=1)
                 ht.matmul(a, b)
-            """
+            # batched matrix-vector multiplication
+            with self.assertRaises(NotImplementedError):
+                a = ht.zeros((3, 3, 3), split=0)
+                b = ht.zeros((3, 3), split=0)
+                ht.matmul(a, b)
 
             # batched, split batch
             n = 11  # number of batches


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [x] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #1645 

## Changes proposed:

-
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
