### PR TITLE
Remove unnecessary contiguous calls

### DIFF
--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -425,7 +425,7 @@ def array(
     elif split is not None:
         # only keep local slice
         _, _, slices = comm.chunk(gshape, split)
-        _ = obj[slices].contiguous()
+        _ = obj[slices]
         del obj
 
         obj = sanitize_memory_layout(_, order=order)

--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -192,7 +192,6 @@ def qr(
         current_comm = A.comm
         local_comm = current_comm.Split(current_comm.rank // procs_to_merge, A.comm.rank)
         Q_loc, R_loc = torch.linalg.qr(A.larray, mode=mode)
-        R_loc = R_loc.contiguous()  # required for all the communication ops lateron
         if mode == "reduced":
             leave_comm = current_comm.Split(current_comm.rank, A.comm.rank)
 
@@ -221,12 +220,9 @@ def qr(
                 if local_comm.rank == 0:
                     previous_shape = R_loc.shape
                     Q_buf, R_loc = torch.linalg.qr(gathered_R_loc, mode=mode)
-                    R_loc = R_loc.contiguous()
                 else:
                     Q_buf = torch.empty(0, device=R_loc.device, dtype=R_loc.dtype)
                 if mode == "reduced":
-                    if local_comm.rank == 0:
-                        Q_buf = Q_buf.contiguous()
                     scattered_Q_buf = torch.empty(
                         R_loc.shape if local_comm.rank != 0 else previous_shape,
                         device=R_loc.device,

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -850,13 +850,11 @@ def diagonal(a: DNDarray, offset: int = 0, dim1: int = 0, dim2: int = 1) -> DNDa
         split = len(shape) - 1
 
     if a.split is None or a.split not in (dim1, dim2):
-        result = torch.diagonal(a.larray, offset=offset, dim1=dim1, dim2=dim2).contiguous()
+        result = torch.diagonal(a.larray, offset=offset, dim1=dim1, dim2=dim2)
     else:
         vz = 1 if a.split == dim1 else -1
         off, _, _ = a.comm.chunk(a.shape, a.split)
-        result = torch.diagonal(
-            a.larray, offset=offset + vz * off, dim1=dim1, dim2=dim2
-        ).contiguous()
+        result = torch.diagonal(a.larray, offset=offset + vz * off, dim1=dim1, dim2=dim2)
     return factories.array(result, dtype=a.dtype, is_split=split, device=a.device, comm=a.comm)
 
 
@@ -2144,7 +2142,7 @@ def reshape(a: DNDarray, *shape: Union[int, Tuple[int, ...]], **kwargs) -> DNDar
             # keep local slice only
             _, _, local_slice = a.comm.chunk(shape, new_split)
             _ = local_a.reshape(shape)
-            local_a = _[local_slice].contiguous()
+            local_a = _[local_slice]
             del _
         else:
             local_a = local_a.reshape(shape)


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Removed unnecessary contiguous calls

Issue/s resolved: #1786 

## Changes proposed:

- removed contiguous calls from:
  - core/factories.py
  - core/manipulations.py
  - core/linalg/qr.py

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

Bug fix (non-breaking change which fixes an issue)

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no
