### PR TITLE
Release drafter action handles multi-branch releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+filter-by-commitish: true
 categories:
   - title: '🔥 Features'
     labels:


### PR DESCRIPTION
Release drafter action should now be able to distinguish between releases on different branches.

## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [x] benchmarks: created for new functionality
    - [x] benchmarks: performance improved or maintained
    - [x] documentation updated where needed

## Description

Add extra option to release-drafter.yml to base the release draft based on the current branch.

Issue/s resolved: #

## Changes proposed:

- "filter-by-commitish: true" -> I don't think I have ever seen it called commitish

