### PR TITLE
Skip large-count communication tests on AMD runner

### DIFF
--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -2522,8 +2522,8 @@ class TestCommunication(TestCase):
 
     # the following test is only for up to three processes to save memory
     @unittest.skipIf(
-        ht.MPI_WORLD.size > 3 or "rocm" in torch.__version__,
-        "Only for up to three processes and not on the AMD runner",
+        ht.MPI_WORLD.size == 1 or ht.MPI_WORLD.size > 3 or "rocm" in torch.__version__,
+        "Only for two or three processes and not on the AMD runner",
     )
     def test_largecount_workaround_Allreduce(self):
         shape = (2**10, 2**11, 2**10)

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -2496,8 +2496,8 @@ class TestCommunication(TestCase):
 
     # The following test is only for the bool data type to save memory
     @unittest.skipIf(
-        ht.MPI_WORLD.size > 2 and "rocm" in torch.__version__,
-        "On the AMD runner only up to 3 processes",
+        ht.MPI_WORLD.size == 1 or (ht.MPI_WORLD.size > 2 and "rocm" in torch.__version__),
+        "Only for more than one process and on the AMD runner only up to 3 processes",
     )
     def test_largecount_workaround_IsendRecv(self):
         shape = (2**15, 2**16)

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -2496,8 +2496,8 @@ class TestCommunication(TestCase):
 
     # The following test is only for the bool data type to save memory
     @unittest.skipIf(
-        ht.MPI_WORLD.size == 1 or "rocm" in torch.__version__,
-        "Only for more than one process and not on the AMD runner",
+        ht.MPI_WORLD.size == 1 or ht.MPI_WORLD.size > 3 or "rocm" in torch.__version__,
+        "Only for two or three processes and not on the AMD runner",
     )
     def test_largecount_workaround_IsendRecv(self):
         shape = (2**15, 2**16)

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -2496,7 +2496,7 @@ class TestCommunication(TestCase):
 
     # The following test is only for the bool data type to save memory
     @unittest.skipIf(
-        ht.MPI_WORLD.size == 1 or ht.MPI_WORLD.size > 3 or "rocm" in torch.__version__,
+        ht.MPI_WORLD.size == 1 or ht.MPI_WORLD.size > 2 or "rocm" in torch.__version__,
         "Only for two or three processes and not on the AMD runner",
     )
     def test_largecount_workaround_IsendRecv(self):
@@ -2522,7 +2522,7 @@ class TestCommunication(TestCase):
 
     # the following test is only for up to three processes to save memory
     @unittest.skipIf(
-        ht.MPI_WORLD.size == 1 or ht.MPI_WORLD.size > 3 or "rocm" in torch.__version__,
+        ht.MPI_WORLD.size == 1 or ht.MPI_WORLD.size > 2 or "rocm" in torch.__version__,
         "Only for two or three processes and not on the AMD runner",
     )
     def test_largecount_workaround_Allreduce(self):

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -2496,8 +2496,8 @@ class TestCommunication(TestCase):
 
     # The following test is only for the bool data type to save memory
     @unittest.skipIf(
-        ht.MPI_WORLD.size == 1 or (ht.MPI_WORLD.size > 2 and "rocm" in torch.__version__),
-        "Only for more than one process and on the AMD runner only up to 3 processes",
+        ht.MPI_WORLD.size == 1 or "rocm" in torch.__version__,
+        "Only for more than one process and not on the AMD runner",
     )
     def test_largecount_workaround_IsendRecv(self):
         shape = (2**15, 2**16)

--- a/heat/core/tests/test_communication.py
+++ b/heat/core/tests/test_communication.py
@@ -2495,7 +2495,10 @@ class TestCommunication(TestCase):
             test4.comm.Alltoallv(test4.larray, redistributed4, send_axis=None)
 
     # The following test is only for the bool data type to save memory
-    # memory requirement: ~16MB * number of processes
+    @unittest.skipIf(
+        ht.MPI_WORLD.size > 2 and "rocm" in torch.__version__,
+        "On the AMD runner only up to 3 processes",
+    )
     def test_largecount_workaround_IsendRecv(self):
         shape = (2**15, 2**16)
         data = (
@@ -2517,9 +2520,11 @@ class TestCommunication(TestCase):
             else not buf.all()
         )
 
-    # the following test is only for two processes to save memory
-    # memory requirement: ~16MB * number of processes
-    @unittest.skipIf(ht.MPI_WORLD.size != 2, "Only for two processes")
+    # the following test is only for up to three processes to save memory
+    @unittest.skipIf(
+        ht.MPI_WORLD.size > 3 or "rocm" in torch.__version__,
+        "Only for up to three processes and not on the AMD runner",
+    )
     def test_largecount_workaround_Allreduce(self):
         shape = (2**10, 2**11, 2**10)
         data = (


### PR DESCRIPTION
So far, the only test of large count MPI actually run on the AMD runner was the test for Isend-Recv on CPU on 4 processes. For whatever reason this often failed. I have run the tests for the communications module (incl. the large scale tests) both on CPU and GPU (2x Nvidia) on our workstation for 2 to 8 processes. No error occurred; thus it is very likely a problem related to the AMD-runner which motivated skipping these tests on the AMD runners.

New version is to run large count Isend-Recv and Allreduce only on the CUDA-runner but on 2 and 3 (both GPU) processes.