### PR TITLE
Linters  will no longer format tutorials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: 6.3.0 # pick a git hash / tag to point to
     hooks:
       - id: pydocstyle
-        exclude: "tests|benchmarks|examples|scripts|setup.py" #|heat/utils/data/mnist.py|heat/utils/data/_utils.py  ?
+        exclude: "tutorials|tests|benchmarks|examples|scripts|setup.py" #|heat/utils/data/mnist.py|heat/utils/data/_utils.py  ?
   - repo: "https://github.com/citation-file-format/cffconvert"
     rev: "054bda51dbe278b3e86f27c890e3f3ac877d616c"
     hooks:


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] ~~unit tests: all split configurations tested~~ Does Not Apply
    - [ ] ~~unit tests: multiple dtypes tested~~ Does Not Apply
    - [ ] ~~benchmarks: created for new functionality~~ Does Not Apply
    - [ ] ~~benchmarks: performance improved or maintained~~ Does Not Apply
    - [ ] ~~documentation updated where needed~~ Does Not Apply

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Modifying pre-commit-config to prevent picky formatting of our tutorials. Once this is merged, we can address formatting in #1523 


Issue/s resolved: None

## Changes proposed:

- add directory `tutorials` to `exclude`  field like in #1523  
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
NA
## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
NA
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->
NA
#### Does this change modify the behaviour of other functions? If so, which?
no
