### PR TITLE
Refactor matmul to avoid index tensors on GPU

### DIFF
--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -881,16 +881,14 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         c_index_map_comm = comm.Iallreduce(MPI.IN_PLACE, c_index_map, MPI.SUM)
 
         if a.split == ndim - 2:
-            a_block_map = torch.zeros(
+            a_block_map = np.zeros(
                 (comm.size, a.shape[-2] // mB // comm.size, a.shape[-1] // kB, 2),
                 dtype=torch.int,
-                device=tdev,
             )
         elif a.split == ndim - 1:  # else should be equivalent at this point
-            a_block_map = torch.zeros(
+            a_block_map = np.zeros(
                 (comm.size, a.shape[-2] // mB, a.shape[-1] // kB // comm.size, 2),
                 dtype=torch.int,
-                device=tdev,
             )
         # units-> [process, dim0 block number, dim1 block number, start coord] **indices are local
 
@@ -902,7 +900,6 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
             a_d1_1s_flag = True
 
         index_map_comm.Wait()
-        a_block_map = a_block_map.cpu().numpy()
         for pr in range(comm.size):
             start0 = index_map[pr, 0, 0, 0].item()
             stop0 = index_map[pr, 0, 0, 1].item()
@@ -919,7 +916,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                 ):
                     # loop over the number of blocks in the 1st dimension
                     a_block_map[pr, dim0, dim1] = (dim0 * mB, dim1 * kB)
-        a_block_map = torch.tensor(a_block_map, device=tdev, dtype=torch.int)
+        a_block_map = torch.from_numpy(a_block_map)
         rem_map_comm.Wait()
 
         if b.split == ndim - 2:
@@ -2263,7 +2260,7 @@ def __mm_c_block_setter(
     c : torch.Tensor
         the local data for C
     """
-    # # (int, int, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, int, int, int, int, torch.Tensor) -> None
+    # (int, int, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, int, int, int, int, torch.Tensor) -> None
     shp_b = b_block_map.shape
     offset_a = b_proc * shp_b[1] if b_proc != 0 else 0
     shp_a = a_block_map.shape
@@ -2271,13 +2268,13 @@ def __mm_c_block_setter(
     # offsets are the number of blocks in the multiplication direction on previous nodes
 
     for bl_1_a in (
-        torch.arange(offset_a, offset_a + shp_b[1], dtype=torch.long, device=c.device)
+        torch.arange(offset_a, offset_a + shp_b[1], dtype=torch.long)
         if b_split == 0
         else torch.arange(a_block_map[a_proc].shape[0], dtype=torch.long, device=c.device)
     ):
         # offset is the number of blocks on the previous node in the direction of multiplication
         for bl_0_a in torch.arange(
-            a_block_map[a_proc].shape[0], dtype=torch.long, device=c.device
+            a_block_map[a_proc].shape[0], dtype=torch.long
         ):  # dim0
             for bl_1_b in torch.arange(
                 b_block_map[b_proc].shape[1], dtype=torch.long, device=c.device

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -830,9 +830,10 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
 
         # get the lshape map to determine what needs to be sent where as well as M and N
         # lshape map dims -> {node, a=0 | b=1, lshape}
-        lshape_map = torch.zeros((comm.size, 2, ndim), dtype=int, device=tdev)
-        lshape_map[comm.rank, 0, :] = torch.tensor(a.lshape, device=tdev)
-        lshape_map[comm.rank, 1, :] = torch.tensor(b.lshape, device=tdev)
+        lshape_map = np.zeros((comm.size, 2, ndim), dtype=int)
+        lshape_map[comm.rank, 0, :] = a.lshape
+        lshape_map[comm.rank, 1, :] = b.lshape
+        lshape_map = torch.from_numpy(lshape_map)
         comm.Allreduce(MPI.IN_PLACE, lshape_map, MPI.SUM)
 
         # find mB (first blocking dim for a) and nB (2nd blocking dim for b)
@@ -849,19 +850,22 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         # get the flags from all processes
         # rem_map dims guide -> {process number, a/b (0/1), dim0/dim1 (0/1), True/False (1/0)
         #   if there is a remainder in this dimension
-        rem_map = torch.zeros((comm.size, 2, 2))
-        rem_map[comm.rank, 0, :] = torch.tensor((rem_a_out, rem_a), device=tdev)
-        rem_map[comm.rank, 1, :] = torch.tensor((rem_b, rem_b_out), device=tdev)
+        rem_map = np.zeros((comm.size, 2, 2))
+        rem_map[comm.rank, 0, :] = (rem_a_out, rem_a)
+        rem_map[comm.rank, 1, :] = (rem_b, rem_b_out)
+        rem_map = torch.from_numpy(rem_map)
         rem_map_comm = comm.Iallreduce(MPI.IN_PLACE, rem_map, MPI.SUM)
 
         # index_map dims guide -> {process number, a=0/b=1, relevant 1st index, 2nd index}
-        index_map = torch.zeros((comm.size, 2, 2, 2), dtype=int, device=tdev)
+        index_map = np.zeros((comm.size, 2, 2, 2), dtype=int)
         a_idx = comm.chunk(a.shape, a.split)[2]
-        index_map[comm.rank, 0, 0] = torch.tensor((a_idx[-2].start, a_idx[-2].stop), device=tdev)
-        index_map[comm.rank, 0, 1] = torch.tensor((a_idx[-1].start, a_idx[-1].stop), device=tdev)
+        index_map[comm.rank, 0, 0] = (a_idx[-2].start, a_idx[-2].stop)
+        index_map[comm.rank, 0, 1] = (a_idx[-1].start, a_idx[-1].stop)
         b_idx = comm.chunk(b.shape, b.split)[2]
-        index_map[comm.rank, 1, 0] = torch.tensor((b_idx[-2].start, b_idx[-2].stop), device=tdev)
-        index_map[comm.rank, 1, 1] = torch.tensor((b_idx[-1].start, b_idx[-1].stop), device=tdev)
+        index_map[comm.rank, 1, 0] = (b_idx[-2].start, b_idx[-2].stop)
+        index_map[comm.rank, 1, 1] = (b_idx[-1].start, b_idx[-1].stop)
+        index_map = torch.from_numpy(index_map)
+
         index_map_comm = comm.Iallreduce(MPI.IN_PLACE, index_map, MPI.SUM)
 
         # output: c = a @ b

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -833,12 +833,11 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         lshape_map = np.zeros((comm.size, 2, ndim), dtype=int)
         lshape_map[comm.rank, 0, :] = a.lshape
         lshape_map[comm.rank, 1, :] = b.lshape
-        lshape_map = torch.from_numpy(lshape_map)
         comm.Allreduce(MPI.IN_PLACE, lshape_map, MPI.SUM)
 
         # find mB (first blocking dim for a) and nB (2nd blocking dim for b)
-        mB = lshape_map[:, 0, -2].min().item()  # smallest number of local rows of a on a node
-        nB = lshape_map[:, 1, -1].min().item()  # smallest number of local columns of b on a node
+        mB = lshape_map[:, 0, -2].min()  # smallest number of local rows of a on a node
+        nB = lshape_map[:, 1, -1].min()  # smallest number of local columns of b on a node
 
         # check for remaining dims in the outside dimensions
         rem_a_out, rem_b_out = 0, 0
@@ -1013,7 +1012,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                     b_lp_data[pr] = b.larray.clone()
                 else:
                     b_lp_data[pr] = torch.zeros(
-                        (*batch_shape, lshape_map[pr, 1, -2].item(), lshape_map[pr, 1, -1].item()),
+                        (*batch_shape, lshape_map[pr, 1, -2], lshape_map[pr, 1, -1]),
                         dtype=b.dtype.torch_type(),
                         device=tdev,
                     )
@@ -1113,7 +1112,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                     b_lp_data[pr] = b.larray.clone()
                 else:
                     b_lp_data[pr] = torch.empty(
-                        (*batch_shape, lshape_map[pr, 1, -2].item(), lshape_map[pr, 1, -1].item()),
+                        (*batch_shape, lshape_map[pr, 1, -2], lshape_map[pr, 1, -1]),
                         dtype=b.dtype.torch_type(),
                         device=tdev,
                     )
@@ -1172,7 +1171,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                     a_lp_data[pr] = a.larray.clone()
                 else:
                     a_lp_data[pr] = torch.zeros(
-                        (*batch_shape, lshape_map[pr, 0, -2].item(), lshape_map[pr, 0, -1].item()),
+                        (*batch_shape, lshape_map[pr, 0, -2], lshape_map[pr, 0, -1]),
                         dtype=a.dtype.torch_type(),
                         device=tdev,
                     )

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -881,12 +881,12 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         c_index_map_comm = comm.Iallreduce(MPI.IN_PLACE, c_index_map, MPI.SUM)
 
         if a.split == ndim - 2:
-            a_block_map = np.zeros(
+            a_block_map = torch.zeros(
                 (comm.size, a.shape[-2] // mB // comm.size, a.shape[-1] // kB, 2),
                 dtype=torch.int,
             )
         elif a.split == ndim - 1:  # else should be equivalent at this point
-            a_block_map = np.zeros(
+            a_block_map = torch.zeros(
                 (comm.size, a.shape[-2] // mB, a.shape[-1] // kB // comm.size, 2),
                 dtype=torch.int,
             )
@@ -900,6 +900,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
             a_d1_1s_flag = True
 
         index_map_comm.Wait()
+        a_block_map = a_block_map.numpy() # temporarily cast to numpy for faster memory access
         for pr in range(comm.size):
             start0 = index_map[pr, 0, 0, 0].item()
             stop0 = index_map[pr, 0, 0, 1].item()
@@ -933,13 +934,11 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
             b_block_map = torch.zeros(
                 (comm.size, b.shape[-2] // kB // comm.size, b.shape[-1] // nB, 2),
                 dtype=torch.int,
-                device=tdev,
             )
         else:  # b split 1
             b_block_map = torch.zeros(
                 (comm.size, b.shape[-2] // kB, b.shape[-1] // nB // comm.size, 2),
                 dtype=torch.int,
-                device=tdev,
             )
         # units-> [process, dim0 block number, dim1 block number, start coord] **indices are local
 
@@ -950,6 +949,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         if any(lshape_map[:, 1, :][:, -1] == 1):
             b_d1_1s_flag = True
 
+        b_block_map = b_block_map.numpy() # temporarily cast to numpy for faster memory access
         for pr in range(b.comm.size):
             start0 = index_map[pr, 1, 0, 0].item()
             stop0 = index_map[pr, 1, 0, 1].item()
@@ -966,9 +966,8 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                     if b_d1_1s_flag
                     else (stop1 - start1) // nB
                 ):
-                    b_block_map[pr, dim0, dim1] = torch.tensor(
-                        (dim0 * kB, dim1 * nB), dtype=torch.int, device=tdev
-                    )
+                    b_block_map[pr, dim0, dim1] = (dim0 * kB, dim1 * nB)
+        b_block_map = torch.from_numpy(b_block_map)
 
         if a.split == ndim - 1:
             cnt = 0
@@ -2270,20 +2269,20 @@ def __mm_c_block_setter(
     for bl_1_a in (
         torch.arange(offset_a, offset_a + shp_b[1], dtype=torch.long)
         if b_split == 0
-        else torch.arange(a_block_map[a_proc].shape[0], dtype=torch.long, device=c.device)
+        else torch.arange(a_block_map[a_proc].shape[0], dtype=torch.long)
     ):
         # offset is the number of blocks on the previous node in the direction of multiplication
         for bl_0_a in torch.arange(
             a_block_map[a_proc].shape[0], dtype=torch.long
         ):  # dim0
             for bl_1_b in torch.arange(
-                b_block_map[b_proc].shape[1], dtype=torch.long, device=c.device
+                b_block_map[b_proc].shape[1], dtype=torch.long
             ):
                 for bl_0_b in (
-                    torch.arange(offset_b, offset_b + shp_a[1], dtype=torch.long, device=c.device)
+                    torch.arange(offset_b, offset_b + shp_a[1], dtype=torch.long)
                     if a_split == 1
                     else torch.arange(
-                        b_block_map[b_proc].shape[0], dtype=torch.long, device=c.device
+                        b_block_map[b_proc].shape[0], dtype=torch.long
                     )
                 ):
                     # this offset is the same as before but for b

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -852,7 +852,6 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         rem_map = np.zeros((comm.size, 2, 2), dtype=int)
         rem_map[comm.rank, 0, :] = (rem_a_out, rem_a)
         rem_map[comm.rank, 1, :] = (rem_b, rem_b_out)
-        rem_map = torch.from_numpy(rem_map)
         rem_map_comm = comm.Iallreduce(MPI.IN_PLACE, rem_map, MPI.SUM)
 
         # index_map dims guide -> {process number, a=0/b=1, relevant 1st index, 2nd index}
@@ -983,12 +982,12 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
             # need to send b here and not a
             #   the rows on 'a' are complete, and the columns of 'b' are split
             # locations of the remainders in b
-            b_rem_locs0 = torch.nonzero(rem_map[:, 1, 0] == 1, as_tuple=False)
-            a_rem_locs0 = torch.nonzero(rem_map[:, 0, 0] == 1, as_tuple=False)
+            b_rem_locs0 = np.array(np.nonzero(rem_map[:, 1, 0] == 1)).T
+            a_rem_locs0 = np.array(np.nonzero(rem_map[:, 0, 0] == 1)).T
             # remainders for a in the
-            a_node_rem_s0 = a.larray[..., :mB, kB : (kB + 1) * b_rem_locs0.numel() : kB + 1]
+            a_node_rem_s0 = a.larray[..., :mB, kB : (kB + 1) * b_rem_locs0.size : kB + 1]
             b_rem = torch.empty(
-                (*batch_shape, b_rem_locs0.numel(), b.lshape[-1]),
+                (*batch_shape, b_rem_locs0.size, b.lshape[-1]),
                 dtype=a.dtype.torch_type(),
                 device=tdev,
             )
@@ -1045,7 +1044,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                         b_rem[..., pr - 1, :] = b_lp_data[pr - 1][..., -1, :]
 
                     # this loop is to take care of the remainders in dim0 of a
-                    if a_rem_locs0.nelement() != 0 and r_loc is not None:
+                    if a_rem_locs0.size != 0 and r_loc is not None:
                         st = index_map[pr - 1, 1, 0, 0]
                         sp = index_map[pr - 1, 1, 0, 1]
 
@@ -1077,7 +1076,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                         b_rem[..., pr, :] = b_lp_data[pr][..., -1, :]
 
                     # this loop is to take care of the remainders in the 0th dimension of A
-                    if a_rem_locs0.nelement() != 0 and r_loc is not None:
+                    if a_rem_locs0.size != 0 and r_loc is not None:
                         st = index_map[pr, 1, 0, 0]
                         sp = index_map[pr, 1, 0, 1]  # linear algebra dimension 0/1
 
@@ -1094,7 +1093,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
 
                     # set the final blocks on the last loop, then adjust for the
                     # the remainders which were collected in b_rem
-                    if b_rem_locs0.numel():
+                    if b_rem_locs0.size:
                         c.larray[..., : a_node_rem_s0.shape[-2], :] += (
                             a_node_rem_s0 @ b_rem
                         )  # shouldnt shape[0] always be mB?
@@ -1144,13 +1143,13 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
             # for this case, a is sent to b
             #   this is because 'b' has complete columns and the rows of 'a' are split
             # locations of the remainders in b
-            b_rem_locs1 = torch.nonzero(rem_map[:, 1, 1] == 1, as_tuple=False)
-            a_rem_locs1 = torch.nonzero(rem_map[:, 0, 1] == 1, as_tuple=False)
-            b_node_rem_s1 = b.larray[..., kB : (kB + 1) * a_rem_locs1.numel() : kB + 1, :nB]
+            b_rem_locs1 = np.array(np.nonzero(rem_map[:, 1, 1] == 1)).T
+            a_rem_locs1 = np.array(np.nonzero(rem_map[:, 0, 1] == 1)).T
+            b_node_rem_s1 = b.larray[..., kB : (kB + 1) * a_rem_locs1.size : kB + 1, :nB]
             # b_node_rem_s1 -> remainders for a in the
 
             a_rem = torch.empty(
-                (*batch_shape, a.lshape[-2], a_rem_locs1.numel()),
+                (*batch_shape, a.lshape[-2], a_rem_locs1.size),
                 dtype=b.dtype.torch_type(),
                 device=tdev,
             )
@@ -1200,7 +1199,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                         # takes care of the remainders in b as well as dim0 of a
                         a_rem[..., pr - 1] = a_lp_data[pr - 1][..., -1]
                     # this loop is to take care of the remainders in dim1 of B
-                    if b_rem_locs1.nelement() != 0 and r_loc is not None:
+                    if b_rem_locs1.size != 0 and r_loc is not None:
                         st = index_map[pr - 1, 0, 1, 0]
                         sp = index_map[pr - 1, 0, 1, 1]
 
@@ -1232,14 +1231,14 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                         # this is to save the data from B required by the remainders from dim1 of A
                         a_rem[..., pr] = a_lp_data[pr][..., -1]
                     # this loop is to take care of the remainders in the 0th dimension of A
-                    if b_rem_locs1.nelement() != 0 and r_loc is not None:
+                    if b_rem_locs1.size != 0 and r_loc is not None:
                         st = index_map[pr, 0, 1, 0]
                         sp = index_map[pr, 0, 1, 1]
                         c.larray[..., r_loc.item()] += (a_lp_data[pr] @ r[..., st:sp, :]).squeeze(
                             -1
                         )
                     # set the final blocks on the last loop, then adjust for the the remainders which were collected in b_rem
-                    if a_rem_locs1.numel():
+                    if a_rem_locs1.size:
                         c.larray[..., : b_node_rem_s1.shape[-1]] += a_rem @ b_node_rem_s1
                     del a_lp_data[pr]
 
@@ -1247,9 +1246,9 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         elif a.split == ndim - 1 and b.split == ndim - 2:
             # todo: this may create the full matrix on evey process, issue #360
             # for this case, only a sum is needed at the end
-            a_rem_locs1 = torch.nonzero(rem_map[:, 0, 1] == 1, as_tuple=False)
+            a_rem_locs1 = np.array(np.nonzero(rem_map[:, 0, 1] == 1)).T
             # locations of the remainders in b
-            b_rem_locs0 = torch.nonzero(rem_map[:, 1, 0] == 1, as_tuple=False)
+            b_rem_locs0 = np.array(np.nonzero(rem_map[:, 1, 0] == 1)).T
             res = torch.zeros(
                 (*batch_shape, a.gshape[-2], b.gshape[-1]), dtype=c_type.torch_type(), device=tdev
             )

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -922,7 +922,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
             # there are between the blocks in the first dim of B
             cnt = 0
             for r in rem_map[:, 1, 0]:
-                if r.item():
+                if r > 0:
                     cnt += 1
                     # why increment by exactly 1? what can we assume about the lshapes on different nodes?
                     # can the sizes in the split dimension differ by more than 1?
@@ -970,7 +970,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
             cnt = 0
             # this loop will push the blocks in B to adjust for the remainders in A
             for r in rem_map[:, 0, 1]:
-                if r.item():
+                if r > 0:
                     cnt += 1
                     b_block_map[:, cnt:, :, 0] += 1
 
@@ -1048,9 +1048,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                         st = index_map[pr - 1, 1, 0, 0]
                         sp = index_map[pr - 1, 1, 0, 1]
 
-                        c.larray[..., r_loc.item(), :] += (
-                            r[..., st:sp] @ b_lp_data[pr - 1]
-                        ).squeeze(-2)
+                        c.larray[..., r_loc, :] += (r[..., st:sp] @ b_lp_data[pr - 1]).squeeze(-2)
                     del b_lp_data[pr - 1]
 
                 # need to wait if its the last loop, also need to collect the remainders
@@ -1085,11 +1083,9 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                         if False:
                             st1 = index_map[pr, 1, 1, 0]
                             sp1 = index_map[pr, 1, 1, 1]
-                            c.larray[..., r_loc.item(), st1:sp1] += r[..., st:sp] @ b_lp_data[pr]
+                            c.larray[..., r_loc, st1:sp1] += r[..., st:sp] @ b_lp_data[pr]
                         else:
-                            c.larray[..., r_loc.item(), :] += (
-                                r[..., st:sp] @ b_lp_data[pr]
-                            ).squeeze(-2)
+                            c.larray[..., r_loc, :] += (r[..., st:sp] @ b_lp_data[pr]).squeeze(-2)
 
                     # set the final blocks on the last loop, then adjust for the
                     # the remainders which were collected in b_rem
@@ -1203,9 +1199,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                         st = index_map[pr - 1, 0, 1, 0]
                         sp = index_map[pr - 1, 0, 1, 1]
 
-                        c.larray[..., r_loc.item()] += (
-                            a_lp_data[pr - 1] @ r[..., st:sp, :]
-                        ).squeeze(-1)
+                        c.larray[..., r_loc] += (a_lp_data[pr - 1] @ r[..., st:sp, :]).squeeze(-1)
 
                     del a_lp_data[pr - 1]
 
@@ -1234,9 +1228,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                     if b_rem_locs1.size != 0 and r_loc is not None:
                         st = index_map[pr, 0, 1, 0]
                         sp = index_map[pr, 0, 1, 1]
-                        c.larray[..., r_loc.item()] += (a_lp_data[pr] @ r[..., st:sp, :]).squeeze(
-                            -1
-                        )
+                        c.larray[..., r_loc] += (a_lp_data[pr] @ r[..., st:sp, :]).squeeze(-1)
                     # set the final blocks on the last loop, then adjust for the the remainders which were collected in b_rem
                     if a_rem_locs1.size:
                         c.larray[..., : b_node_rem_s1.shape[-1]] += a_rem @ b_node_rem_s1

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -902,6 +902,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
             a_d1_1s_flag = True
 
         index_map_comm.Wait()
+        a_block_map = a_block_map.cpu().numpy()
         for pr in range(comm.size):
             start0 = index_map[pr, 0, 0, 0].item()
             stop0 = index_map[pr, 0, 0, 1].item()
@@ -917,9 +918,8 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                     (stop1 - start1) // kB // comm.size if a_d1_1s_flag else (stop1 - start1) // kB
                 ):
                     # loop over the number of blocks in the 1st dimension
-                    a_block_map[pr, dim0, dim1] = torch.tensor(
-                        (dim0 * mB, dim1 * kB), dtype=torch.int, device=tdev
-                    )
+                    a_block_map[pr, dim0, dim1] = (dim0 * mB, dim1 * kB)
+        a_block_map = torch.tensor(a_block_map, device=tdev, dtype=torch.int)
         rem_map_comm.Wait()
 
         if b.split == ndim - 2:

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -863,7 +863,6 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         b_idx = comm.chunk(b.shape, b.split)[2]
         index_map[comm.rank, 1, 0] = (b_idx[-2].start, b_idx[-2].stop)
         index_map[comm.rank, 1, 1] = (b_idx[-1].start, b_idx[-1].stop)
-        index_map = torch.from_numpy(index_map)
 
         index_map_comm = comm.Iallreduce(MPI.IN_PLACE, index_map, MPI.SUM)
 
@@ -901,10 +900,10 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         index_map_comm.Wait()
         a_block_map = a_block_map.numpy()  # temporarily cast to numpy for faster memory access
         for pr in range(comm.size):
-            start0 = index_map[pr, 0, 0, 0].item()
-            stop0 = index_map[pr, 0, 0, 1].item()
-            start1 = index_map[pr, 0, 1, 0].item()
-            stop1 = index_map[pr, 0, 1, 1].item()
+            start0 = index_map[pr, 0, 0, 0]
+            stop0 = index_map[pr, 0, 0, 1]
+            start1 = index_map[pr, 0, 1, 0]
+            stop1 = index_map[pr, 0, 1, 1]
 
             # maybe we could use torch.arange instead of this nested loop
             for dim0 in range(
@@ -950,10 +949,10 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
 
         b_block_map = b_block_map.numpy()  # temporarily cast to numpy for faster memory access
         for pr in range(b.comm.size):
-            start0 = index_map[pr, 1, 0, 0].item()
-            stop0 = index_map[pr, 1, 0, 1].item()
-            start1 = index_map[pr, 1, 1, 0].item()
-            stop1 = index_map[pr, 1, 1, 1].item()
+            start0 = index_map[pr, 1, 0, 0]
+            stop0 = index_map[pr, 1, 0, 1]
+            start1 = index_map[pr, 1, 1, 0]
+            stop1 = index_map[pr, 1, 1, 1]
 
             # loop over the number of blocks in the 0th dimension
             for dim0 in range(
@@ -1047,8 +1046,8 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
 
                     # this loop is to take care of the remainders in dim0 of a
                     if a_rem_locs0.nelement() != 0 and r_loc is not None:
-                        st = index_map[pr - 1, 1, 0, 0].item()
-                        sp = index_map[pr - 1, 1, 0, 1].item()
+                        st = index_map[pr - 1, 1, 0, 0]
+                        sp = index_map[pr - 1, 1, 0, 1]
 
                         c.larray[..., r_loc.item(), :] += (
                             r[..., st:sp] @ b_lp_data[pr - 1]
@@ -1079,14 +1078,14 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
 
                     # this loop is to take care of the remainders in the 0th dimension of A
                     if a_rem_locs0.nelement() != 0 and r_loc is not None:
-                        st = index_map[pr, 1, 0, 0].item()
-                        sp = index_map[pr, 1, 0, 1].item()  # linear algebra dimension 0/1
+                        st = index_map[pr, 1, 0, 0]
+                        sp = index_map[pr, 1, 0, 1]  # linear algebra dimension 0/1
 
                         # code not reachable?
                         # if split_01_flag:
                         if False:
-                            st1 = index_map[pr, 1, 1, 0].item()
-                            sp1 = index_map[pr, 1, 1, 1].item()
+                            st1 = index_map[pr, 1, 1, 0]
+                            sp1 = index_map[pr, 1, 1, 1]
                             c.larray[..., r_loc.item(), st1:sp1] += r[..., st:sp] @ b_lp_data[pr]
                         else:
                             c.larray[..., r_loc.item(), :] += (
@@ -1123,20 +1122,20 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                 if pr != 0:
                     req[pr - 1].Wait()
                     # after receiving the last loop's bcast
-                    st0 = index_map[pr - 1, 0, 0, 0].item()
-                    sp0 = index_map[pr - 1, 0, 0, 1].item() + 1
-                    st1 = index_map[pr - 1, 1, 1, 0].item()
-                    sp1 = index_map[pr - 1, 1, 1, 1].item()
+                    st0 = index_map[pr - 1, 0, 0, 0]
+                    sp0 = index_map[pr - 1, 0, 0, 1] + 1
+                    st1 = index_map[pr - 1, 1, 1, 0]
+                    sp1 = index_map[pr - 1, 1, 1, 1]
 
                     c.larray[..., : sp0 - st0, st1:sp1] += a.larray @ b_lp_data[pr - 1]
 
                     del b_lp_data[pr - 1]
                 if pr == comm.size - 1:
                     req[pr].Wait()
-                    st0 = index_map[pr, 0, 0, 0].item()
-                    sp0 = index_map[pr, 0, 0, 1].item() + 1
-                    st1 = index_map[pr, 1, 1, 0].item()
-                    sp1 = index_map[pr, 1, 1, 1].item()
+                    st0 = index_map[pr, 0, 0, 0]
+                    sp0 = index_map[pr, 0, 0, 1] + 1
+                    st1 = index_map[pr, 1, 1, 0]
+                    sp1 = index_map[pr, 1, 1, 1]
                     c.larray[..., : sp0 - st0, st1:sp1] += a.larray @ b_lp_data[pr]
                     del b_lp_data[pr]
 
@@ -1202,8 +1201,8 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                         a_rem[..., pr - 1] = a_lp_data[pr - 1][..., -1]
                     # this loop is to take care of the remainders in dim1 of B
                     if b_rem_locs1.nelement() != 0 and r_loc is not None:
-                        st = index_map[pr - 1, 0, 1, 0].item()
-                        sp = index_map[pr - 1, 0, 1, 1].item()
+                        st = index_map[pr - 1, 0, 1, 0]
+                        sp = index_map[pr - 1, 0, 1, 1]
 
                         c.larray[..., r_loc.item()] += (
                             a_lp_data[pr - 1] @ r[..., st:sp, :]
@@ -1234,8 +1233,8 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
                         a_rem[..., pr] = a_lp_data[pr][..., -1]
                     # this loop is to take care of the remainders in the 0th dimension of A
                     if b_rem_locs1.nelement() != 0 and r_loc is not None:
-                        st = index_map[pr, 0, 1, 0].item()
-                        sp = index_map[pr, 0, 1, 1].item()
+                        st = index_map[pr, 0, 1, 0]
+                        sp = index_map[pr, 0, 1, 1]
                         c.larray[..., r_loc.item()] += (a_lp_data[pr] @ r[..., st:sp, :]).squeeze(
                             -1
                         )

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -850,7 +850,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         # get the flags from all processes
         # rem_map dims guide -> {process number, a/b (0/1), dim0/dim1 (0/1), True/False (1/0)
         #   if there is a remainder in this dimension
-        rem_map = np.zeros((comm.size, 2, 2))
+        rem_map = np.zeros((comm.size, 2, 2), dtype=int)
         rem_map[comm.rank, 0, :] = (rem_a_out, rem_a)
         rem_map[comm.rank, 1, :] = (rem_b, rem_b_out)
         rem_map = torch.from_numpy(rem_map)
@@ -2266,19 +2266,15 @@ def __mm_c_block_setter(
     offset_b = a_proc * shp_a[2] if a_proc != 0 else 0
     # offsets are the number of blocks in the multiplication direction on previous nodes
 
-    for bl_1_a in (
-        torch.arange(offset_a, offset_a + shp_b[1], dtype=torch.long)
-        if b_split == 0
-        else torch.arange(a_block_map[a_proc].shape[0], dtype=torch.long)
-    ):
+    a_range_start = offset_a if b_split == 0 else 0
+    a_range_end = offset_a + shp_b[1] if b_split == 0 else a_block_map[a_proc].shape[0]
+    for bl_1_a in range(a_range_start, a_range_end):
         # offset is the number of blocks on the previous node in the direction of multiplication
-        for bl_0_a in torch.arange(a_block_map[a_proc].shape[0], dtype=torch.long):  # dim0
-            for bl_1_b in torch.arange(b_block_map[b_proc].shape[1], dtype=torch.long):
-                for bl_0_b in (
-                    torch.arange(offset_b, offset_b + shp_a[1], dtype=torch.long)
-                    if a_split == 1
-                    else torch.arange(b_block_map[b_proc].shape[0], dtype=torch.long)
-                ):
+        for bl_0_a in range(a_block_map[a_proc].shape[0]):
+            for bl_1_b in range(b_block_map[b_proc].shape[1]):
+                b_range_start = offset_b if a_split == 1 else 0
+                b_range_end = offset_b + shp_a[1] if a_split == 1 else b_block_map[b_proc].shape[0]
+                for bl_0_b in range(b_range_start, b_range_end):
                     # this offset is the same as before but for b
                     a_start1 = int(a_block_map[a_proc, bl_0_a, bl_1_a, 1].item())
                     a_start0 = int(a_block_map[a_proc, bl_0_a, bl_1_a, 0].item())

--- a/heat/core/linalg/basics.py
+++ b/heat/core/linalg/basics.py
@@ -900,7 +900,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
             a_d1_1s_flag = True
 
         index_map_comm.Wait()
-        a_block_map = a_block_map.numpy() # temporarily cast to numpy for faster memory access
+        a_block_map = a_block_map.numpy()  # temporarily cast to numpy for faster memory access
         for pr in range(comm.size):
             start0 = index_map[pr, 0, 0, 0].item()
             stop0 = index_map[pr, 0, 0, 1].item()
@@ -949,7 +949,7 @@ def matmul(a: DNDarray, b: DNDarray, allow_resplit: bool = False) -> DNDarray:
         if any(lshape_map[:, 1, :][:, -1] == 1):
             b_d1_1s_flag = True
 
-        b_block_map = b_block_map.numpy() # temporarily cast to numpy for faster memory access
+        b_block_map = b_block_map.numpy()  # temporarily cast to numpy for faster memory access
         for pr in range(b.comm.size):
             start0 = index_map[pr, 1, 0, 0].item()
             stop0 = index_map[pr, 1, 0, 1].item()
@@ -2272,18 +2272,12 @@ def __mm_c_block_setter(
         else torch.arange(a_block_map[a_proc].shape[0], dtype=torch.long)
     ):
         # offset is the number of blocks on the previous node in the direction of multiplication
-        for bl_0_a in torch.arange(
-            a_block_map[a_proc].shape[0], dtype=torch.long
-        ):  # dim0
-            for bl_1_b in torch.arange(
-                b_block_map[b_proc].shape[1], dtype=torch.long
-            ):
+        for bl_0_a in torch.arange(a_block_map[a_proc].shape[0], dtype=torch.long):  # dim0
+            for bl_1_b in torch.arange(b_block_map[b_proc].shape[1], dtype=torch.long):
                 for bl_0_b in (
                     torch.arange(offset_b, offset_b + shp_a[1], dtype=torch.long)
                     if a_split == 1
-                    else torch.arange(
-                        b_block_map[b_proc].shape[0], dtype=torch.long
-                    )
+                    else torch.arange(b_block_map[b_proc].shape[0], dtype=torch.long)
                 ):
                     # this offset is the same as before but for b
                     a_start1 = int(a_block_map[a_proc, bl_0_a, bl_1_a, 1].item())


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [x] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->
GPUs are fast in computation, but not in memory allocation. Allocating small tensors for indices on GPU doesn't yield any performance benefits. In fact, quite the opposite: CPUs tend to be much better optimized for fine-grained memory access than GPUs.

Also, numpy allows for more flexible memory allocation than torch. Consider the following case:
```python
a = np.zeros(4)
a[:2] = (1, 1)
```
This works fast and easy with numpy. On the other hand, with we torch need to do:
```python
b = torch.zeros(4, device='cuda')
b[:2] = torch.tensor((1, 1), device=b.device)
```
that is to say, we need to cast to torch tensor before we can assign. This incurs overhead because we need to allocate a tiny torch tensor on GPU before the assignment which the GPU is not optimized for. Even when staying on CPU, we have some overhead from allocating the tiny torch tensor. 

This PR, therefore, changes the instances of things like the previous example in matmul to:
```python
c = np.zeros(4)
c[:2] = (1, 1)
c = torch.from_numpy(c)
```
Two things are different: We stay on CPU, and we use the more efficient assignment from Numpy. Also, I find it easier to read  what is assigned here.

In order to determine the performance impact, I recorded some weak scaling on 4 A100 on Juwels booster with all split combinations:

<img width="1920" height="1440" alt="matmul_scaling_refactor" src="https://github.com/user-attachments/assets/3da2a791-f28f-4e26-8c76-4be6ddfa93e4" />

Solid lines are the current main and dashed lines are this branch. The black speedup line compares the split 00 combination.
For small matrix sizes, this has a large impact and yields a speedup of about 2, while for larger matrices this fine-grained optimization doesn't matter.
Performance-wise, this is not crucial to Heat because we are more focussed on weak scaling than strong scaling, but I think it's nice anyways.


## Changes proposed:

- Move tiny index tensors to CPU in matmul
- Use more efficient numpy assignment in matmul


## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->
Refactoring

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->
Changes are only to small index arrays, shouldn't impact the overall memory footprint meaningfully

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->
Improved performance for small matrix sizes
