### PR TITLE
Bug report: Isolate edge case `heat.array([[5]])` failing on AMD

### DIFF
--- a/tests/core/test_factories.py
+++ b/tests/core/test_factories.py
@@ -400,6 +400,11 @@ class TestFactories(TestCase):
                 dim = self.get_rank() + 1
                 ht.array([[0] * dim] * dim, is_split=0)
 
+        # edge case: single element in 2D array
+        a = ht.array([[5]])
+        self.assertTrue(np.allclose(a.shape, (1, 1)))
+        self.assertEqual(a[0,0], 5)
+
     def test_array_implicit_device_selection(self):
         # test implicit device selection
         for device in ['cpu', 'cuda', 'mps']:


### PR DESCRIPTION
This is a report of the bug in [this CI run](https://codebase.helmholtz.cloud/helmholtz-analytics/ci/-/jobs/3024934), where
```python
TypeError: invalid data of type <class 'list'>
```
is raised in `heat.factories.array` during the simple call `heat.array([[5]])`.
This appears to happen only on AMD GPUs. And can't be reproduced on CPUs or NVIDIA GPUs.

It's not marked as draft in order to trigger the codebase CI.