### PR TITLE
Make `test_load_npy_exception` unflaky

### DIFF
--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -877,6 +877,7 @@ class TestIO(TestCase):
             ht.MPI_WORLD.Barrier()
             with self.assertRaises(RuntimeError):
                 ht.load_npy_from_path(path, dtype=ht.int64, split=0)
+            ht.MPI_WORLD.Barrier()
 
     def test_load_multiple_csv(self):
         if not ht.io.supports_pandas():


### PR DESCRIPTION
In #2193 we implemented temporary directories for some test that are cleaned up when they get garbage collected. Turns out there are some race conditions that if rank 0 exists the test first, the temporary directory is cleaned up before other tasks finished with the test.
This can be prevented by simply calling a barrier at the end of the test. Note that it's not enough to call a barrier in the tear down method because at that point the temporary directory is already cleaned up.
Sorry that I noticed this only now, but hopefully we can quickly fix this.