### PR TITLE
Fix for double counting error from #2093

### DIFF
--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -841,9 +841,9 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
 
         # check for remaining dims in the outside dimensions
         rem_a_out, rem_b_out = 0, 0
-        if a.lshape[-2] % mB != 0 or (kB == 1 and a.lshape[-2] != 1):
+        if a.lshape[-2] % mB != 0 or (mB == 1 and a.lshape[-2] != 1):
             rem_a_out = 1
-        if b.lshape[-1] % nB != 0 or (kB == 1 and b.lshape[-1] != 1):
+        if b.lshape[-1] % nB != 0 or (nB == 1 and b.lshape[-1] != 1):
             rem_b_out = 1
 
         # get the flags from all processes

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -843,7 +843,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         rem_a_out, rem_b_out = 0, 0
         if a.lshape[-2] % mB != 0 or (mB == 1 and a.lshape[-2] != 1):
             rem_a_out = 1
-        if b.lshape[-1] % nB != 0 or (nB == 1 and b.lshape[-1] != 1):
+        if b.lshape[-1] % nB != 0 or (kB == 1 and b.lshape[-1] != 1):
             rem_b_out = 1
 
         # get the flags from all processes

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -843,7 +843,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         rem_a_out, rem_b_out = 0, 0
         if a.lshape[-2] % mB != 0 or (mB == 1 and a.lshape[-2] != 1):
             rem_a_out = 1
-        if b.lshape[-1] % nB != 0 or (kB == 1 and b.lshape[-1] != 1):
+        if b.lshape[-1] % nB != 0 or (nB == 1 and b.lshape[-1] != 1):
             rem_b_out = 1
 
         # get the flags from all processes

--- a/tests/core/linalg/test_basics.py
+++ b/tests/core/linalg/test_basics.py
@@ -996,7 +996,7 @@ class TestLinalgBasics(TestCase):
             B = ht.ones(shape[::-1], split=split)
 
             C = A @ B
-            assert ht.allclose(C, shape[-1])
+            self.assertTrue(ht.allclose(C, shape[-1]))
         else:
             self.skipTest('This edge case requires four tasks')
 

--- a/tests/core/linalg/test_basics.py
+++ b/tests/core/linalg/test_basics.py
@@ -985,6 +985,21 @@ class TestLinalgBasics(TestCase):
                     # self.assertTrue(ht.allclose(ret_batched, c, 1e-2))
                     self.assertTrue(max_diff < 1e-4)
 
+    def test_matmul_edge_case_1(self):
+        # test edge cases as documented in #2093
+
+        if ht.comm.size == 4:
+            split = 0
+            shape = (8, 6)
+
+            A = ht.ones(shape, split=split)
+            B = ht.ones(shape[::-1], split=split)
+
+            C = A @ B
+            assert ht.allclose(C, shape[-1])
+        else:
+            self.skipTest('This edge case requires four tasks')
+
     def test_matrix_norm(self):
         a = ht.arange(9, dtype=ht.float) - 4
         b = a.reshape((3, 3))

--- a/tests/core/linalg/test_basics.py
+++ b/tests/core/linalg/test_basics.py
@@ -996,7 +996,14 @@ class TestLinalgBasics(TestCase):
             B = ht.ones(shape[::-1], split=split)
 
             C = A @ B
-            self.assertTrue(ht.allclose(C, shape[-1]))
+            self.assertTrue(ht.allclose(C, A.shape[-1]))
+
+            A = A.T
+            B = B.T
+            C = A @ B
+            self.assertEqual(A.split, 1)
+            self.assertEqual(C.split, 1)
+            self.assertTrue(ht.allclose(C, A.shape[-1]))
         else:
             self.skipTest('This edge case requires four tasks')
 


### PR DESCRIPTION
This PR fixes one of the issues in #2093, namely the bug with running code:
```python
import heat as ht

split = 0
shape = (4, 3)

A = ht.ones(shape, split=split)
B = ht.ones(shape[::-1], split=split)

C = A @ B
C_glob = (A.resplit(None) @ B.resplit(None)).resplit(C.split)

print(C)
print(C_glob)
```
which gives an output when run with two tasks:
```
DNDarray([[3., 3., 3., 3.],
          [6., 6., 6., 6.],
          [3., 3., 3., 3.],
          [6., 6., 6., 6.]], dtype=ht.float32, device=cpu:0, split=0)
DNDarray([[3., 3., 3., 3.],
          [3., 3., 3., 3.],
          [3., 3., 3., 3.],
          [3., 3., 3., 3.]], dtype=ht.float32, device=cpu:0, split=0)
```

This PR implements an analogous test with four tasks. I first pushed the test without the fix to record that the test fails on the current main. Then, I pushed the fix, which is just two small typos.

This does not close the original issue because it doesn't resolve all the issues, but I thought this is something we can merge quickly and independently of a larger refactor and fix for the other problems, which will come later.