### PR TITLE
Return indices as ht.int64 in ht.unique(..., return_inverse=True)

### DIFF
--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -3375,7 +3375,13 @@ def unique(
         )
         if isinstance(torch_output, tuple):
             heat_output = tuple(
-                factories.array(i, dtype=a.dtype, split=None, device=a.device, comm=a.comm)
+                factories.array(
+                    i,
+                    dtype=types.canonical_heat_type(i.dtype),
+                    split=None,
+                    device=a.device,
+                    comm=a.comm,
+                )
                 for i in torch_output
             )
         else:

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3687,7 +3687,7 @@ class TestManipulations(TestCase):
 
         torch_array = torch.tensor(
             [[1, 2], [2, 3], [1, 2], [2, 3], [1, 2]],
-            dtype=torch.int32,
+            dtype=torch.float32,
             device=self.device.torch_device,
         )
         data = ht.array(torch_array, split=0)
@@ -3697,6 +3697,8 @@ class TestManipulations(TestCase):
         self.assertTrue(
             (inv == ht.array(exp_inv.to(dtype=inv.larray.dtype), split=inv.split)).all()
         )
+        self.assertEqual(res.dtype, data.dtype)
+        self.assertEqual(inv.dtype, ht.int64)
 
         res, inv = ht.unique(data, return_inverse=True, axis=1)
         _, exp_inv = torch_array.unique(dim=1, return_inverse=True, sorted=True)
@@ -3720,7 +3722,7 @@ class TestManipulations(TestCase):
         res, inv = ht.unique(data_split_none, return_inverse=True, sorted=True)
         self.assertIsInstance(inv, ht.DNDarray)
         self.assertEqual(inv.split, None)
-        self.assertEqual(inv.dtype, data_split_none.dtype)
+        self.assertEqual(inv.dtype, ht.int64)
         self.assertEqual(inv.device, data_split_none.device)
         self.assertTrue(torch.equal(inv.larray, exp_inv.int()))
 

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3724,7 +3724,7 @@ class TestManipulations(TestCase):
         self.assertEqual(inv.split, None)
         self.assertEqual(inv.dtype, ht.int64)
         self.assertEqual(inv.device, data_split_none.device)
-        self.assertTrue(torch.equal(inv.larray, exp_inv.int()))
+        self.assertTrue(torch.equal(inv.larray, exp_inv))
 
         data_split_zero = ht.array(torch_array, split=0)
         res, inv = ht.unique(data_split_zero, return_inverse=True, sorted=True)


### PR DESCRIPTION
In the current main, the indices of unique elements are returned in the same data type as the input. This doesn't make sense and is not the behavior of numpy and torch. That is to say, in numpy and torch, we get:
```
>>> import numpy as np
>>> me = np.array([1., 2.])
>>> np.unique(me, return_inverse=True)
(array([1., 2.]), array([0, 1]))
```
meaning the index array is of integer type as appropriate for an index array, regardless of the type of the data.

This PR adapts the Heat API to the numpy one and returns the indices as integers by simply using the heat version of the torch type of each torch output.

The current behavior became an issue in #2199. There, I need to either force integer input or use any input type with this fix. I prefer this fix, but note that this needs to be merged before #2199.