### PR TITLE
Bug fix: printing non-distributed data 

### DIFF
--- a/heat/core/printing.py
+++ b/heat/core/printing.py
@@ -196,8 +196,9 @@ def __str__(dndarray) -> str:
             + f", device: {dndarray.device}, split: {dndarray.split}"
         )
     if dndarray.comm.size == 1:
+        tab_size = len(__PREFIX) + 1
         return (
-            f"{__PREFIX}({torch._tensor_str._tensor_str(dndarray.larray, 0)}, dtype=ht.{dndarray.dtype.__name__}, "
+            f"{__PREFIX}({torch._tensor_str._tensor_str(dndarray.larray, tab_size)}, dtype=ht.{dndarray.dtype.__name__}, "
             f"device={dndarray.device}, split={dndarray.split})"
         )
     tensor_string = _tensor_str(dndarray, __INDENT + 1)

--- a/heat/core/printing.py
+++ b/heat/core/printing.py
@@ -195,6 +195,11 @@ def __str__(dndarray) -> str:
             torch._tensor_str._tensor_str(dndarray.larray, 0)
             + f", device: {dndarray.device}, split: {dndarray.split}"
         )
+    if dndarray.comm.size == 1:
+        return (
+            f"{__PREFIX}({torch._tensor_str._tensor_str(dndarray.larray, 0)}, dtype=ht.{dndarray.dtype.__name__}, "
+            f"device={dndarray.device}, split={dndarray.split})"
+        )
     tensor_string = _tensor_str(dndarray, __INDENT + 1)
     if dndarray.comm.rank != 0:
         return ""

--- a/heat/core/printing.py
+++ b/heat/core/printing.py
@@ -7,8 +7,6 @@ from .communication import MPI_WORLD
 
 from .dndarray import DNDarray
 
-import time
-
 __all__ = ["get_printoptions", "global_printing", "local_printing", "print0", "set_printoptions"]
 
 


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [ ] ~~benchmarks: created for new functionality~~ does not apply
    - [x] benchmarks: performance improved or maintained
    - [x] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

I noticed that printing out moderately large DNDarrays in non-distributed mode (i.e. interactive session or split=None) takes a disproportionate amount of time (see below) compared to printing the underlying tensor. Culprit is the [`Formatter` call](https://github.com/helmholtz-analytics/heat/blob/2fb161843255a145c166c33cbcf9e2065ae86b85/heat/core/printing.py#L310). 

I've changed the printing module to bypass `Formatter` if the input dndarray is not distributed. Torch takes care of the data formatting, tests pass.

Example: 

```
data =  ht.random.randn(91392, 52, 4)
print(data)
```

On 1 process: 
`main` branch: 84 seconds
this PR: 0.01 seconds





Issue/s resolved: #

## Changes proposed:

- let torch handle formatting of non-distributed data
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue)

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
NA
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->
see above

#### Does this change modify the behaviour of other functions? If so, which?
no
