### PR TITLE
Remove `heat/array_api` from codecov-ignore

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,6 @@
 ignore:
   - "heat/utils/data/mnist.py"
   - "heat/utils/data/_utils.py"
-  - "heat/array_api/**"
 
 coverage:
   status:


### PR DESCRIPTION
Given that we currently have some sort of support for this module, I don't think we should exclude it from the coverage report. @mtar is currently merging the functionality into the main `DNDarray`, so eventually we can get rid of this code and get coverage back up to today's level. Until then, I suggest we are honest about not covering this in any tests.