### PR TITLE
add newaxis constant

### DIFF
--- a/heat/array_api/_constants.py
+++ b/heat/array_api/_constants.py
@@ -1,3 +1,5 @@
+# NOTE: All additions have been ported. Will be removed soon.
+
 import heat as ht
 
 e = ht.e

--- a/heat/core/constants.py
+++ b/heat/core/constants.py
@@ -4,7 +4,7 @@ Constants module.
 
 import torch
 
-__all__ = ["e", "Euler", "inf", "Inf", "Infty", "Infinity", "nan", "NaN", "pi"]
+__all__ = ["e", "Euler", "inf", "Inf", "Infty", "Infinity", "nan", "NaN", "pi", "newaxis"]
 
 # infinity
 INF = float("inf")

--- a/heat/core/constants.py
+++ b/heat/core/constants.py
@@ -37,3 +37,5 @@ e = E
 """Euler's number, Euler's constant (:math:`e`)."""
 Euler = E
 """Euler's number, Euler's constant (:math:`e`)."""
+newaxis = None
+"""An alias for ``None`` which is useful for indexing arrays."""

--- a/tests/core/test_constants.py
+++ b/tests/core/test_constants.py
@@ -13,3 +13,4 @@ class TestConstants(TestCase):
         self.assertTrue(np.isinf(ht.inf))
         self.assertTrue(ht.pi == np.pi)
         self.assertTrue(ht.e == np.e)
+        self.assertTrue(ht.newaxis is None)


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Adds the newaxis constant to the main namespace.

Issue/s resolved: #2417 

## Changes proposed:

- add newaxis constant

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

array api

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
