### PR TITLE
feat: add ptp function to statistics module (#1897)

### DIFF
--- a/heat/core/statistics.py
+++ b/heat/core/statistics.py
@@ -40,6 +40,7 @@ __all__ = [
     "min",
     "minimum",
     "percentile",
+    "ptp",
     "skew",
     "std",
     "var",
@@ -1737,6 +1738,58 @@ def percentile(
         del sorted_x
 
     return percentile
+
+
+def ptp(
+    x: DNDarray,
+    axis: Optional[Union[int, Tuple[int, ...]]] = None,
+    out: Optional[DNDarray] = None,
+    keepdims: bool = False,
+) -> DNDarray:
+    """
+    Range of values (maximum - minimum) along a given axis.
+
+    Parameters
+    ----------
+    x : ht.DNDarray
+        Input array.
+    axis : None or int or Tuple[int,...], optional
+        Axis or axes along which to operate. By default, flattened input is used.
+        If this is a tuple of ints, the ptp is selected over multiple axes,
+        instead of a single axis or all the axes as before.
+    out : DNDarray, optional
+        Output array to place the result.
+    keepdims : bool, optional
+        If this is set to ``True``, the axes which are reduced are left in the result as dimensions with size one.
+
+    Returns
+    -------
+    ptp : ht.DNDarray
+        An array with the same shape as `x`, with the specified axis removed. If `keepdims` is True, the reduced axes are left in the result as dimensions with size one.
+
+    Examples
+    --------
+    >>> a = ht.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], dtype=ht.float32)
+    >>> ht.ptp(a)
+    DNDarray([11.], dtype=ht.float32, device=cpu:0, split=None)
+    >>> ht.ptp(a, axis=0)
+    DNDarray([9., 9., 9.], dtype=ht.float32, device=cpu:0, split=None)
+    >>> ht.ptp(a, axis=1)
+    DNDarray([2., 2., 2., 2.], dtype=ht.float32, device=cpu:0, split=None)
+    """
+    xmax = max(x, axis=axis, keepdims=keepdims)
+    xmin = min(x, axis=axis, keepdims=keepdims)
+
+    if out is not None:
+        arithmetics.subtract(xmax, xmin, out=out)
+        return out
+    return arithmetics.subtract(xmax, xmin)
+
+
+DNDarray.ptp: Callable[[DNDarray, Union[int, Tuple[int, ...]], DNDarray, bool], DNDarray] = (
+    lambda x, axis=None, out=None, keepdims=False: ptp(x, axis, out, keepdims)
+)
+DNDarray.ptp.__doc__ = ptp.__doc__
 
 
 def skew(x: DNDarray, axis: int = None, unbiased: bool = True) -> DNDarray:

--- a/heat/core/tests/test_statistics.py
+++ b/heat/core/tests/test_statistics.py
@@ -1327,6 +1327,75 @@ class TestStatistics(TestCase):
         with self.assertRaises(ValueError):
             ht.percentile(X, q, axis=axis, sketched=True, sketch_size=10)
 
+    def test_ptp(self):
+        # argument errors
+        x = ht.zeros((2, 3, 4))
+        with self.assertRaises((ValueError, IndexError)):
+            ht.ptp(x, axis=10)
+        with self.assertRaises(TypeError):
+            ht.ptp(x, axis="01")
+        with self.assertRaises(TypeError):
+            ht.ptp(x, axis=(0, "10"))
+
+        # simple deterministic example
+        a = ht.array([[1, 2, 3],
+                      [4, 5, 6],
+                      [7, 8, 9],
+                      [10, 11, 12]])
+        self.assertEqual(ht.ptp(a), 11)
+        self.assertEqual(a.ptp(), 11)
+
+        # helper to check split of result
+        def __split_calc(ht_split, axis):
+            sp = ht_split if axis > ht_split else ht_split - 1
+            if axis == ht_split:
+                sp = None
+            return sp
+
+        # 1D: comparison with NumPy and invariance to split
+        v = ht.random.rand(50)
+        v_np = v.copy().numpy()
+        self.assertAlmostEqual(ht.ptp(v), np.ptp(v_np), places=5)
+
+        v = ht.resplit(v, 0)
+        self.assertAlmostEqual(ht.ptp(v), np.ptp(v_np), places=5)
+
+        # 2D float (take into account mps as in other tests)
+        dtype = ht.float32 if self.is_mps else ht.float64
+        X = ht.random.rand(50, 30, dtype=dtype)
+        X_np = X.copy().numpy()
+
+        # without axis
+        self.assertAlmostEqual(ht.ptp(X) - np.ptp(X_np), 0.0, places=5)
+
+        # along axes and for different splits
+        for split in (0, 1):
+            Xs = ht.resplit(X, split)
+            for ax in (0, 1):
+                expected = ht.array(np.ptp(X_np, axis=ax), dtype=Xs.dtype)
+                got = ht.ptp(Xs, axis=ax)
+                self.assertTrue(ht.allclose(got, expected, atol=1e-5))
+                self.assertEqual(got.split, __split_calc(Xs.split, ax))
+
+        # keepdims: only shape is checked (different splits are not important)
+        kd0 = ht.ptp(X, axis=0, keepdims=True)
+        kd1 = ht.ptp(X, axis=1, keepdims=True)
+        self.assertEqual(kd0.shape, (1, 30))
+        self.assertEqual(kd1.shape, (50, 1))
+
+        # out buffer: correct shape, return the same object, values match
+        Xs = ht.resplit(X, 0)
+        out = ht.empty((30,), dtype=Xs.dtype, split=None)
+        res = ht.ptp(Xs, axis=0, out=out)
+        self.assertIs(res, out)
+        self.assertTrue(ht.allclose(out, ht.ptp(Xs, axis=0)))
+
+        # integer input: correct value and dtype retention
+        b = ht.arange(-3, 5, dtype=ht.int64) # range [-3..4]
+        r = ht.ptp(b)
+        self.assertEqual(r, 7) # 4 - (-3) = 7
+        self.assertEqual(r.dtype, b.dtype)
+
     def test_skew(self):
         x = ht.zeros((2, 3, 4))
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Due Diligence
- General:
    - [x] **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [ ] unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [x] documentation updated where needed

## Description

Implemented `ht.ptp`, the peak-to-peak function, consistent with `numpy.ptp`.
Supports `axis`, `out`, and `keepdims` arguments.

Closes #1897

Issue/s resolved: #1897

## Changes proposed:
- Added `ptp` function to `heat/core/statistics.py`
- Added `DNDarray.ptp` method binding
- Added unit tests for `ptp` in `heat/core/tests/test_statistics.py`
- Updated docstrings and examples

## Type of change
- New feature (non-breaking change which adds functionality)

## Memory requirements
No additional memory requirements compared to equivalent `ht.max` and `ht.min`.

## Performance
Performance is expected to be similar to running `ht.max` and `ht.min` separately.  
Future optimization may reduce collective communications to a single pass.

#### Does this change modify the behaviour of other functions? 
No.