### PR TITLE
Leaner CI matrix + `test_io` deadlock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - main
-      - dependabot/**    
+      - dependabot/**
 
 jobs:
   approved:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,5 +51,6 @@ jobs:
         run: |
           pip install pytest
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
-          mpirun -n 3 pytest -vv -x heat/
-          mpirun -n 4 pytest -vv -x heat/
+          # use pytest -vv -x for debugging
+          mpirun -n 3 pytest heat/
+          mpirun -n 4 pytest heat/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  push:
 
 jobs:
   approved:
@@ -52,5 +52,5 @@ jobs:
           pip install pytest
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
           # use pytest -vv -x for debugging
-          mpirun -n 3 pytest heat/
+          pytest heat/
           mpirun -n 4 pytest heat/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,14 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         py-version:
-          - '3.14' # Latest stable
           - '3.10' # Oldest supported
+          - '3.14' # Latest stable
         mpi: [ 'openmpi' ]
         install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
         pytorch-version:
-          - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0' # Latest stable
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Oldest supported
           - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026
+          - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0' # Latest stable
         exclude:
           - py-version: '3.10'
             install-options: '.[hdf5,netcdf,pandas,zarr]'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Test
         run: |
-          pip install pytest
+          pip install pytest pytest-timeout
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
-          mpirun -n 3 pytest -v heat/
-          mpirun -n 4 pytest -v heat/
+          mpirun -n 3 pytest --timeout=120 -v -s heat/
+          mpirun -n 4 pytest --timeout=120 -v -s heat/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,6 @@ jobs:
           - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026
           - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0' # Latest stable
         exclude:
-          # Maintain your existing exclusion for 3.10 with full extras if desired
           - py-version: '3.10'
             install-options: '.[hdf5,netcdf,pandas,zarr]'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ jobs:
   approved:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,5 +51,5 @@ jobs:
         run: |
           pip install pytest
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
-          mpirun -n 3 pytest  -vs heat/
-          mpirun -n 4 pytest  -vs heat/
+          mpirun -n 3 pytest -v heat/
+          mpirun -n 4 pytest -v heat/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,14 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         py-version:
-          - '3.10' # Oldest supported
           - '3.14' # Latest stable
+          - '3.10' # Oldest supported
         mpi: [ 'openmpi' ]
         install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
         pytorch-version:
+          - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0' # Latest stable
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Oldest supported
           - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026
-          - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0' # Latest stable
         exclude:
           - py-version: '3.10'
             install-options: '.[hdf5,netcdf,pandas,zarr]'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,44 +12,18 @@ jobs:
       fail-fast: false
       matrix:
         py-version:
-          - '3.10'
-          - '3.11'
-          - '3.12'
-          - '3.13'
-          - '3.14'
+          - '3.10' # Oldest supported
+          - '3.14' # Latest stable
         mpi: [ 'openmpi' ]
         install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
         pytorch-version:
-          - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
-          - 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'
-          - 'torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1'
-          - 'torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0'
-          - 'torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1'
-          - 'torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0'
-          - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'
-          - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0'
+          - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Minimum supported
+          - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026
+          - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0' # Latest stable
         exclude:
-          - py-version: '3.14'
-            pytorch-version: 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
-          - py-version: '3.14'
-            pytorch-version: 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'
-          - py-version: '3.14'
-            pytorch-version: 'torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1'
-          - py-version: '3.14'
-            pytorch-version: 'torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0'
-          - py-version: '3.14'
-            pytorch-version: 'torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1'
-          - py-version: '3.14'
-            pytorch-version: 'torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0'
-          - py-version: '3.13'
-            pytorch-version: 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
-          - py-version: '3.13'
-            pytorch-version: 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'
-          - py-version: '3.13'
-            pytorch-version: 'torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1'
+          # Maintain your existing exclusion for 3.10 with full extras if desired
           - py-version: '3.10'
             install-options: '.[hdf5,netcdf,pandas,zarr]'
-
 
     name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}; options ${{ matrix.install-options }}
     steps:
@@ -60,15 +34,18 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Setup MPI
         uses: mpi4py/setup-mpi@3969f247e8fceef153418744f9d9ee6fdaeda29f # v1.2.0
         with:
           mpi: ${{ matrix.mpi }}
+
       - name: Use Python ${{ matrix.py-version }}
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ matrix.py-version }}
           architecture: x64
+
       - name: Test
         run: |
           pip install pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Test
         run: |
-          pip install pytest 
+          pip install pytest
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
           mpirun -n 3 pytest  -vs heat/
           mpirun -n 4 pytest  -vs heat/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,5 +51,5 @@ jobs:
         run: |
           pip install pytest
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
-          mpirun -n 3 pytest -v heat/
-          mpirun -n 4 pytest -v heat/
+          mpirun -n 3 pytest -vv -x heat/
+          mpirun -n 4 pytest -vv -x heat/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,14 +18,14 @@ jobs:
           - '3.10' # Oldest supported
           - '3.14' # Latest stable
         mpi: [ 'openmpi' ]
-        install-options: [ '.', '.[hdf5,netcdf,zarr]' ]
+        install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Oldest supported
           - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026
           - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0' # Latest stable
         exclude:
           - py-version: '3.10'
-            install-options: '.[hdf5,netcdf,zarr]'
+            install-options: '.[hdf5,netcdf,pandas,zarr]'
           - py-version: '3.14'
             pytorch-version: 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,5 +51,5 @@ jobs:
         run: |
           pip install pytest
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
-          mpirun -n 3 pytest heat/
-          mpirun -n 4 pytest heat/
+          mpirun -n 3 pytest -v heat/
+          mpirun -n 4 pytest -v heat/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Test
         run: |
-          pip install pytest pytest-timeout
+          pip install pytest 
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
-          mpirun -n 3 pytest --timeout=120 -v -s heat/
-          mpirun -n 4 pytest --timeout=120 -v -s heat/
+          mpirun -n 3 pytest  -vs heat/
+          mpirun -n 4 pytest  -vs heat/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,10 @@
 name: ci
 
 on:
-  pull_request:
   push:
+    branches-ignore:
+      - main
+      - dependabot/**    
 
 jobs:
   approved:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,14 +17,14 @@ jobs:
           - '3.10' # Oldest supported
           - '3.14' # Latest stable
         mpi: [ 'openmpi' ]
-        install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
+        install-options: [ '.', '.[hdf5,netcdf,zarr]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Oldest supported
           - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026
           - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0' # Latest stable
         exclude:
           - py-version: '3.10'
-            install-options: '.[hdf5,netcdf,pandas,zarr]'
+            install-options: '.[hdf5,netcdf,zarr]'
           - py-version: '3.14'
             pytorch-version: 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
 
@@ -55,4 +55,4 @@ jobs:
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
           # use pytest -vv -x for debugging
           pytest heat/
-          mpirun -n 4 pytest heat/
+          mpirun -n 4 pytest -vv heat/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
         exclude:
           - py-version: '3.10'
             install-options: '.[hdf5,netcdf,pandas,zarr]'
+          - py-version: '3.14'
+            pytorch-version: 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
 
     name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}; options ${{ matrix.install-options }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,12 @@
 name: ci
 
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   approved:
-    if: github.event.review.state == 'approved'
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -17,7 +17,7 @@ jobs:
         mpi: [ 'openmpi' ]
         install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
         pytorch-version:
-          - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Minimum supported
+          - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Oldest supported
           - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026
           - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0' # Latest stable
         exclude:

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -1,12 +1,14 @@
-name: ci
+name: ci_full
 
 on:
-  pull_request_review:
-    types: [submitted]
+  push:
+    branches:
+      - main
+    paths:
+      - 'heat/**'
 
 jobs:
-  approved:
-    if: github.event.review.state == 'approved'
+  full_matrix_test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -50,7 +52,6 @@ jobs:
           - py-version: '3.10'
             install-options: '.[hdf5,netcdf,pandas,zarr]'
 
-
     name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}; options ${{ matrix.install-options }}
     steps:
       - name: Harden Runner
@@ -60,15 +61,18 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Setup MPI
         uses: mpi4py/setup-mpi@3969f247e8fceef153418744f9d9ee6fdaeda29f # v1.2.0
         with:
           mpi: ${{ matrix.mpi }}
+
       - name: Use Python ${{ matrix.py-version }}
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ matrix.py-version }}
           architecture: x64
+
       - name: Test
         run: |
           pip install pytest

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -23,7 +23,7 @@ jobs:
           - '3.13'
           - '3.14'
         mpi: [ 'openmpi' ]
-        install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
+        install-options: [ '.', '.[hdf5,netcdf,zarr]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
           - 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'
@@ -53,7 +53,7 @@ jobs:
           - py-version: '3.13'
             pytorch-version: 'torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1'
           - py-version: '3.10'
-            install-options: '.[hdf5,netcdf,pandas,zarr]'
+            install-options: '.[hdf5,netcdf,zarr]'
 
     name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}; options ${{ matrix.install-options }}
     steps:

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - stable      
     paths:
       - 'heat/**'
       - 'pyproject.toml'

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   full_matrix_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -24,7 +24,7 @@ jobs:
           - '3.13'
           - '3.14'
         mpi: [ 'openmpi' ]
-        install-options: [ '.', '.[hdf5,netcdf,zarr]' ]
+        install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
           - 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'
@@ -54,7 +54,7 @@ jobs:
           - py-version: '3.13'
             pytorch-version: 'torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1'
           - py-version: '3.10'
-            install-options: '.[hdf5,netcdf,zarr]'
+            install-options: '.[hdf5,netcdf,pandas,zarr]'
 
     name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}; options ${{ matrix.install-options }}
     steps:

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - stable      
+      - stable
     paths:
       - 'heat/**'
       - 'pyproject.toml'

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'heat/**'
+      - 'pyproject.toml' 
+      - '.github/workflows/ci_full.yaml'
 
 jobs:
   full_matrix_test:

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -1,0 +1,77 @@
+name: ci
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  approved:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py-version:
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
+        mpi: [ 'openmpi' ]
+        install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
+        pytorch-version:
+          - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
+          - 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'
+          - 'torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1'
+          - 'torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0'
+          - 'torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1'
+          - 'torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0'
+          - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'
+          - 'torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0'
+        exclude:
+          - py-version: '3.14'
+            pytorch-version: 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
+          - py-version: '3.14'
+            pytorch-version: 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'
+          - py-version: '3.14'
+            pytorch-version: 'torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1'
+          - py-version: '3.14'
+            pytorch-version: 'torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0'
+          - py-version: '3.14'
+            pytorch-version: 'torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1'
+          - py-version: '3.14'
+            pytorch-version: 'torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0'
+          - py-version: '3.13'
+            pytorch-version: 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
+          - py-version: '3.13'
+            pytorch-version: 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'
+          - py-version: '3.13'
+            pytorch-version: 'torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1'
+          - py-version: '3.10'
+            install-options: '.[hdf5,netcdf,pandas,zarr]'
+
+
+    name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}; options ${{ matrix.install-options }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup MPI
+        uses: mpi4py/setup-mpi@3969f247e8fceef153418744f9d9ee6fdaeda29f # v1.2.0
+        with:
+          mpi: ${{ matrix.mpi }}
+      - name: Use Python ${{ matrix.py-version }}
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: ${{ matrix.py-version }}
+          architecture: x64
+      - name: Test
+        run: |
+          pip install pytest
+          pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
+          mpirun -n 3 pytest heat/
+          mpirun -n 4 pytest heat/

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'heat/**'
-      - 'pyproject.toml' 
+      - 'pyproject.toml'
       - '.github/workflows/ci_full.yaml'
 
 jobs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -32,7 +32,7 @@ build:
           # If grep failed to find a match (exit code 1), then exit with 18
           if [ $? -eq 1 ]; then
             echo "No relevant changes found. Skipping build."
-            exit 18
+            exit 0
           fi
         fi
 

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -995,7 +995,7 @@ class TestIO(TestCase):
         nested_group_name = "MAIN_0"
         array_name = "DATA"
         variable_path = f"{nested_group_name}/{array_name}"
-
+        print("DEBUGGING: writing out nested zarr store")
         if ht.MPI_WORLD.rank == 0:
             root = zarr.open_group(self.ZARR_NESTED_PATH, mode="w")
             main_0 = root.create_group(nested_group_name)
@@ -1009,7 +1009,9 @@ class TestIO(TestCase):
         ht.MPI_WORLD.Barrier()
 
         # Test loading using both positional and keyword arguments for different splits
+        print("DEBUGGING: test loading args kwargs")
         for split in [None, 0, 1]:
+            print(f"DEBUGGING: split {split}")
             # Test with positional argument
             with self.subTest(split=split, arg_type="positional"):
                 ht_tensor_pos = ht.load(self.ZARR_NESTED_PATH, variable_path, split=split)
@@ -1027,7 +1029,7 @@ class TestIO(TestCase):
                 self.assertTrue(np.array_equal(ht_tensor_kw.numpy(), original_data))
 
         ht.MPI_WORLD.Barrier()
-
+        print("DEBUGGING: test loading with wildcard")
         # test loading with wildcard
         num_chunks = self.comm.size * 2 + 1
         if self.comm.size > 3:
@@ -1040,6 +1042,7 @@ class TestIO(TestCase):
 
         ht.MPI_WORLD.Barrier()
         for dtype in np_testing_types:
+            print(f"dtype {dtype}")
             global_data_shape = (num_chunks * 10, num_chunks * 5, 7)
             global_data = np.arange(np.prod(global_data_shape), dtype=dtype).reshape(global_data_shape)
             if self.comm.rank == 0:
@@ -1070,6 +1073,7 @@ class TestIO(TestCase):
             ht.MPI_WORLD.Barrier()
 
             # test wildcard loading for split=0
+            print("DEBUGGING: test loading with wildcard and split 0")
             with self.subTest(dtype=dtype, split=0):
                 ht_array_split0 = ht.load(self.ZARR_OUT_PATH, variable="CHUNK_*_SPLIT0/DATA", split=0, device=self.device)
                 self.assertIsInstance(ht_array_split0, ht.DNDarray)
@@ -1079,6 +1083,7 @@ class TestIO(TestCase):
                 self.assertTrue(ht_array_split0.dtype == ht.types.canonical_heat_type(dtype))
 
             # test wildcard loading for split=1
+            print("DEBUGGING: test loading with wildcard and split 1")
             with self.subTest(dtype=dtype, split=1):
                 ht_array_split1 = ht.load(self.ZARR_OUT_PATH, variable="CHUNK_*_SPLIT1/DATA", split=1, device=self.device)
                 self.assertIsInstance(ht_array_split1, ht.DNDarray)
@@ -1087,6 +1092,7 @@ class TestIO(TestCase):
                 self.assertTrue(ht_array_split1.dtype == ht.types.canonical_heat_type(dtype))
 
             # test wildcard loading with dtype conversion
+            print("DEBUGGING: test loading with wildcard and dtype conversion")            
             with self.subTest(dtype=dtype, split="dtype_conversion"):
                 # only for non-complex dtypes
                 if not np.issubdtype(dtype, np.complexfloating):

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -1041,7 +1041,6 @@ class TestIO(TestCase):
 
         ht.MPI_WORLD.Barrier()
         for dtype in np_testing_types:
-            print(f"dtype {dtype}")
             global_data_shape = (num_chunks * 10, num_chunks * 5, 7)
             global_data = np.arange(np.prod(global_data_shape), dtype=dtype).reshape(global_data_shape)
             if self.comm.rank == 0:

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -997,7 +997,7 @@ class TestIO(TestCase):
         nested_group_name = "MAIN_0"
         array_name = "DATA"
         variable_path = f"{nested_group_name}/{array_name}"
-        print("DEBUGGING: writing out nested zarr store")
+
         if ht.MPI_WORLD.rank == 0:
             root = zarr.open_group(self.ZARR_NESTED_PATH, mode="w")
             main_0 = root.create_group(nested_group_name)
@@ -1011,9 +1011,7 @@ class TestIO(TestCase):
         ht.MPI_WORLD.Barrier()
 
         # Test loading using both positional and keyword arguments for different splits
-        print("DEBUGGING: test loading args kwargs")
         for split in [None, 0, 1]:
-            print(f"DEBUGGING: split {split}")
             # Test with positional argument
             with self.subTest(split=split, arg_type="positional"):
                 ht_tensor_pos = ht.load(self.ZARR_NESTED_PATH, variable_path, split=split)
@@ -1031,7 +1029,6 @@ class TestIO(TestCase):
                 self.assertTrue(np.array_equal(ht_tensor_kw.numpy(), original_data))
 
         ht.MPI_WORLD.Barrier()
-        print("DEBUGGING: test loading with wildcard")
         # test loading with wildcard
         num_chunks = self.comm.size * 2 + 1
         if self.comm.size > 3:
@@ -1075,7 +1072,6 @@ class TestIO(TestCase):
             ht.MPI_WORLD.Barrier()
 
             # test wildcard loading for split=0
-            print("DEBUGGING: test loading with wildcard and split 0")
             with self.subTest(dtype=dtype, split=0):
                 ht_array_split0 = ht.load(self.ZARR_OUT_PATH, variable="CHUNK_*_SPLIT0/DATA", split=0, device=self.device)
                 self.assertIsInstance(ht_array_split0, ht.DNDarray)
@@ -1085,7 +1081,6 @@ class TestIO(TestCase):
                 self.assertTrue(ht_array_split0.dtype == ht.types.canonical_heat_type(dtype))
 
             # test wildcard loading for split=1
-            print("DEBUGGING: test loading with wildcard and split 1")
             with self.subTest(dtype=dtype, split=1):
                 ht_array_split1 = ht.load(self.ZARR_OUT_PATH, variable="CHUNK_*_SPLIT1/DATA", split=1, device=self.device)
                 self.assertIsInstance(ht_array_split1, ht.DNDarray)
@@ -1094,7 +1089,6 @@ class TestIO(TestCase):
                 self.assertTrue(ht_array_split1.dtype == ht.types.canonical_heat_type(dtype))
 
             # test wildcard loading with dtype conversion
-            print("DEBUGGING: test loading with wildcard and dtype conversion")
             with self.subTest(dtype=dtype, split="dtype_conversion"):
                 # only for non-complex dtypes
                 if not np.issubdtype(dtype, np.complexfloating):

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -1119,6 +1119,8 @@ class TestIO(TestCase):
             with self.assertRaises(FileNotFoundError):
                 test = ht.load(self.ZARR_OUT_PATH, variable="NONEXSISTENT_CHUNK_*_SPLIT0/DATA", split=0)
 
+            ht.MPI_WORLD.Barrier()
+
     def test_load_zarr_slice(self):
         if not ht.io.supports_zarr():
             self.skipTest("Requires zarr")

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -74,7 +74,8 @@ class TestIO(TestCase):
                 os.remove(self.NETCDF_OUT_PATH)
             except FileNotFoundError:
                 pass
-
+        
+        ht.MPI_WORLD.Barrier()
         if ht.io.supports_zarr():
             if ht.MPI_WORLD.rank == 0:
                 for file in [

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -990,6 +990,8 @@ class TestIO(TestCase):
 
         import zarr
 
+        ht.MPI_WORLD.Barrier()
+        
         # Write out a nested Zarr store
         original_data = np.arange(np.prod(self.ZARR_SHAPE)).reshape(self.ZARR_SHAPE)
         nested_group_name = "MAIN_0"

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -74,7 +74,7 @@ class TestIO(TestCase):
                 os.remove(self.NETCDF_OUT_PATH)
             except FileNotFoundError:
                 pass
-        
+
         ht.MPI_WORLD.Barrier()
         if ht.io.supports_zarr():
             if ht.MPI_WORLD.rank == 0:

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -1092,7 +1092,7 @@ class TestIO(TestCase):
                 self.assertTrue(ht_array_split1.dtype == ht.types.canonical_heat_type(dtype))
 
             # test wildcard loading with dtype conversion
-            print("DEBUGGING: test loading with wildcard and dtype conversion")            
+            print("DEBUGGING: test loading with wildcard and dtype conversion")
             with self.subTest(dtype=dtype, split="dtype_conversion"):
                 # only for non-complex dtypes
                 if not np.issubdtype(dtype, np.complexfloating):

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -65,7 +65,7 @@ class TestIO(TestCase):
                 pass
 
             try:
-                shutil.rmtree(self.HDF5_MULTIPLE_FOLDER)
+                shutil.rmtree(self.HDF5_MULTIPLE_FOLDER, ignore_errors=True)
             except FileNotFoundError:
                 pass
 
@@ -75,7 +75,6 @@ class TestIO(TestCase):
             except FileNotFoundError:
                 pass
 
-        ht.MPI_WORLD.Barrier()
         if ht.io.supports_zarr():
             if ht.MPI_WORLD.rank == 0:
                 for file in [
@@ -85,7 +84,7 @@ class TestIO(TestCase):
                     self.ZARR_NESTED_PATH,
                 ]:
                     try:
-                        shutil.rmtree(file)
+                        shutil.rmtree(file, ignore_errors=True)
                     except FileNotFoundError:
                         pass
 

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -991,7 +991,7 @@ class TestIO(TestCase):
         import zarr
 
         ht.MPI_WORLD.Barrier()
-        
+
         # Write out a nested Zarr store
         original_data = np.arange(np.prod(self.ZARR_SHAPE)).reshape(self.ZARR_SHAPE)
         nested_group_name = "MAIN_0"

--- a/heat/core/tests/test_io.py
+++ b/heat/core/tests/test_io.py
@@ -65,7 +65,7 @@ class TestIO(TestCase):
                 pass
 
             try:
-                shutil.rmtree(self.HDF5_MULTIPLE_FOLDER, ignore_errors=True)
+                shutil.rmtree(self.HDF5_MULTIPLE_FOLDER)
             except FileNotFoundError:
                 pass
 
@@ -84,7 +84,7 @@ class TestIO(TestCase):
                     self.ZARR_NESTED_PATH,
                 ]:
                     try:
-                        shutil.rmtree(file, ignore_errors=True)
+                        shutil.rmtree(file)
                     except FileNotFoundError:
                         pass
 


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [x] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR implements a leaner CI matrix as discussed in #2134. The race condition + deadlock arising in test_io with Python 3.14 has also been solved.  


Issue/s resolved: #2134 

## Changes proposed:

- refactor `ci.yaml` as per #2134 . Runs for every commit as requested by @brownbaerchen 
- keep the full matrix in `ci_full.yaml`. This will run when a PR is merged into `main`, if the PR affects the codebase
- in `test_io.test_load_zarr_group` prevent race condition by inserting a Barrier before starting to write out the zarr group. Might be related to [PEP 703](https://peps.python.org/pep-0703/) in combination with Zarr V3's asynchronous I/O. 
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
- Bug fix (non-breaking change which fixes an issue) + GH action refactoring

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
DNA
## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->
DNA
#### Does this change modify the behaviour of other functions? If so, which?
no
