### PR TITLE
Flaky flag corrections

### DIFF
--- a/.github/actions/gh_tests/action.yml
+++ b/.github/actions/gh_tests/action.yml
@@ -17,10 +17,6 @@ inputs:
     description: "MPI implementation to install."
     required: false
     default: "mpich"
-  install-options:
-    description: "Package install target/options for heat."
-    required: false
-    default: ".[dev]"
   pytorch-version:
     description: "Pinned torch/torchvision/torchaudio versions."
     required: false
@@ -48,14 +44,14 @@ runs:
         UV_SYSTEM_PYTHON: 1
       run: |
         uv pip install ${{ inputs.pytorch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
-        uv pip install ${{ inputs.install-options }}
+        uv pip install .[dev]
     - name: Install quick test dependencies
       if: ${{ inputs.mode == 'quick' }}
       shell: bash
       env:
         UV_SYSTEM_PYTHON: 1
       run: |
-        uv pip install ${{ inputs.install-options }}
+        uv pip install .[dev]
     # Running tests
     - name: Run serial tests
       shell: bash

--- a/.github/actions/gh_tests/action.yml
+++ b/.github/actions/gh_tests/action.yml
@@ -47,7 +47,7 @@ runs:
       env:
         UV_SYSTEM_PYTHON: 1
       run: |
-        uv pip install pytest flaky
+        uv pip install -e .[dev]
         uv pip install ${{ inputs.pytorch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
         uv pip install -e ${{ inputs.install-options }}
     - name: Install quick test dependencies
@@ -56,8 +56,7 @@ runs:
       env:
         UV_SYSTEM_PYTHON: 1
       run: |
-        uv pip install pytest flaky
-        uv pip install .
+        uv pip install -e .[dev]
     # Running tests
     - name: Run serial tests
       shell: bash

--- a/.github/actions/gh_tests/action.yml
+++ b/.github/actions/gh_tests/action.yml
@@ -47,16 +47,15 @@ runs:
       env:
         UV_SYSTEM_PYTHON: 1
       run: |
-        uv pip install -e .[dev]
         uv pip install ${{ inputs.pytorch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
-        uv pip install -e ${{ inputs.install-options }}
+        uv pip install ${{ inputs.install-options }}
     - name: Install quick test dependencies
       if: ${{ inputs.mode == 'quick' }}
       shell: bash
       env:
         UV_SYSTEM_PYTHON: 1
       run: |
-        uv pip install -e .[dev]
+        uv pip install ${{ inputs.install-options }}
     # Running tests
     - name: Run serial tests
       shell: bash

--- a/.github/workflows/pr_update.yml
+++ b/.github/workflows/pr_update.yml
@@ -18,7 +18,6 @@ jobs:
           - '3.11' # Oldest supported
           - '3.14' # Latest stable
         mpi: [ 'mpich' ]
-        install-options: [ '.[dev]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Oldest supported
           - 'torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0' # Latest stable
@@ -41,7 +40,6 @@ jobs:
           sha: ${{ github.event.pull_request.head.sha }}
           py-version: ${{ matrix.py-version }}
           mpi: ${{ matrix.mpi }}
-          install-options: ${{ matrix.install-options }}
           pytorch-version: ${{ matrix.pytorch-version }}
 
   trigger-tests:

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -45,7 +45,6 @@ jobs:
           - '3.13'
           - '3.14'
         mpi: [ 'mpich' ]
-        install-options: [ '.[dev]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
           - 'torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1'
@@ -76,7 +75,7 @@ jobs:
           - py-version: '3.13'
             pytorch-version: 'torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1'
 
-    name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}; options ${{ matrix.install-options }}
+    name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -91,5 +90,4 @@ jobs:
           mode: "full"
           py-version: ${{ matrix.py-version }}
           mpi: ${{ matrix.mpi }}
-          install-options: ${{ matrix.install-options }}
           pytorch-version: ${{ matrix.pytorch-version }}

--- a/.github/workflows/push_other.yml
+++ b/.github/workflows/push_other.yml
@@ -37,7 +37,6 @@ jobs:
           - '3.11' # Oldest supported
           - '3.14' # Latest stable
         mpi: [ 'mpich' ]
-        install-options: [ '.[dev]' ]
         pytorch-version:
           - 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'   # Oldest supported
           - 'torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1'   # JSC Stage 2026
@@ -45,7 +44,7 @@ jobs:
         exclude:
           - py-version: '3.14'
             pytorch-version: 'torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1'
-    name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}; options ${{ matrix.install-options }}
+    name: Python ${{ matrix.py-version }} with ${{ matrix.pytorch-version }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -60,5 +59,4 @@ jobs:
           mode: "full"
           py-version: ${{ matrix.py-version }}
           mpi: ${{ matrix.mpi }}
-          install-options: ${{ matrix.install-options }}
           pytorch-version: ${{ matrix.pytorch-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dev = [
     # Testing
     "pytest",
     "coverage",
-    "flaky",
+    "pytest-rerunfailures",
 
     # Benchmarking
     "perun",

--- a/tests/utils/data/test_partial_dataset.py
+++ b/tests/utils/data/test_partial_dataset.py
@@ -8,7 +8,7 @@ from pathlib import Path
 HDF5_PATH = str(Path(ht.__file__).parent / "datasets" / "iris.h5")
 USE_GPU = torch.cuda.is_available() and os.getenv("HEAT_TEST_USE_GPU") == "gpu"
 
-@pytest.mark.skipif(torch.cuda.is_available() and torch.version.hip, reason="Not supported for ROCM/HIP")
+@pytest.mark.skipif(torch.cuda.is_available() and torch.version.hip is not None, reason="Not supported for ROCM/HIP")
 @pytest.mark.skipif(not ht.supports_hdf5(), reason="Requires HDF5")
 class TestPartialDataset:
     def _create_test_dataset(self, file, comm, initial_load, load_length, use_gpu=False):

--- a/tests/utils/data/test_partial_dataset.py
+++ b/tests/utils/data/test_partial_dataset.py
@@ -1,19 +1,16 @@
+import pytest
 import heat as ht
 import torch
-import unittest
-from flaky import flaky
+import os
 
 from pathlib import Path
 
+HDF5_PATH = str(Path(ht.__file__).parent / "datasets" / "iris.h5")
+USE_GPU = torch.cuda.is_available() and os.getenv("HEAT_TEST_USE_GPU") == "gpu"
 
-@unittest.skipIf(torch.cuda.is_available() and torch.version.hip, "not supported for HIP")
-@unittest.skipUnless(ht.supports_hdf5(), "Requires HDF5")
-class TestPartialDataset(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.HDF5_PATH = str(Path(ht.__file__).parent / "datasets" / "iris.h5")
-
+@pytest.mark.skipif(torch.cuda.is_available() and torch.version.hip, reason="Not supported for ROCM/HIP")
+@pytest.mark.skipif(not ht.supports_hdf5(), reason="Requires HDF5")
+class TestPartialDataset:
     def _create_test_dataset(self, file, comm, initial_load, load_length, use_gpu=False):
         """Helper method to create a TestDataset instance."""
         class TestDataset(ht.utils.data.partial_dataset.PartialH5Dataset):
@@ -29,192 +26,147 @@ class TestPartialDataset(unittest.TestCase):
 
     def test_dataset_initialization(self):
         """Test that PartialH5Dataset initializes correctly."""
-        full_data = ht.load(self.HDF5_PATH, dataset="data", split=None)
+        full_data = ht.load(HDF5_PATH, dataset="data", split=None)
 
         # Test basic initialization
         initial_load = 30
         load_length = 20
-        partial_dset = self._create_test_dataset(self.HDF5_PATH, full_data.comm, initial_load, load_length)
-        self.assertEqual(partial_dset.total_size, full_data.shape[0])
+        partial_dset = self._create_test_dataset(HDF5_PATH, full_data.comm, initial_load, load_length)
+        assert partial_dset.total_size == full_data.shape[0]
 
         rows = full_data.shape[0]
         if initial_load > rows // full_data.comm.size:
-            self.assertFalse(partial_dset.partial_dataset)
+            assert partial_dset.partial_dataset == False
         else:
-            self.assertTrue(partial_dset.partial_dataset)
+            assert partial_dset.partial_dataset == True
 
-    def test_batch_shape_consistency(self):
+    @pytest.mark.parametrize("pin_memory", [False, True])
+    def test_batch_shape_consistency(self, pin_memory):
         """Test that all batches have the expected shape across device configurations."""
-        full_data = ht.load(self.HDF5_PATH, dataset="data", split=None)
-        target_shape = full_data.shape
+        full_data = ht.load(HDF5_PATH, dataset="data", split=None)
         expected_batch_shape = (7, 4)
 
         # Test with different device configurations
-        device_configs = [
-            {"use_gpu": False, "pin_memory": False},
-        ]
-        if torch.cuda.is_available():
-            device_configs.append({"use_gpu": True, "pin_memory": True})
 
-        for config in device_configs:
-            with self.subTest(use_gpu=config["use_gpu"], pin_memory=config["pin_memory"]):
-                partial_dset = self._create_test_dataset(
-                    self.HDF5_PATH, full_data.comm, 30, 20, use_gpu=config["use_gpu"]
-                )
-                dl = ht.utils.data.DataLoader(
-                    dataset=partial_dset,
-                    batch_size=7,
-                    pin_memory=config["pin_memory"],
-                )
+        partial_dset = self._create_test_dataset(
+            HDF5_PATH, full_data.comm, 30, 20, use_gpu=USE_GPU
+        )
+        dl = ht.utils.data.DataLoader(
+            dataset=partial_dset,
+            batch_size=7,
+            pin_memory=pin_memory,
+        )
 
-                for batch in dl:
-                    self.assertEqual(batch.shape, expected_batch_shape)
-                    break  # Just check first batch for this test
+        for batch in dl:
+            assert batch.shape == expected_batch_shape
+            break  # Just check first batch for this test
 
-    @flaky
-    def test_consecutive_batches_differ(self):
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.parametrize("pin_memory", [False, True])
+    def test_consecutive_batches_differ(self, pin_memory):
         """Test that consecutive batches within an epoch are different."""
-        full_data = ht.load(self.HDF5_PATH, dataset="data", split=None)
+        full_data = ht.load(HDF5_PATH, dataset="data", split=None)
 
-        device_configs = [
-            {"use_gpu": False, "pin_memory": False},
-        ]
-        if torch.cuda.is_available():
-            device_configs.append({"use_gpu": True, "pin_memory": True})
+        partial_dset = self._create_test_dataset(
+            HDF5_PATH, full_data.comm, 30, 20, use_gpu=USE_GPU
+        )
+        dl = ht.utils.data.DataLoader(
+            dataset=partial_dset,
+            batch_size=7,
+            pin_memory=pin_memory,
+        )
 
-        for config in device_configs:
-            with self.subTest(use_gpu=config["use_gpu"]):
-                partial_dset = self._create_test_dataset(
-                    self.HDF5_PATH, full_data.comm, 30, 20, use_gpu=config["use_gpu"]
-                )
-                dl = ht.utils.data.DataLoader(
-                    dataset=partial_dset,
-                    batch_size=7,
-                    pin_memory=config["pin_memory"],
-                )
+        last_batch = None
+        batch_count = 0
+        for batch in dl:
+            if last_batch is not None:
+                assert not torch.allclose(last_batch, batch)
+            last_batch = batch
+            batch_count += 1
+            if batch_count >= 3:  # Only check first few batches
+                break
 
-                last_batch = None
-                batch_count = 0
-                for batch in dl:
-                    if last_batch is not None:
-                        self.assertFalse(
-                            torch.allclose(last_batch, batch),
-                            "Consecutive batches should differ"
-                        )
-                    last_batch = batch
-                    batch_count += 1
-                    if batch_count >= 3:  # Only check first few batches
-                        break
-
-    def test_element_count_per_epoch(self):
+    @pytest.mark.parametrize("pin_memory", [False, True])
+    def test_element_count_per_epoch(self, pin_memory):
         """Test that the total element count is within expected bounds."""
-        full_data = ht.load(self.HDF5_PATH, dataset="data", split=None)
+        full_data = ht.load(HDF5_PATH, dataset="data", split=None)
         target_shape = full_data.shape
 
-        device_configs = [
-            {"use_gpu": False, "pin_memory": False},
-        ]
-        if torch.cuda.is_available():
-            device_configs.append({"use_gpu": True, "pin_memory": True})
+        partial_dset = self._create_test_dataset(
+            HDF5_PATH, full_data.comm, 30, 20, use_gpu=USE_GPU
+        )
+        dl = ht.utils.data.DataLoader(
+            dataset=partial_dset,
+            batch_size=7,
+            pin_memory=pin_memory,
+        )
 
-        for config in device_configs:
-            with self.subTest(use_gpu=config["use_gpu"]):
-                partial_dset = self._create_test_dataset(
-                    self.HDF5_PATH, full_data.comm, 30, 20, use_gpu=config["use_gpu"]
-                )
-                dl = ht.utils.data.DataLoader(
-                    dataset=partial_dset,
-                    batch_size=7,
-                    pin_memory=config["pin_memory"],
-                )
+        elems = 0
+        for batch in dl:
+            elems += batch.shape[0]
 
-                elems = 0
-                for batch in dl:
-                    elems += batch.shape[0]
+        expected_min = (target_shape[0] - 7) // full_data.comm.size
+        assert elems >= expected_min, f"Element count {elems} should be >= {expected_min}"
 
-                expected_min = (target_shape[0] - 7) // full_data.comm.size
-                self.assertGreaterEqual(
-                    elems, expected_min,
-                    f"Element count {elems} should be >= {expected_min}"
-                )
-
-    @flaky
-    def test_data_varies_between_epochs(self):
+    @pytest.mark.parametrize("pin_memory", [False, True])
+    def test_data_varies_between_epochs(self, pin_memory):
         """Test that data differs between consecutive epochs due to shuffling."""
-        full_data = ht.load(self.HDF5_PATH, dataset="data", split=None)
+        full_data = ht.load(HDF5_PATH, dataset="data", split=None)
 
-        device_configs = [
-            {"use_gpu": False, "pin_memory": False},
-        ]
-        if torch.cuda.is_available():
-            device_configs.append({"use_gpu": True, "pin_memory": True})
+        partial_dset = self._create_test_dataset(
+            HDF5_PATH, full_data.comm, 30, 20, use_gpu=USE_GPU
+        )
+        dl = ht.utils.data.DataLoader(
+            dataset=partial_dset,
+            batch_size=7,
+            pin_memory=pin_memory,
+        )
 
-        for config in device_configs:
-            with self.subTest(use_gpu=config["use_gpu"]):
-                partial_dset = self._create_test_dataset(
-                    self.HDF5_PATH, full_data.comm, 30, 20, use_gpu=config["use_gpu"]
-                )
-                dl = ht.utils.data.DataLoader(
-                    dataset=partial_dset,
-                    batch_size=7,
-                    pin_memory=config["pin_memory"],
-                )
+        epoch_data = []
+        for epoch in range(2):
+            epoch_batches = None
+            for batch in dl:
+                if epoch_batches is None:
+                    epoch_batches = batch
+                else:
+                    epoch_batches = torch.cat((epoch_batches, batch), dim=0)
+            epoch_data.append(epoch_batches)
 
-                epoch_data = []
-                for epoch in range(2):
-                    epoch_batches = None
-                    for batch in dl:
-                        if epoch_batches is None:
-                            epoch_batches = batch
-                        else:
-                            epoch_batches = torch.cat((epoch_batches, batch), dim=0)
-                    epoch_data.append(epoch_batches)
+        # Ensure we collected data from both epochs
+        assert len(epoch_data) == 2, f"Expected data from 2 epochs, got {len(epoch_data)}"
 
-                # Ensure we collected data from both epochs
-                self.assertEqual(len(epoch_data), 2)
+        # Check that the two epochs have different data
+        assert not torch.allclose(epoch_data[0], epoch_data[1]), "Data should vary between epochs"
 
-                # Check that the two epochs have different data
-                self.assertFalse(
-                    torch.allclose(epoch_data[0], epoch_data[1]),
-                    "Data should vary between epochs"
-                )
-
-    @flaky
-    def test_partial_h5_dataset_integration(self):
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.parametrize("pin_memory", [False, True])
+    def test_partial_h5_dataset_integration(self, pin_memory):
         """Integration test: verify the complete workflow with both CPU and GPU."""
-        full_data = ht.load(self.HDF5_PATH, dataset="data", split=None)
+        full_data = ht.load(HDF5_PATH, dataset="data", split=None)
         target_shape = full_data.shape
 
-        device_configs = [
-            {"use_gpu": False, "pin_memory": False},
-        ]
-        if torch.cuda.is_available():
-            device_configs.append({"use_gpu": True, "pin_memory": True})
+        partial_dset = self._create_test_dataset(
+            HDF5_PATH, full_data.comm, 30, 20, use_gpu=USE_GPU
+        )
+        dl = ht.utils.data.DataLoader(
+            dataset=partial_dset,
+            batch_size=7,
+            pin_memory=pin_memory,
+        )
 
-        for config in device_configs:
-            with self.subTest(use_gpu=config["use_gpu"], pin_memory=config["pin_memory"]):
-                partial_dset = self._create_test_dataset(
-                    self.HDF5_PATH, full_data.comm, 30, 20, use_gpu=config["use_gpu"]
-                )
-                dl = ht.utils.data.DataLoader(
-                    dataset=partial_dset,
-                    batch_size=7,
-                    pin_memory=config["pin_memory"],
-                )
+        for epoch in range(2):
+            elems = 0
+            last_batch = None
+            for batch in dl:
+                elems += batch.shape[0]
+                # Check batch shape
+                assert batch.shape == (7, 4), f"Expected batch shape (7, 4), got {batch.shape}"
 
-                for epoch in range(2):
-                    elems = 0
-                    last_batch = None
-                    for batch in dl:
-                        elems += batch.shape[0]
-                        # Check batch shape
-                        self.assertEqual(batch.shape, (7, 4))
+                # Check that consecutive batches are different
+                if last_batch is not None:
+                    assert not torch.allclose(last_batch, batch), "Consecutive batches should differ"
+                last_batch = batch
 
-                        # Check that consecutive batches are different
-                        if last_batch is not None:
-                            self.assertFalse(torch.allclose(last_batch, batch))
-                        last_batch = batch
-
-                    # Check element count
-                    expected_min = (target_shape[0] - 7) // full_data.comm.size
-                    self.assertGreaterEqual(elems, expected_min)
+            # Check element count
+            expected_min = (target_shape[0] - 7) // full_data.comm.size
+            assert elems >= expected_min, f"Element count {elems} should be >= {expected_min}"


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

Some of things after the merge:
- Flaky is not officially supported by pytest any more, google lead me to an outdated version of the documentation.
- It does not interact well with substests, as we see in codebase, flaky reports success, but some subtests failed.

Issue/s resolved: #

## Changes proposed:

- Change from flaky to pytest-rerunfailures
- Slow transition to pytest-only -> Removed TestCase class, use parametrized instead of subtest
- Installing .[dev] in actions to avoid having to change this constantly.
-

