### PR TITLE
Restricting zarr version to <3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
 ## IO Modules
 hdf5 = ["h5py>=3.11"]
 netcdf = ["netCDF4>=1.7"]
-zarr = ["zarr"]
+zarr = ["zarr<3.2"]
 pandas = ["pandas"]
 
 ## Examples and tutorial
@@ -86,7 +86,7 @@ dev = [
     # Additional dependencies required to run the entire test suite
     "h5py>=3.11",
     "netCDF4>=1.7",
-    "zarr",
+    "zarr<3.2",
     "pandas",
 ]
 


### PR DESCRIPTION
Restricted zarr Version to <3.2, temporary fix for #2272 