### PR TITLE
Removed python 3.10 from workflows

### DIFF
--- a/.github/workflows/ReceivePR.yml
+++ b/.github/workflows/ReceivePR.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
-          python-version: '3.10'
+          python-version: '3.14'
           architecture: x64
 
       - name: Setup MPI

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         mpi: [ 'openmpi' ]
 
     steps:


### PR DESCRIPTION
We increased the minimum supported Python version to 3.11 in #2174. This PR removes 3.10 from all workflows since they otherwise fail because they cannot install heat in python 3.10.