### PR TITLE
Make unit tests compatible with NumPy 2.x

### DIFF
--- a/.github/workflows/ReceivePR.yml
+++ b/.github/workflows/ReceivePR.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          python-version: 3.9
+          python-version: 3.10
           architecture: x64
 
       - name: Setup MPI

--- a/.github/workflows/ReceivePR.yml
+++ b/.github/workflows/ReceivePR.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          python-version: 3.10
+          python-version: '3.10'
           architecture: x64
 
       - name: Setup MPI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         py-version:
-          - 3.9
           - '3.10'
           - 3.11
           - 3.12

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -62,14 +62,20 @@ class TestLinalgBasics(TestCase):
         b_2d = ht.array(np_b[:-1, :, :], split=1)
         cross_3d_2d = ht.cross(a, b_2d, axisa=1, axisb=0)
         np_cross_3d_2d = np.cross(
-            np_a, np.concatenate([np_b[:-1, :, :], np.zeros((1, 40, 50))], axis=0), axisa=1, axisb=0
+            np_a,
+            np.concatenate([np_b[:-1, :, :], np.zeros((1, 40, 50))], axis=0, dtype=np.float32),
+            axisa=1,
+            axisb=0,
         )
         self.assert_array_equal(cross_3d_2d, np_cross_3d_2d)
 
         a_2d = ht.array(np_a[:, :-1, :], split=0)
         cross_2d_3d = ht.cross(a_2d, b, axisa=1, axisb=0)
         np_cross_2d_3d = np.cross(
-            np.concatenate([np_a[:, :-1, :], np.zeros((40, 1, 50))], axis=1), np_b, axisa=1, axisb=0
+            np.concatenate([np_a[:, :-1, :], np.zeros((40, 1, 50))], axis=1, dtype=np.float32),
+            np_b,
+            axisa=1,
+            axisb=0,
         )
         self.assert_array_equal(cross_2d_3d, np_cross_2d_3d)
 

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -61,20 +61,23 @@ class TestLinalgBasics(TestCase):
         self.assert_array_equal(cross_axisc, np_cross_axisc)
 
         # test vector axes with 2 elements
-        if np.lib.NumpyVersion(np.__version__) < "2.0.0b1":
-            b_2d = ht.array(np_b[:-1, :, :], split=1)
-            cross_3d_2d = ht.cross(a, b_2d, axisa=1, axisb=0)
-            np_cross_3d_2d = np.cross(np_a, np_b[:-1, :, :], axisa=1, axisb=0)
-            self.assert_array_equal(cross_3d_2d, np_cross_3d_2d)
+        b_2d = ht.array(np_b[:-1, :, :], split=1)
+        cross_3d_2d = ht.cross(a, b_2d, axisa=1, axisb=0)
+        np_cross_3d_2d = np.cross(
+            np_a, np.concatenate([np_b[:-1, :, :], np.zeros((1, 40, 50))], axis=0), axisa=1, axisb=0
+        )
+        self.assert_array_equal(cross_3d_2d, np_cross_3d_2d)
 
-            a_2d = ht.array(np_a[:, :-1, :], split=0)
-            cross_2d_3d = ht.cross(a_2d, b, axisa=1, axisb=0)
-            np_cross_2d_3d = np.cross(np_a[:, :-1, :], np_b, axisa=1, axisb=0)
-            self.assert_array_equal(cross_2d_3d, np_cross_2d_3d)
+        a_2d = ht.array(np_a[:, :-1, :], split=0)
+        cross_2d_3d = ht.cross(a_2d, b, axisa=1, axisb=0)
+        np_cross_2d_3d = np.cross(
+            np.concatenate([np_a[:, :-1, :], np.zeros((40, 1, 50))], axis=1), np_b, axisa=1, axisb=0
+        )
+        self.assert_array_equal(cross_2d_3d, np_cross_2d_3d)
 
-            cross_z_comp = ht.cross(a_2d, b_2d, axisa=1, axisb=0)
-            np_cross_z_comp = np.cross(np_a[:, :-1, :], np_b[:-1, :, :], axisa=1, axisb=0)
-            self.assert_array_equal(cross_z_comp, np_cross_z_comp)
+        cross_z_comp = ht.cross(a_2d, b_2d, axisa=1, axisb=0)
+        np_cross_z_comp = np.cross(np_a[:, :-1, :], np_b[:-1, :, :], axisa=1, axisb=0)
+        self.assert_array_equal(cross_z_comp, np_cross_z_comp)
 
         a_wrong_split = ht.array(np_a[:, :-1, :], split=2)
         with self.assertRaises(ValueError):

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -76,7 +76,7 @@ class TestLinalgBasics(TestCase):
         self.assert_array_equal(cross_2d_3d, np_cross_2d_3d)
 
         cross_z_comp = ht.cross(a_2d, b_2d, axisa=1, axisb=0)
