### PR TITLE
Add MPI barrier before all tests

### DIFF
--- a/heat/core/tests/test_suites/basic_test.py
+++ b/heat/core/tests/test_suites/basic_test.py
@@ -19,6 +19,7 @@ class TestCase(unittest.TestCase):
     envar: Optional[str] = None
 
     def setUp(self) -> None:
+        ht.MPI_WORLD.Barrier()
         seed(42)
 
     @classmethod


### PR DESCRIPTION
The CI currently runs into deadlocks with some IO tests. We have not understood why, but seemingly adding some MPI barriers helps. In this PR, I simply add a global MPI barrier before every test that is derived from the basic `TestCase` using the `setUp` function.
Since I cannot reproduce the problem locally and we don't understand the problem, I have no clue if this fixes the issue. Nevertheless, I don't think this hurts and I'd rather do this in a centralized place for all tests than randomly spamming barriers in the code.
Schauen wir mal was wird.

Looking forward to being able to just do this on my fork without requiring a review from somebody else once we have merged #2139 ;)