### PR TITLE
Running ReceivePR and ci_full on changes to tests

### DIFF
--- a/.github/workflows/ReceivePR.yml
+++ b/.github/workflows/ReceivePR.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'heat/**'
+      - 'tests/**'
 
 jobs:
   build:

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -7,6 +7,7 @@ on:
       - stable
     paths:
       - 'heat/**'
+      - 'tests/**'
       - 'pyproject.toml'
       - '.github/workflows/ci_full.yaml'
 


### PR DESCRIPTION
We noticed that PRs that change tests but no other functionality such as #2257 don't trigger the codebase CI or the full CI.
However, we want them to! We just forgot to add the respective triggers to the workflows when moving the tests to their own directory in #2172. This PR adds the missing path-based triggers.