### PR TITLE
Quick fix for failing 2D convolution test

### DIFF
--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -1059,4 +1059,5 @@ class TestSignal(TestCase):
 
             if not self.is_mps:
                 conv = ht.convolve2d(float(1),float(5),stride=(stride,stride))
-                self.assertTrue(ht.equal(ht.array([[5]]), conv))
+                self.assertTrue(np.allclose(conv.shape, (1, 1)))
+                self.assertEqual(conv[0,0], 5)

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -1059,5 +1059,6 @@ class TestSignal(TestCase):
 
             if not self.is_mps:
                 conv = ht.convolve2d(float(1),float(5),stride=(stride,stride))
+                expect = ht.ones_like(conv) * 5
                 self.assertEqual(conv.shape, (1, 1))
-                self.assertEqual(conv[0,0], 5)
+                self.assertTrue(ht.allclose(conv, expect))

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -1059,5 +1059,5 @@ class TestSignal(TestCase):
 
             if not self.is_mps:
                 conv = ht.convolve2d(float(1),float(5),stride=(stride,stride))
-                self.assertTrue(np.allclose(conv.shape, (1, 1)))
+                self.assertEqual(conv.shape, (1, 1))
                 self.assertEqual(conv[0,0], 5)


### PR DESCRIPTION
As reported in #2280, there is a mysterious failure in the 2D convolution tests.
I hope we can circumvent this bug in this way, which is just a slightly longer test for the same thing as before.
Sadly, I cannot test this outside of a non-draft PR because I don't have access to the hardware in another way..