### PR TITLE
Expand `dev` optional dependencies to include everything required to run the entire test suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
           - '3.11' # Oldest supported
           - '3.14' # Latest stable
         mpi: [ 'openmpi' ]
-        install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
+        install-options: [ '.', '.[dev]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Oldest supported
           - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026

--- a/.github/workflows/ci_full.yaml
+++ b/.github/workflows/ci_full.yaml
@@ -23,7 +23,7 @@ jobs:
           - '3.13'
           - '3.14'
         mpi: [ 'openmpi' ]
-        install-options: [ '.', '.[hdf5,netcdf,pandas,zarr]' ]
+        install-options: [ '.', '.[dev]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
           - 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,12 @@ dev = [
 
     # Benchmarking
     "perun",
+
+    # Additional dependencies required to run the entire test suite
+    "h5py>=3.11",
+    "netCDF4>=1.7",
+    "zarr",
+    "pandas",
 ]
 
 docs = [

--- a/quick_start.md
+++ b/quick_start.md
@@ -86,7 +86,7 @@ conda activate heat_dev
 3. Install Heat in editable mode:
 
 ```bash
-pip install -e '.[hdf5, netcdf, zarr, dev]'
+pip install -e '.[dev]'
 ```
 
 #### Method B: manual dependency management (pip)
@@ -105,7 +105,7 @@ source heat_dev/bin/activate
 3. Install Heat in editable mode:
 
 ```bash
-pip install -e '.[hdf5, netcdf, zarr, dev]'
+pip install -e '.[dev]'
 ```
 
 ### Repository syncing


### PR DESCRIPTION
In this PR, all additional dependencies are added to the `dev` optional dependencies that are needed to run any tests.
For now this is just IO stuff, but in #2199, we will then add scikit-learn and use it as reference in the tests. This is actually the reason why we do this PR. Heat doesn't need scikit-learn because it should be used as a kind of replacement for it. So we need a streamlined set of optional dependencies for the tests. Since developers are supposed to run the tests, @JuanPedroGHM suggested to just put this in the `dev` optional dependencies.

This PR is only half of it. We still need to adapt the codebase CI. I am not sure on which branch exactly I should edit what exactly. Can you take care of it, @mtar?