### PR TITLE
Fix bug for split SVD/eigh

### DIFF
--- a/heat/core/linalg/eigh.py
+++ b/heat/core/linalg/eigh.py
@@ -87,7 +87,7 @@ def _subspaceiteration(
                 X,
                 randn(
                     X.shape[0],
-                    X.shape[0] - X.shape[1],
+                    max(1, X.shape[0] - X.shape[1]),
                     dtype=X.dtype,
                     device=X.device,
                     comm=X.comm,


### PR DESCRIPTION
## Description
This PR fixes a small bug for some split matrices that causes SVD and eigh to fail.

Issue/s resolved: #2171 

## Changes proposed:

- ensure that the second axis size is at least 1 in the case where ` X.shape[0] == X.shape[1]` (this function is only called for split matrices)
## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Memory requirements
- Only happens on split matrices

Below is a minimal reproducer:
```python
import heat as ht
import numpy as np

# Constants
nx, ny = 4, 4
Nt = 32
Lambda = 2*nx*ny
beta=8
U=2
mu=0
delta = beta / Nt

# Heat settings
default_device = "cpu"
default_type = ht.float64

kappa=ht.diag(ht.zeros(Lambda, device=default_device, dtype=default_type))
for ix in range(nx):  # only loop over unit cells
    for iy in range(ny):
        ixy = 2 * (ix*ny + iy)
        kappa[ixy, ixy+1] += 1   # unit cell nearest neighbor
        kappa[ixy+1, ixy] += 1
        
        ixy1 = 2 * (((ix-1) % nx) * ny+iy)
        kappa[ixy, ixy1+1] += 1   # second nearest neighbor
        kappa[ixy1+1, ixy] += 1

        ixy2 = 2 * (ix*ny + (iy-1) % ny)
        kappa[ixy, ixy2+1] += 1   # third nearest neighbor
        kappa[ixy2+1, ixy] += 1
print(kappa)

mutilde = ht.diag(ht.ones(Lambda, device=default_device, dtype=default_type) * delta * mu)
M = delta * kappa - mutilde 
print(M)


# Self made exponential function
eig, eigv = ht.linalg.eigh(M)
inv_eigv = ht.linalg.inv(eigv)
expM = eigv @ ht.diag(np.exp(eig)) @ inv_eigv
print(expM)

print(ht.expm(M)) ## Note that expm does not return the same split as the original matrix

s, v, d = ht.linalg.svd(expM) # This fails on a split matrix
```