### PR TITLE
add array api inspection

### DIFF
--- a/heat/array_api/__init__.py
+++ b/heat/array_api/__init__.py
@@ -6,9 +6,11 @@ import warnings
 
 warnings.warn("The heat.array_api submodule is not fully implemented.", stacklevel=2)
 
-__array_api_version__ = "2023.12"
+__array_api_version__ = "2025.12"
 
 __all__ = ["__array_api_version__"]
+
+from ._inspection import __array_namespace_info__
 
 from ._constants import e, inf, nan, newaxis, pi
 

--- a/heat/array_api/_inspection.py
+++ b/heat/array_api/_inspection.py
@@ -1,0 +1,151 @@
+import heat.core.devices as ht_devices
+
+from types import SimpleNamespace
+from heat.core.types import (
+    bool,
+    complex64,
+    complex128,
+    float16,
+    float32,
+    float64,
+    int8,
+    int16,
+    int32,
+    int64,
+    uint8
+)
+
+
+def __array_namespace_info__():
+    """Returns a namespace with Array API namespace inspection utilities."""
+    info = SimpleNamespace()
+    info.capabilities  = capabilities
+    info.default_device = default_device
+    info.default_dtypes = default_dtypes
+    info.devices = devices
+    info.dtypes = dtypes
+    return info
+
+def capabilities():
+    """Returns a dictionary of array library capabilities."""
+    return {
+        "boolean indexing": True,
+        "data-dependent shapes": True,
+        "max dimensions": 64
+    }
+
+def default_device():
+    """Returns the default device."""
+    return ht_devices.get_device()
+
+def default_dtypes(*, device=None):
+    """Returns a dictionary containing default data types."""
+    if device is None:
+        device = default_device()
+
+    if not isinstance(device, ht_devices.Device):
+        raise ValueError(
+            f"Device not understood: {device}"
+        )
+
+    if device == ht_devices.cpu:
+        return {
+            "real floating": float32,
+            "complex floating": complex64,
+            "integral": int64,
+            "indexing": int64,
+        }
+
+    if device == ht_devices.gpu:
+        return {
+            "real floating": float32,
+            "complex floating": complex64,
+            "integral": int64,
+            "indexing": int64,
+        }
+
+    raise ValueError(f"Unsupported device: {device}")
+
+    
+def devices():
+    """Returns a list of supported devices which are available at runtime."""
+    if hasattr(ht_devices, "gpu"):
+        return (ht_devices.cpu, ht_devices.gpu)
+    else:
+        return (ht_devices.cpu,)
+
+def dtypes(*, device=None, kind=None):
+    """Returns a dictionary of supported Array API data types"""
+    if device is None:
+        device = default_device()
+    
+    if not isinstance(device, ht_devices.Device):
+        raise ValueError(
+            f"Device not understood: {device}"
+        )
+
+    if kind is None:
+        return {
+            "bool": bool,
+            "int8": int8,
+            "int16": int16,
+            "int32": int32,
+            "int64": int64,
+            "uint8": uint8,
+            "float32": float32,
+            "float64": float64,
+            "complex64": complex64,
+            "complex128": complex128,
+        }
+    if kind == "bool":
+        return {
+            "bool": bool,
+        }
+    if kind == "signed integer":
+        return {
+            "int8": int8,
+            "int16": int16,
+            "int32": int32,
+            "int64": int64,
+        }
+    if kind == "unsigned integer":
+        return {
+            "uint8": uint8,
+        }
+    if kind == "integral":
+        return {
+            "int8": int8,
+            "int16": int16,
+            "int32": int32,
+            "int64": int64,
+            "uint8": uint8,
+        }
+    if kind == "real floating":
+        return {
+            "float32": float32,
+            "float64": float64,
+        }
+    if kind == "complex floating":
+        return {
+            "complex64": complex64,
+            "complex128": complex128,
+        }
+    if kind == "numeric":
+        return {
+            "int8": int8,
+            "int16": int16,
+            "int32": int32,
+            "int64": int64,
+            "uint8": uint8,
+            "float32": float32,
+            "float64": float64,
+            "complex64": complex64,
+            "complex128": complex128,
+        }
+    if isinstance(kind, tuple):
+        res = {}
+        for k in kind:
+            res |= dtypes(device=device, kind=k)
+        return res
+    raise ValueError(f"Unsupported kind: {kind}")
+

--- a/heat/array_api/_inspection.py
+++ b/heat/array_api/_inspection.py
@@ -45,21 +45,20 @@ def default_dtypes(*, device=None):
     if not isinstance(device, ht_devices.Device):
         raise ValueError(f"Device not understood: {device}")
 