-        np_cross_z_comp = np.cross(np_a[:, :-1, :], np_b[:-1, :, :], axisa=1, axisb=0)
+        np_cross_z_comp = np_a[:, 0, ...] * np_b[1, ...] - np_a[:, 1, ...] * np_b[0, ...]
         self.assert_array_equal(cross_z_comp, np_cross_z_comp)
 
         a_wrong_split = ht.array(np_a[:, :-1, :], split=2)

--- a/heat/core/linalg/tests/test_basics.py
+++ b/heat/core/linalg/tests/test_basics.py
@@ -61,19 +61,20 @@ class TestLinalgBasics(TestCase):
         self.assert_array_equal(cross_axisc, np_cross_axisc)
 
         # test vector axes with 2 elements
-        b_2d = ht.array(np_b[:-1, :, :], split=1)
-        cross_3d_2d = ht.cross(a, b_2d, axisa=1, axisb=0)
-        np_cross_3d_2d = np.cross(np_a, np_b[:-1, :, :], axisa=1, axisb=0)
-        self.assert_array_equal(cross_3d_2d, np_cross_3d_2d)
+        if np.lib.NumpyVersion(np.__version__) < "2.0.0b1":
+            b_2d = ht.array(np_b[:-1, :, :], split=1)
+            cross_3d_2d = ht.cross(a, b_2d, axisa=1, axisb=0)
+            np_cross_3d_2d = np.cross(np_a, np_b[:-1, :, :], axisa=1, axisb=0)
+            self.assert_array_equal(cross_3d_2d, np_cross_3d_2d)
 
-        a_2d = ht.array(np_a[:, :-1, :], split=0)
-        cross_2d_3d = ht.cross(a_2d, b, axisa=1, axisb=0)
-        np_cross_2d_3d = np.cross(np_a[:, :-1, :], np_b, axisa=1, axisb=0)
-        self.assert_array_equal(cross_2d_3d, np_cross_2d_3d)
+            a_2d = ht.array(np_a[:, :-1, :], split=0)
+            cross_2d_3d = ht.cross(a_2d, b, axisa=1, axisb=0)
+            np_cross_2d_3d = np.cross(np_a[:, :-1, :], np_b, axisa=1, axisb=0)
+            self.assert_array_equal(cross_2d_3d, np_cross_2d_3d)
 
-        cross_z_comp = ht.cross(a_2d, b_2d, axisa=1, axisb=0)
-        np_cross_z_comp = np.cross(np_a[:, :-1, :], np_b[:-1, :, :], axisa=1, axisb=0)
-        self.assert_array_equal(cross_z_comp, np_cross_z_comp)
+            cross_z_comp = ht.cross(a_2d, b_2d, axisa=1, axisb=0)
+            np_cross_z_comp = np.cross(np_a[:, :-1, :], np_b[:-1, :, :], axisa=1, axisb=0)
+            self.assert_array_equal(cross_z_comp, np_cross_z_comp)
 
         a_wrong_split = ht.array(np_a[:, :-1, :], split=2)
         with self.assertRaises(ValueError):

--- a/heat/core/tests/test_exponential.py
+++ b/heat/core/tests/test_exponential.py
@@ -96,7 +96,8 @@ class TestExponential(TestCase):
 
     def test_exp2(self):
         elements = 10
-        tmp = np.exp2(torch.arange(elements, dtype=torch.float64))
+        tmp = np.exp2(torch.arange(elements, dtype=torch.float64).numpy())
+        tmp = torch.tensor(tmp)
         tmp = tmp.to(self.device.torch_device)
         comparison = ht.array(tmp, device=self.device)
 

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -2687,7 +2687,7 @@ class TestManipulations(TestCase):
         # test local row_stack, 2-D arrays
         a = np.arange(10, dtype=np.float32).reshape(2, 5)
         b = np.arange(15, dtype=np.float32).reshape(3, 5)
-        if np.version.version >= "2.0.0":
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
             np_rstack = np.vstack((a, b))
         else:
             np_rstack = np.row_stack((a, b))
@@ -2698,7 +2698,7 @@ class TestManipulations(TestCase):
 
         # 2-D and 1-D arrays
         c = np.arange(5, dtype=np.float32)
-        if np.version.version >= "2.0.0":
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
             np_rstack = np.vstack((a, b, c))
         else:
             np_rstack = np.row_stack((a, b, c))
@@ -2708,7 +2708,7 @@ class TestManipulations(TestCase):
 
         # 2-D and 1-D arrays, distributed
         c = np.arange(5, dtype=np.float32)
-        if np.version.version >= "2.0.0":
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
             np_rstack = np.vstack((a, b, c))
         else:
             np_rstack = np.row_stack((a, b, c))
@@ -2722,7 +2722,7 @@ class TestManipulations(TestCase):
         # 1-D arrays, distributed, different dtypes
         d = np.arange(10).astype(np.float32)
         e = np.arange(10)
