### PR TITLE
Added support for complex values in QR

### DIFF
--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -10,7 +10,6 @@ from ..dndarray import DNDarray
 from ..manipulations import concatenate
 from .. import factories
 from .. import communication
-from ..types import issubdtype, floating, complex
 
 __all__ = ["qr"]
 
@@ -93,10 +92,6 @@ def qr(
         )
     if procs_to_merge == 0:
         procs_to_merge = A.comm.size
-    if not issubdtype(A.dtype, floating) and not issubdtype(A.dtype, complex):
-        raise TypeError(
-            f"QR decomposition is only implemented for floating point or complex numbers, not {A.dtype}"
-        )
 
     QR = collections.namedtuple("QR", "Q, R")
 
@@ -107,7 +102,13 @@ def qr(
 
     if not A.is_distributed() or A.split < A.ndim - 2:
         # handle the case of a single process or split=None: just PyTorch QR
-        Q, R = single_proc_qr(A.larray, mode=mode)
+        try:
+            Q, R = single_proc_qr(A.larray, mode=mode)
+        except NotImplementedError as E:
+            raise NotImplementedError(
+                f"`heat.linalg.qr` relies on `torch.linalg.qr`, which is not implemented for dtype {A.dtype}"
+            ) from E
+
         R = factories.array(R, is_split=A.split, device=A.device)
         if mode == "reduced":
             Q = factories.array(Q, is_split=A.split, device=A.device)

--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -10,6 +10,7 @@ from ..dndarray import DNDarray
 from ..manipulations import concatenate
 from .. import factories
 from .. import communication
+from ..types import float32, float64, complex64, complex128
 
 __all__ = ["qr"]
 
@@ -93,6 +94,17 @@ def qr(
     if procs_to_merge == 0:
         procs_to_merge = A.comm.size
 
+    if A.dtype not in [float32, float64, complex64, complex128]:
+        try:
+            torch.linalg.qr(A.larray)
+        except (NotImplementedError, RuntimeError) as E:
+            raise TypeError(
+                f"Array 'A' must have datatype of float32, float64, complex64, or complex128, but has {A.dtype}"
+            ) from E
+        raise NotImplementedError(
+            f"`heat.linalg.qr` is not implemented for dtype {A.dtype}, but is supported by torch. Please open an issue on GitHub to get this implemented"
+        )
+
     QR = collections.namedtuple("QR", "Q, R")
 
     if A.ndim == 3:
@@ -102,12 +114,7 @@ def qr(
 
     if not A.is_distributed() or A.split < A.ndim - 2:
         # handle the case of a single process or split=None: just PyTorch QR
-        try:
-            Q, R = single_proc_qr(A.larray, mode=mode)
-        except NotImplementedError as E:
-            raise NotImplementedError(
-                f"`heat.linalg.qr` relies on `torch.linalg.qr`, which is not implemented for dtype {A.dtype}"
-            ) from E
+        Q, R = single_proc_qr(A.larray, mode=mode)
 
         R = factories.array(R, is_split=A.split, device=A.device)
         if mode == "reduced":

--- a/heat/core/linalg/qr.py
+++ b/heat/core/linalg/qr.py
@@ -102,7 +102,7 @@ def qr(
                 f"Array 'A' must have datatype of float32, float64, complex64, or complex128, but has {A.dtype}"
             ) from E
         raise NotImplementedError(
-            f"`heat.linalg.qr` is not implemented for dtype {A.dtype}, but is supported by torch. Please open an issue on GitHub to get this implemented"
+            f"`heat.linalg.qr` is not implemented for dtype {A.dtype}. Please open an issue on GitHub to get this implemented"
         )
 
     QR = collections.namedtuple("QR", "Q, R")

--- a/heat/core/linalg/tests/test_qr.py
+++ b/heat/core/linalg/tests/test_qr.py
@@ -11,7 +11,7 @@ class TestQR(TestCase):
         if self.is_mps:
             dtypes = [ht.float32]
         else:
-            dtypes = [ht.float32, ht.float64]
+            dtypes = [ht.float32, ht.float64, ht.complex64, ht.complex128]
 
         for split in [1, None]:
             for mode in ["reduced", "r"]:
@@ -22,63 +22,57 @@ class TestQR(TestCase):
                     (40 * ht.MPI_WORLD.size - 1, 20 * ht.MPI_WORLD.size),
                 ]:
                     for dtype in dtypes:
-                        dtypetol = 1e-3 if dtype == ht.float32 else 1e-6
-                        mat = ht.random.randn(*shape, dtype=dtype, split=split)
-                        qr = ht.linalg.qr(mat, mode=mode)
+                        with self.subTest(f'{dtype=} {shape=} {mode=}'):
+                            dtypetol = 1e-3 if dtype in [ht.float32, ht.complex64] else 1e-6
+                            mat = ht.random.randn(*shape, dtype=dtype, split=split)
+                            qr = ht.linalg.qr(mat, mode=mode)
 
-                        if mode == "reduced":
-                            allclose = ht.allclose(qr.Q @ qr.R, mat, atol=dtypetol, rtol=dtypetol)
-                            if not allclose:
-                                diff = qr.Q @ qr.R - mat
-                                max_diff = ht.max(diff)
-                                #print(f"diff: {diff}")
-                                #print(f"max_diff: {max_diff}m")
-
-                            self.assertTrue(
-                                ht.allclose(qr.Q @ qr.R, mat, atol=dtypetol, rtol=dtypetol)
-                            )
-                            self.assertIsInstance(qr.Q, ht.DNDarray)
-
-                            # test if Q is orthogonal
-                            self.assertTrue(
-                                ht.allclose(
-                                    qr.Q.T @ qr.Q,
-                                    ht.eye(qr.Q.shape[1], dtype=dtype),
-                                    atol=dtypetol,
-                                    rtol=dtypetol,
+                            if mode == "reduced":
+                                self.assertTrue(
+                                    ht.allclose(qr.Q @ qr.R, mat, atol=dtypetol, rtol=dtypetol)
                                 )
-                            )
-                            # test correct shape of Q
-                            self.assertEqual(qr.Q.shape, (shape[0], min(shape)))
-                        else:
-                            self.assertIsNone(qr.Q)
+                                self.assertIsInstance(qr.Q, ht.DNDarray)
 
-                        # test correct type and shape of R
-                        self.assertIsInstance(qr.R, ht.DNDarray)
-                        self.assertEqual(qr.R.shape, (min(shape), shape[1]))
+                                # test if Q is orthogonal / hermitian
+                                self.assertTrue(
+                                    ht.allclose(
+                                        ht.conj(qr.Q).T @ qr.Q,
+                                        ht.eye(qr.Q.shape[1], dtype=dtype),
+                                        atol=dtypetol,
+                                        rtol=dtypetol,
+                                    )
+                                )
+                                # test correct shape of Q
+                                self.assertEqual(qr.Q.shape, (shape[0], min(shape)))
+                            else:
+                                self.assertIsNone(qr.Q)
 
-                        # compare with torch qr, due to different signs we can only compare absolute values
-                        mat_t = mat.resplit_(None).larray
-                        q_t, r_t = torch.linalg.qr(mat_t, mode=mode)
-                        r_ht = qr.R.resplit_(None).larray
-                        self.assertTrue(
-                            torch.allclose(
-                                torch.abs(r_t), torch.abs(r_ht), atol=dtypetol, rtol=dtypetol
-                            )
-                        )
-                        if mode == "reduced":
-                            q_ht = qr.Q.resplit_(None).larray
+                            # test correct type and shape of R
+                            self.assertIsInstance(qr.R, ht.DNDarray)
+                            self.assertEqual(qr.R.shape, (min(shape), shape[1]))
+
+                            # compare with torch qr, due to different signs we can only compare absolute values
+                            mat_t = mat.resplit_(None).larray
+                            q_t, r_t = torch.linalg.qr(mat_t, mode=mode)
+                            r_ht = qr.R.resplit_(None).larray
                             self.assertTrue(
                                 torch.allclose(
-                                    torch.abs(q_t), torch.abs(q_ht), atol=dtypetol, rtol=dtypetol
+                                    torch.abs(r_t), torch.abs(r_ht), atol=dtypetol, rtol=dtypetol
                                 )
                             )
+                            if mode == "reduced":
+                                q_ht = qr.Q.resplit_(None).larray
+                                self.assertTrue(
+                                    torch.allclose(
+                                        torch.abs(q_t), torch.abs(q_ht), atol=dtypetol, rtol=dtypetol
+                                    )
+                                )
 
     def test_qr_split0(self):
         if self.is_mps:
             dtypes = [ht.float32]
         else:
-            dtypes = [ht.float32, ht.float64]
+            dtypes = [ht.float32, ht.float64, ht.complex64, ht.complex128]
         split = 0
         for procs_to_merge in [0, 2, 3]:
             for mode in ["reduced", "r"]:
@@ -89,51 +83,52 @@ class TestQR(TestCase):
                     (40 * ht.MPI_WORLD.size - 1, 20 * ht.MPI_WORLD.size),
                 ]:
                     for dtype in dtypes:
-                        dtypetol = 1e-3 if dtype == ht.float32 else 1e-6
-                        mat = ht.random.randn(*shape, dtype=dtype, split=split)
+                        with self.subTest(f'{dtype=} {shape=} {mode=} {procs_to_merge=}'):
+                            dtypetol = 1e-3 if dtype in [ht.float32, ht.complex64] else 1e-6
+                            mat = ht.random.randn(*shape, dtype=dtype, split=split)
 
-                        qr = ht.linalg.qr(mat, mode=mode, procs_to_merge=procs_to_merge)
+                            qr = ht.linalg.qr(mat, mode=mode, procs_to_merge=procs_to_merge)
 
-                        if mode == "reduced":
-                            self.assertTrue(
-                                ht.allclose(qr.Q @ qr.R, mat, atol=dtypetol, rtol=dtypetol)
-                            )
-                            self.assertIsInstance(qr.Q, ht.DNDarray)
-
-                            # test if Q is orthogonal
-                            self.assertTrue(
-                                ht.allclose(
-                                    qr.Q.T @ qr.Q,
-                                    ht.eye(qr.Q.shape[1], dtype=dtype),
-                                    atol=dtypetol,
-                                    rtol=dtypetol,
+                            if mode == "reduced":
+                                self.assertTrue(
+                                    ht.allclose(qr.Q @ qr.R, mat, atol=dtypetol, rtol=dtypetol)
                                 )
-                            )
-                            # test correct shape of Q
-                            self.assertEqual(qr.Q.shape, (shape[0], min(shape)))
-                        else:
-                            self.assertIsNone(qr.Q)
+                                self.assertIsInstance(qr.Q, ht.DNDarray)
 
-                        # test correct type and shape of R
-                        self.assertIsInstance(qr.R, ht.DNDarray)
-                        self.assertEqual(qr.R.shape, (min(shape), shape[1]))
+                                # test if Q is orthogonal / hermitian
+                                self.assertTrue(
+                                    ht.allclose(
+                                        ht.conj(qr.Q).T @ qr.Q,
+                                        ht.eye(qr.Q.shape[1], dtype=dtype),
+                                        atol=dtypetol,
+                                        rtol=dtypetol,
+                                    )
+                                )
+                                # test correct shape of Q
+                                self.assertEqual(qr.Q.shape, (shape[0], min(shape)))
+                            else:
+                                self.assertIsNone(qr.Q)
 
-                        # compare with torch qr, due to different signs we can only compare absolute values
-                        mat_t = mat.resplit_(None).larray
-                        q_t, r_t = torch.linalg.qr(mat_t, mode=mode)
-                        r_ht = qr.R.resplit_(None).larray
-                        self.assertTrue(
-                            torch.allclose(
-                                torch.abs(r_t), torch.abs(r_ht), atol=dtypetol, rtol=dtypetol
-                            )
-                        )
-                        if mode == "reduced":
-                            q_ht = qr.Q.resplit_(None).larray
+                            # test correct type and shape of R
+                            self.assertIsInstance(qr.R, ht.DNDarray)
+                            self.assertEqual(qr.R.shape, (min(shape), shape[1]))
+
+                            # compare with torch qr, due to different signs we can only compare absolute values
+                            mat_t = mat.resplit_(None).larray
+                            q_t, r_t = torch.linalg.qr(mat_t, mode=mode)
+                            r_ht = qr.R.resplit_(None).larray
                             self.assertTrue(
                                 torch.allclose(
-                                    torch.abs(q_t), torch.abs(q_ht), atol=dtypetol, rtol=dtypetol
+                                    torch.abs(r_t), torch.abs(r_ht), atol=dtypetol, rtol=dtypetol
                                 )
                             )
+                            if mode == "reduced":
+                                q_ht = qr.Q.resplit_(None).larray
+                                self.assertTrue(
+                                    torch.allclose(
+                                        torch.abs(q_t), torch.abs(q_ht), atol=dtypetol, rtol=dtypetol
+                                    )
+                                )
 
     def test_batched_qr_splitNone(self):
         # two batch dimensions, float64 data type, "split = None" (split batch axis)

--- a/heat/core/linalg/tests/test_qr.py
+++ b/heat/core/linalg/tests/test_qr.py
@@ -72,7 +72,7 @@ class TestQR(TestCase):
         if self.is_mps:
             dtypes = [ht.float32]
         else:
-            dtypes = [ht.float32, ht.float64, ht.complex64, ht.complex128]
+            dtypes = [ht.float32, ht.float64, ht.complex64, ht.complex128, ht.float16]
         split = 0
         for procs_to_merge in [0, 2, 3]:
             for mode in ["reduced", "r"]:
@@ -87,7 +87,10 @@ class TestQR(TestCase):
                             dtypetol = 1e-3 if dtype in [ht.float32, ht.complex64] else 1e-6
                             mat = ht.random.randn(*shape, dtype=dtype, split=split)
 
-                            qr = ht.linalg.qr(mat, mode=mode, procs_to_merge=procs_to_merge)
+                            try:
+                                qr = ht.linalg.qr(mat, mode=mode, procs_to_merge=procs_to_merge)
+                            except NotImplementedError as e:
+                                self.skipTest(str(e))
 
                             if mode == "reduced":
                                 self.assertTrue(
@@ -185,5 +188,5 @@ class TestQR(TestCase):
         with self.assertRaises(ValueError):
             ht.linalg.qr(ht.zeros((10, 10)), procs_to_merge=1)
         # test wrong dtype
-        with self.assertRaises(TypeError):
+        with self.assertRaises(RuntimeError):
             ht.linalg.qr(ht.zeros((10, 10), dtype=ht.int32))

--- a/heat/core/linalg/tests/test_qr.py
+++ b/heat/core/linalg/tests/test_qr.py
@@ -72,7 +72,7 @@ class TestQR(TestCase):
         if self.is_mps:
             dtypes = [ht.float32]
         else:
-            dtypes = [ht.float32, ht.float64, ht.complex64, ht.complex128, ht.float16]
+            dtypes = [ht.float32, ht.float64, ht.complex64, ht.complex128]
         split = 0
         for procs_to_merge in [0, 2, 3]:
             for mode in ["reduced", "r"]:
@@ -188,5 +188,5 @@ class TestQR(TestCase):
         with self.assertRaises(ValueError):
             ht.linalg.qr(ht.zeros((10, 10)), procs_to_merge=1)
         # test wrong dtype
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             ht.linalg.qr(ht.zeros((10, 10), dtype=ht.int32))


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [x] documentation updated where needed

## Description
As torch supports complex values in QR decomposition, only minimal changes are needed to make heat support it as well. Only the type check needs to be altered and the complex conjugate needs to be taken in a few places, that's it.

There is already a very similar PR open for this (#2040). However, it lacks testing. Here, I added tests. The diff is quite large because I split the test in subtests, but I actually changed very little there.

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #2039, #2040 

## Changes proposed:

- Allow complex values in QR


## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
 - New feature
