### PR TITLE
heat operators eq ne now allow non array operands

### DIFF
--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -74,7 +74,9 @@ def eq(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> DNDarr
     return res
 
 
-DNDarray.__eq__ = lambda self, other: eq(self, other)
+DNDarray.__eq__ = lambda self, other: (
+    eq(self, other) if type(other) in (DNDarray, int, float) else False
+)
 DNDarray.__eq__.__doc__ = eq.__doc__
 
 
@@ -413,7 +415,9 @@ def ne(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> DNDarr
     return res
 
 
-DNDarray.__ne__ = lambda self, other: ne(self, other)
+DNDarray.__ne__ = lambda self, other: (
+    ne(self, other) if type(other) in (DNDarray, int, float) else True
+)
 DNDarray.__ne__.__doc__ = ne.__doc__
 
 # alias

--- a/heat/core/relational.py
+++ b/heat/core/relational.py
@@ -33,11 +33,12 @@ __all__ = [
 ]
 
 
-def eq(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> DNDarray:
+def eq(x, y) -> DNDarray:
     """
     Returns a :class:`~heat.core.dndarray.DNDarray` containing the results of element-wise comparision.
     Takes the first and second operand (scalar or :class:`~heat.core.dndarray.DNDarray`) whose elements are to be
     compared as argument.
+    Returns False if the operands are not scalars or :class:`~heat.core.dndarray.DNDarray`
 
     Parameters
     ----------
@@ -57,26 +58,29 @@ def eq(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> DNDarr
     >>> ht.eq(x, y)
     DNDarray([[False,  True],
               [False, False]], dtype=ht.bool, device=cpu:0, split=None)
+    >>> ht.eq(x, slice(None))
+    False
     """
-    res = _operations.__binary_op(torch.eq, x, y)
+    try:
+        res = _operations.__binary_op(torch.eq, x, y)
 
-    if res.dtype != types.bool:
-        res = dndarray.DNDarray(
-            res.larray.type(torch.bool),
-            res.gshape,
-            types.bool,
-            res.split,
-            res.device,
-            res.comm,
-            res.balanced,
-        )
+        if res.dtype != types.bool:
+            res = dndarray.DNDarray(
+                res.larray.type(torch.bool),
+                res.gshape,
+                types.bool,
+                res.split,
+                res.device,
+                res.comm,
+                res.balanced,
+            )
 
-    return res
+        return res
+    except (TypeError, ValueError):
+        return False
 
 
-DNDarray.__eq__ = lambda self, other: (
-    eq(self, other) if type(other) in (DNDarray, int, float) else False
-)
+DNDarray.__eq__ = lambda self, other: eq(self, other)
 DNDarray.__eq__.__doc__ = eq.__doc__
 
 
@@ -374,11 +378,12 @@ less = lt
 less.__doc__ = lt.__doc__
 
 
-def ne(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> DNDarray:
+def ne(x, y) -> DNDarray:
     """
     Returns a :class:`~heat.core.dndarray.DNDarray` containing the results of element-wise rich comparison of non-equality between values from two operands, commutative.
     Takes the first and second operand (scalar or :class:`~heat.core.dndarray.DNDarray`) whose elements are to be
     compared as argument.
+    Returns True if the operands are not scalars or :class:`~heat.core.dndarray.DNDarray`
 
     Parameters
     ----------
@@ -398,26 +403,29 @@ def ne(x: Union[DNDarray, float, int], y: Union[DNDarray, float, int]) -> DNDarr
     >>> ht.ne(x, y)
     DNDarray([[ True, False],
               [ True,  True]], dtype=ht.bool, device=cpu:0, split=None)
+    >>> ht.ne(x, slice(None))
+    True
     """
-    res = _operations.__binary_op(torch.ne, x, y)
+    try:
+        res = _operations.__binary_op(torch.ne, x, y)
 
-    if res.dtype != types.bool:
-        res = dndarray.DNDarray(
-            res.larray.type(torch.bool),
-            res.gshape,
-            types.bool,
-            res.split,
-            res.device,
-            res.comm,
-            res.balanced,
-        )
+        if res.dtype != types.bool:
+            res = dndarray.DNDarray(
+                res.larray.type(torch.bool),
+                res.gshape,
+                types.bool,
+                res.split,
+                res.device,
+                res.comm,
+                res.balanced,
+            )
 
-    return res
+        return res
+    except (TypeError, ValueError):
+        return True
 
 
-DNDarray.__ne__ = lambda self, other: (
-    ne(self, other) if type(other) in (DNDarray, int, float) else True
-)
+DNDarray.__ne__ = lambda self, other: ne(self, other)
 DNDarray.__ne__.__doc__ = ne.__doc__
 
 # alias

--- a/heat/core/tests/test_relational.py
+++ b/heat/core/tests/test_relational.py
@@ -32,12 +32,9 @@ class TestRelational(TestCase):
 
         self.assertEqual(ht.eq(self.a_split_tensor, self.a_tensor).dtype, ht.bool)
 
-        with self.assertRaises(ValueError):
-            ht.eq(self.a_tensor, self.another_vector)
-        with self.assertRaises(TypeError):
-            ht.eq(self.a_tensor, self.errorneous_type)
-        with self.assertRaises(TypeError):
-            ht.eq("self.a_tensor", "s")
+        self.assertFalse(ht.eq(self.a_tensor, self.another_vector))
+        self.assertFalse(ht.eq(self.a_tensor, self.errorneous_type))
+        self.assertFalse(ht.eq("self.a_tensor", "s"))
 
     def test_equal(self):
         self.assertTrue(ht.equal(self.a_tensor, self.a_tensor))
@@ -159,9 +156,6 @@ class TestRelational(TestCase):
 
         self.assertEqual(ht.ne(self.a_split_tensor, self.a_tensor).dtype, ht.bool)
 
-        with self.assertRaises(ValueError):
-            ht.ne(self.a_tensor, self.another_vector)
-        with self.assertRaises(TypeError):
-            ht.ne(self.a_tensor, self.errorneous_type)
-        with self.assertRaises(TypeError):
-            ht.ne("self.a_tensor", "s")
+        self.assertTrue(ht.ne(self.a_tensor, self.another_vector))
+        self.assertTrue(ht.ne(self.a_tensor, self.errorneous_type))
+        self.assertTrue(ht.ne("self.a_tensor", "s"))


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [x] benchmarks: created for new functionality
    - [x] benchmarks: performance improved or maintained
    - [x] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

The eq and ne operands were changed to allow the comparison between not supported Types without causing an error.
Instead eq now returns False and ne returns True, when before there would have been a TypeError or ValueError.

It was also necessary to change the relations test as it checked whether these errors occurred.

Issue/s resolved: #1292 

## Changes proposed:

- Using not supported Types with eq now returns False instead of an error
- Using not supported Types with ne now returns True instead of an error
- Small changes to the relations test (to check for True/False instead of the errors)

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

Bug fix

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no?
