### PR TITLE
Expand np funcs to heat

### DIFF
--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -482,6 +482,34 @@ class DNDarray:
         """
         return self.larray.cpu().__array__()
 
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """
+        Override NumPy's universal functions.
+        """
+        import heat
+
+        # TODO support ufunc method variants
+        if method == "__call__":
+            try:
+                func = getattr(heat, ufunc.__name__)
+            except AttributeError:
+                return NotImplemented
+            return func(*inputs, **kwargs)
+        else:
+            return NotImplemented
+
+    def __array_function__(self, func, types, args, kwargs):
+        """
+        Augments NumPy's functions.
+        """
+        import heat
+
+        try:
+            ht_func = getattr(heat, func.__name__)
+        except AttributeError:
+            return NotImplemented
+        return ht_func(*args, **kwargs)
+
     def astype(self, dtype, copy=True) -> DNDarray:
         """
         Returns a casted version of this array.

--- a/heat/core/linalg/polar.py
+++ b/heat/core/linalg/polar.py
@@ -48,7 +48,7 @@ def _zolopd_n_iterations(r: int, kappa: float) -> int:
 
 def _compute_zolotarev_coefficients(
     r: int, ell: float, device: str, dtype: types.datatype = types.float64
-) -> Tuple[DNDarray, DNDarray, types.datatype]:
+) -> Tuple[DNDarray, DNDarray, DNDarray]:
     """
     Computes c=(c_i)_i defined in equation (3.4), as well as a=(a_j)_j and Mhat defined in formulas (4.2)/(4.3) of the paper Nakatsukasa, Y., & Freund, R. W. (2016). Computing the polar decomposition with applications. SIAM Review, 58(3), DOI: https://doi.org/10.1137/140990334.
     Evaluations of the respective complete elliptic integral of the first kind and the Jacobi elliptic functions are imported from SciPy.
@@ -317,8 +317,8 @@ def polar(
             ellold = ell
             ell = 1
             for j in range(r):
-                ell *= (ellold**2 + c[2 * j + 1]) / (ellold**2 + c[2 * j])
-            ell *= Mhat * ellold
+                ell *= (ellold**2 + c[2 * j + 1].item()) / (ellold**2 + c[2 * j].item())
+            ell *= Mhat.item() * ellold
             c, a, Mhat = _compute_zolotarev_coefficients(r, ell, A.device, dtype=A.dtype)
         else:
             if not silent:

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -258,6 +258,25 @@ class TestDNDarray(TestCase):
         self.assertEqual(x.__array__().dtype, x_np.dtype)
         self.assertEqual(x.__array__().shape, x.lshape)
 
+    def test_array_ufunc(self):
+        arr = ht.array([1, 2, 3, 4])
+        self.assertIsInstance(np.multiply(arr, 3), ht.DNDarray)
+        self.assertIsInstance(np.add(arr, 3), ht.DNDarray)
+        self.assertIsInstance(np.sin(arr), ht.DNDarray)
+
+        with self.assertRaises(TypeError):
+            np.multiply.reduce(arr)
+        with self.assertRaises(TypeError):
+            np.heaviside(a, 5)
+
+    def test_array_function(self):
+        arr = ht.array([1, 2, 3, 4])
+        self.assertIsInstance(np.concatenate([arr, arr]), ht.DNDarray)
+        self.assertIsInstance(np.sum(arr, axis=0), ht.DNDarray)
+
+        with self.assertRaises(TypeError):
+            np.array_equiv(a, a)
+
     def test_larray(self):
         # undistributed case
         x = ht.arange(6 * 7 * 8).reshape((6, 7, 8))

--- a/heat/core/tests/test_dndarray.py
+++ b/heat/core/tests/test_dndarray.py
@@ -267,7 +267,7 @@ class TestDNDarray(TestCase):
         with self.assertRaises(TypeError):
             np.multiply.reduce(arr)
         with self.assertRaises(TypeError):
-            np.heaviside(a, 5)
+            np.heaviside(arr, 5)
 
     def test_array_function(self):
         arr = ht.array([1, 2, 3, 4])
@@ -275,7 +275,7 @@ class TestDNDarray(TestCase):
         self.assertIsInstance(np.sum(arr, axis=0), ht.DNDarray)
 
         with self.assertRaises(TypeError):
-            np.array_equiv(a, a)
+            np.array_equiv(arr, arr)
 
     def test_larray(self):
         # undistributed case


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Add special methods for NumPy that allows to divert the execution of functions when used on heat arrays.

Issue/s resolved: #1887 

## Changes proposed:

- add `__array_ufunc__` method
- add `__array_function__` method

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no
