### PR TITLE
Remove ignore section from codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,3 @@
-ignore:
-  - "heat/utils/data/mnist.py"
-  - "heat/utils/data/_utils.py"
-
 coverage:
   status:
     project:


### PR DESCRIPTION
I actually see no reason to exclude any part of the code from the coverage report. So, let's just get rid of the `ignore` section entirely.