### PR TITLE
Print world rank rather than 0 in setup guide smoke test

### DIFF
--- a/quick_start.md
+++ b/quick_start.md
@@ -50,7 +50,7 @@ See our [docker README](https://github.com/helmholtz-analytics/heat/blob/main/do
 Confirm the installation by running a distributed smoke test to verify tensor splitting across processes:
 
 ```bash
-mpirun -n 2 python -c "import heat as ht; x = ht.arange(10, split=0); print(f'Rank {ht.communication.MPI_SELF.rank} local shape: {x.lshape}')"
+mpirun -n 2 python -c "import heat as ht; x = ht.arange(10, split=0); print(f'Rank {x.comm.rank} local shape: {x.lshape}')"
 ```
 This should output something like:
 


### PR DESCRIPTION
As @maliesen for pointed out in #2373, the distributed smoke test in the setup guide prints the rank of `COMM_SELF`, which is always zero, instead of the actually relevant `COMM_WORLD`.
This PR fixes this. Note that this PR doesn't change any code but only documentation.

Issue/s resolved: #2373 