### PR TITLE
Update test_dmd.py

### DIFF
--- a/heat/decomposition/tests/test_dmd.py
+++ b/heat/decomposition/tests/test_dmd.py
@@ -478,7 +478,7 @@ class TestDMDc(TestCase):
             - dmd.rom_transfer_matrix_ @ X_red[:, :-1]
             - dmd.rom_control_matrix_ @ C[:, :-1]
         )
-        self.assertTrue(ht.max(ht.abs(X_res)) < 1e-12)
+        self.assertTrue(ht.max(ht.abs(X_res)) < 1e-10)
 
         # check predict
         Y = dmd.predict(X[:, 0], C[:, :10]).squeeze()
@@ -490,8 +490,8 @@ class TestDMDc(TestCase):
             - dmd.rom_transfer_matrix_ @ Y_red[:, :-1]
             - dmd.rom_control_matrix_ @ C[:, :-1]
         )
-        self.assertTrue(ht.max(ht.abs(Y_res)) < 1e-12)
-        self.assertTrue(ht.allclose(Y[:, :], X[:, :10], atol=1e-12, rtol=1e-12))
+        self.assertTrue(ht.max(ht.abs(Y_res)) < 1e-10)
+        self.assertTrue(ht.allclose(Y[:, :], X[:, :10], atol=1e-10, rtol=1e-10))
 
     def test_dmdc_correctness_split1(self):
         # check correctness on behalf of a constructed example with known solution,


### PR DESCRIPTION
lower tolerances for the AMD-runner

## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #

## Changes proposed:

-
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
