### PR TITLE
Skip tests without optional dependencies in lean CI

### DIFF
--- a/.github/workflows/ReceivePR.yml
+++ b/.github/workflows/ReceivePR.yml
@@ -30,13 +30,6 @@ jobs:
         with:
           mpi: openmpi
 
-      - name: Test
-        run: |
-          pip install .[dev]
-          pip install pytest
-          pre-commit run --all-files
-          pytest
-
       - name: Save PR number
         env:
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,7 @@ on:
       - dependabot/**
 
 jobs:
-  approved:
-    if: github.event.pull_request.draft == false
+  tests:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -18,7 +17,7 @@ jobs:
           - '3.11' # Oldest supported
           - '3.14' # Latest stable
         mpi: [ 'openmpi' ]
-        install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
+        install-options: [ '.[hdf5,netcdf,pandas,zarr,dev]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Oldest supported
           - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026
@@ -48,10 +47,20 @@ jobs:
           python-version: ${{ matrix.py-version }}
           architecture: x64
 
-      - name: Test
+      - name: Install heat and pytest
         run: |
           pip install pytest
           pip install ${{ matrix.pytorch-version }} ${{ matrix.install-options }} --extra-index-url https://download.pytorch.org/whl/cpu
+
+      - name: Lint
+        run: |
+          pre-commit run --all-files
+
+      - name: Run serial tests
+        run: |
           # use pytest -vv -x for debugging
           pytest
+
+      - name: Run parallel tests
+        run: |
           mpirun -n 4 pytest -vv


### PR DESCRIPTION
## Description
The CI can be more lean! Afaik, when installing optional dependencies, we only run more tests than without. So there is no need to also run without optional dependencies in the lean CI in my opinion. This halves the number of jobs spawned by the lean CI.
On the other hand, I do think the lean CI should run the linter.

ReceivePR should not run any tests or linters in my opinion. The workflows should be as simple as possible.

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->


## Changes proposed:

- Run lean CI only with all optional dependencies
- Run linter in lean CI
- Small refactor of lean CI
- Do not run tests in ReceivePR
- Do not run linter in ReceivePR