-        if np.version.version >= "2.0.0":
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
             np_rstack = np.vstack((d, e))
         else:
             np_rstack = np.row_stack((d, e))

--- a/heat/core/tests/test_manipulations.py
+++ b/heat/core/tests/test_manipulations.py
@@ -2687,7 +2687,10 @@ class TestManipulations(TestCase):
         # test local row_stack, 2-D arrays
         a = np.arange(10, dtype=np.float32).reshape(2, 5)
         b = np.arange(15, dtype=np.float32).reshape(3, 5)
-        np_rstack = np.row_stack((a, b))
+        if np.version.version >= "2.0.0":
+            np_rstack = np.vstack((a, b))
+        else:
+            np_rstack = np.row_stack((a, b))
         ht_a = ht.array(a)
         ht_b = ht.array(b)
         ht_rstack = ht.row_stack((ht_a, ht_b))
@@ -2695,14 +2698,20 @@ class TestManipulations(TestCase):
 
         # 2-D and 1-D arrays
         c = np.arange(5, dtype=np.float32)
-        np_rstack = np.row_stack((a, b, c))
+        if np.version.version >= "2.0.0":
+            np_rstack = np.vstack((a, b, c))
+        else:
+            np_rstack = np.row_stack((a, b, c))
         ht_c = ht.array(c)
         ht_rstack = ht.row_stack((ht_a, ht_b, ht_c))
         self.assertTrue((np_rstack == ht_rstack.numpy()).all())
 
         # 2-D and 1-D arrays, distributed
         c = np.arange(5, dtype=np.float32)
-        np_rstack = np.row_stack((a, b, c))
+        if np.version.version >= "2.0.0":
+            np_rstack = np.vstack((a, b, c))
+        else:
+            np_rstack = np.row_stack((a, b, c))
         ht_a = ht.array(a, split=0)
         ht_b = ht.array(b, split=0)
         ht_c = ht.array(c, split=0)
@@ -2713,7 +2722,10 @@ class TestManipulations(TestCase):
         # 1-D arrays, distributed, different dtypes
         d = np.arange(10).astype(np.float32)
         e = np.arange(10)
-        np_rstack = np.row_stack((d, e))
+        if np.version.version >= "2.0.0":
+            np_rstack = np.vstack((d, e))
+        else:
+            np_rstack = np.row_stack((d, e))
         ht_d = ht.array(d, split=0)
         ht_e = ht.array(e, split=0)
         ht_rstack = ht.row_stack((ht_d, ht_e))

--- a/heat/fft/tests/test_fft.py
+++ b/heat/fft/tests/test_fft.py
@@ -123,7 +123,7 @@ class TestFFT(TestCase):
         x = ht.random.randn(10, 8, 6, dtype=ht.float64, split=0)
         # FFT along last 2 axes
         y = ht.fft.fftn(x, s=(6, 6))
-        np_y = np.fft.fftn(x.numpy(), s=(6, 6))
+        np_y = np.fft.fftn(x.numpy(), s=(6, 6), axes=(1, 2))
         self.assertIsInstance(y, ht.DNDarray)
         self.assertEqual(y.shape, np_y.shape)
         self.assertTrue(y.split == 0)

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,9 @@ setup(
     author_email="martin.siggel@dlr.de",
     url="https://github.com/helmholtz-analytics/heat",
     keywords=["data", "analytics", "tensors", "distributed", "gpu"],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -34,9 +33,9 @@ setup(
     ],
     install_requires=[
         "mpi4py>=3.0.0",
-        "numpy>=1.22.0",
+        "numpy>=1.23.5",
         "torch>=2.0.0, <2.6.1",
-        "scipy>=1.10.0",
+        "scipy>=1.14.0",
         "pillow>=6.0.0",
         "torchvision>=0.15.2, <0.21.1",
     ],

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     install_requires=[
         "mpi4py>=3.0.0",
-        "numpy>=1.22.0, <2",
+        "numpy>=1.22.0",
         "torch>=2.0.0, <2.6.1",
         "scipy>=1.10.0",
         "pillow>=6.0.0",


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [ ] benchmarks: created for new functionality
    - [x] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Fixed DeprecationWarnings from numpy 2.x
- [x] row_stack to vstack
- [x] passing axes to np.fft.fftn when s is not None
- [ ] `__array__` implementation doesn't accept a copy keyword (probably related to `Tensor.__array__`) --> torch issue
- [ ] `__array_wrap__` must accept context and return_scalar arguments --> torch issue
- [x] Arrays of 2-dimensional vectors are deprecated (`np.cross()`)

Issue/s resolved: #1552 

## Changes proposed:

- unittests use vstack instead of row_stack if the numpy version is >= 2.0.0
- unittests now pass axes to np.fft.fftn when s is not None
- changed setup.py to allow numpy versions >= 2.0.0
- changed requirements (python 3.10, numpy 1.23.5, scipy 1.14.0)
- changed workflows to use python 3.10

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
