### PR TITLE
Fix conda env script

### DIFF
--- a/scripts/heat_dev.yml
+++ b/scripts/heat_dev.yml
@@ -1,9 +1,8 @@
 name: heat_dev
 channels:
   - conda-forge
-  - defaults
 dependencies:
-- python>=3.11
+  - python>=3.11
   - openmpi
   - mpi4py>=3.1
   - h5py>=3.11


### PR DESCRIPTION
## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
Thanks, @christiandibuo for pointing this out! Indeed there was a typo that rendered the file unusable.
While at it, I removed the commercial `defaults` channel which we are not allowed to access free of charge.

Issue/s resolved: #2254 

## Changes proposed:

- remove defaults channel
- fix indentation


## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
 - Bug fix