### PR TITLE
Bugs/1892  Bug-fix in QR 

### DIFF
--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -277,6 +277,7 @@ def qr(
                     if local_comm.rank == 0:
                         previous_shape = R_loc.shape
                         Q_buf, R_loc = single_proc_qr(gathered_R_loc, mode=mode)
+                        R_loc = R_loc.contiguous()
                     else:
                         Q_buf = torch.empty(0, device=R_loc.device, dtype=R_loc.dtype)
                     if mode == "reduced":

--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -165,7 +165,7 @@ def qr(
                 # orthogonalize the current block of columns by utilizing PyTorch QR
                 Q_curr, R_loc = single_proc_qr(A_columns, mode="reduced")
                 if i < nprocs - 1:
-                    Q_buf = Q_curr
+                    Q_buf = Q_curr.contiguous()
                 if mode == "reduced":
                     Q.larray = Q_curr
                 r_size = R.larray[..., R_shapes[i] : R_shapes[i + 1], :].shape[-2]
@@ -249,6 +249,7 @@ def qr(
             current_comm = A.comm
             local_comm = current_comm.Split(current_comm.rank // procs_to_merge, A.comm.rank)
             Q_loc, R_loc = single_proc_qr(A.larray, mode=mode)
+            R_loc = R_loc.contiguous()
             if mode == "reduced":
                 leave_comm = current_comm.Split(current_comm.rank, A.comm.rank)
 
@@ -281,6 +282,8 @@ def qr(
                     else:
                         Q_buf = torch.empty(0, device=R_loc.device, dtype=R_loc.dtype)
                     if mode == "reduced":
+                        if local_comm.rank == 0:
+                            Q_buf = Q_buf.contiguous()
                         scattered_Q_buf = torch.empty(
                             R_loc.shape if local_comm.rank != 0 else previous_shape,
                             device=R_loc.device,


### PR DESCRIPTION
## Due Diligence

Some of the unnecessary contiguous calls in QR were actually necessary, at least on the terrabyte cluster. 

- General:
    - [X]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [X] unit tests: all split configurations tested
    - [X] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - ~~[ ] benchmarks: created for new functionality~~
    - ~~[ ] benchmarks: performance improved or maintained~~
    - ~~[ ] documentation updated where needed~~


