### PR TITLE
Better error message for unknown device

### DIFF
--- a/heat/core/devices.py
+++ b/heat/core/devices.py
@@ -189,7 +189,9 @@ def sanitize_device(device: Optional[Union[str, Device]] = None) -> Device:
     try:
         return __device_mapping[device.strip().lower()]
     except (AttributeError, KeyError, TypeError):
-        raise ValueError(f"Unknown device, must be one of {', '.join(__device_mapping.keys())}")
+        raise ValueError(
+            f"Unknown device {device!r}, must be one of {', '.join(__device_mapping.keys())}"
+        )
 
 
 def use_device(device: Optional[Union[str, Device]] = None) -> None:

--- a/heat/core/devices.py
+++ b/heat/core/devices.py
@@ -190,7 +190,7 @@ def sanitize_device(device: Optional[Union[str, Device]] = None) -> Device:
         return __device_mapping[device.strip().lower()]
     except (AttributeError, KeyError, TypeError):
         raise ValueError(
-            f"Unknown device {device!r}, must be one of {', '.join(__device_mapping.keys())}"
+            f"Unknown device {device!r}, must be one of {tuple(__device_mapping.keys())}"
         )
 
 

--- a/tests/core/test_devices.py
+++ b/tests/core/test_devices.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import pytest
 
 import heat as ht
 from heat.testing.basic_test import TestCase
@@ -72,3 +73,9 @@ class TestDevices(TestCase):
             ht.use_device("fpu")
         with self.assertRaises(ValueError):
             ht.use_device(1)
+
+
+def test_unknown_device_error_message():
+    device_name = "Sauron's Eye"
+    with pytest.raises(ValueError, match=device_name):
+        ht.use_device(device_name)


### PR DESCRIPTION
This PR includes the requested device in the error message when said device is not found.
It also includes a test for this. Note the handy `match` argument of `pytest.raises` that makes such tests convenient.