### PR TITLE
Remove updating dependency versions when installing heat in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,6 @@ jobs:
       - name: Test
         run: |
           pip install pytest
-          pip install ${{ matrix.pytorch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install ${{ matrix.install-options }}
+          pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
           mpirun -n 3 pytest heat/
           mpirun -n 4 pytest heat/


### PR DESCRIPTION



## Description

As discussed in #2097, installing heat like
```
pip install numpy=1.26.0
pip install .
```
can lead to a newer version of the dependency being installed while installing heat, which is not what we want in the CI.
Instead, merging the two commands to 
```
pip install numpy=1.26.0 .
```
leads to pip respecting all the listed constraints in the installation and does not install a newer version of the dependencies.

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #2097 

## Changes proposed:

- Merge installation of dependencies with specific version and heat in CI


## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
Bug fix