### PR TITLE
Disabling fail fast for PR update workflow

### DIFF
--- a/.github/workflows/pr_update.yml
+++ b/.github/workflows/pr_update.yml
@@ -12,7 +12,7 @@ jobs:
   quick-tests:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         py-version:
           - '3.11' # Oldest supported


### PR DESCRIPTION
We use multiple jobs with different python and pytorch versions in the CI. The `fail-fast` strategy cancels jobs that haven't yet completed if one of them fails. This is not what we want because it hides if the failure is version specific or more general. For other workflows this is already disabled, but I think we should also disable it in the PR update workflow.