### PR TITLE
Remove non-existent paths from codecov-ignore

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,6 @@
 ignore:
-  - "heat/core/regression/lasso/demo.py"
-  - "heat/core/regression/lasso/plotfkt.py"
-  - "heat/examples/*"
   - "heat/utils/data/mnist.py"
   - "heat/utils/data/_utils.py"
-  - "heat/**/test_*.py"
   - "heat/array_api/**"
 
 coverage:


### PR DESCRIPTION
Presumably, these paths have existed at some point, but they don't anymore and we should remove this dead code.
```
$ ls heat/core/regression/
ls: heat/core/regression/: No such file or directory
$ ls heat/examples/
ls: heat/examples/: No such file or directory
$ ls heat/**/test_*.py
zsh: no matches found: heat/**/test_*.py
```