-    if device == ht_devices.cpu:
+    if "mps" in device.torch_device:
         return {
             "real floating": float32,
             "complex floating": complex64,
-            "integral": int64,
-            "indexing": int64,
+            "integral": int32,
+            "indexing": int32,
         }
 
-    if device == ht_devices.gpu:
-        return {
-            "real floating": float32,
-            "complex floating": complex64,
-            "integral": int64,
-            "indexing": int64,
-        }
+    return {
+        "real floating": float32,
+        "complex floating": complex64,
+        "integral": int64,
+        "indexing": int64,
+    }
 
     raise ValueError(f"Unsupported device: {device}")
 
@@ -79,6 +78,56 @@ def dtypes(*, device=None, kind=None):
 
     if not isinstance(device, ht_devices.Device):
         raise ValueError(f"Device not understood: {device}")
+
+    if "mps" in device.torch_device:
+        if kind is None:
+            return {
+                "bool": bool,
+                "int8": int8,
+                "int16": int16,
+                "int32": int32,
+                "uint8": uint8,
+                "float32": float32,
+                "complex64": complex64,
+            }
+        if kind == "bool":
+            return {
+                "bool": bool,
+            }
+        if kind == "signed integer":
+            return {
+                "int8": int8,
+                "int16": int16,
+                "int32": int32,
+            }
+        if kind == "unsigned integer":
+            return {
+                "uint8": uint8,
+            }
+        if kind == "integral":
+            return {
+                "int8": int8,
+                "int16": int16,
+                "int32": int32,
+                "uint8": uint8,
+            }
+        if kind == "real floating":
+            return {
+                "float32": float32,
+            }
+        if kind == "complex floating":
+            return {
+                "complex64": complex64,
+            }
+        if kind == "numeric":
+            return {
+                "int8": int8,
+                "int16": int16,
+                "int32": int32,
+                "uint8": uint8,
+                "float32": float32,
+                "complex64": complex64,
+            }
 
     if kind is None:
         return {

--- a/heat/array_api/_inspection.py
+++ b/heat/array_api/_inspection.py
@@ -12,31 +12,30 @@ from heat.core.types import (
     int16,
     int32,
     int64,
-    uint8
+    uint8,
 )
 
 
 def __array_namespace_info__():
     """Returns a namespace with Array API namespace inspection utilities."""
     info = SimpleNamespace()
-    info.capabilities  = capabilities
+    info.capabilities = capabilities
     info.default_device = default_device
     info.default_dtypes = default_dtypes
     info.devices = devices
     info.dtypes = dtypes
     return info
 
+
 def capabilities():
     """Returns a dictionary of array library capabilities."""
-    return {
-        "boolean indexing": True,
-        "data-dependent shapes": True,
-        "max dimensions": 64
-    }
+    return {"boolean indexing": True, "data-dependent shapes": True, "max dimensions": 64}
+
 
 def default_device():
     """Returns the default device."""
     return ht_devices.get_device()
+
 
 def default_dtypes(*, device=None):
     """Returns a dictionary containing default data types."""
@@ -44,9 +43,7 @@ def default_dtypes(*, device=None):
         device = default_device()
 
     if not isinstance(device, ht_devices.Device):
-        raise ValueError(
-            f"Device not understood: {device}"
-        )
+        raise ValueError(f"Device not understood: {device}")
 
     if device == ht_devices.cpu:
         return {
@@ -66,7 +63,7 @@ def default_dtypes(*, device=None):
 
     raise ValueError(f"Unsupported device: {device}")
 
-    
+
 def devices():
     """Returns a list of supported devices which are available at runtime."""
     if hasattr(ht_devices, "gpu"):
@@ -74,15 +71,14 @@ def devices():
     else:
         return (ht_devices.cpu,)
 
+
 def dtypes(*, device=None, kind=None):
     """Returns a dictionary of supported Array API data types"""
     if device is None:
         device = default_device()
-    
+
     if not isinstance(device, ht_devices.Device):
-        raise ValueError(
-            f"Device not understood: {device}"
-        )
+        raise ValueError(f"Device not understood: {device}")
 
     if kind is None:
         return {
@@ -148,4 +144,3 @@ def dtypes(*, device=None, kind=None):
             res |= dtypes(device=device, kind=k)
         return res
     raise ValueError(f"Unsupported kind: {kind}")
-


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR introduces the inspection utility described in the [array api standard](https://data-apis.org/array-api/latest/API_specification/inspection.html). It is required for the verification test suite to run.

Issue/s resolved: #2209

## Changes proposed:

- add _inspection.py

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

- API

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no
