### PR TITLE
Add concurrency condition to push to main workflow

### DIFF
--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -8,6 +8,11 @@ on:
       - 'heat/**'
       - 'tests/**'
       - 'pyproject.toml'
+
+concurrency:
+  group: main-ci
+  cancel-in-progress: true
+
 jobs:
   codebase-test-and-bench-main:
     name: Codebase Tests and Benchmarks


### PR DESCRIPTION
The push to main CI is very comprehensive with a matrix spanning 33 different runs. When we merge many small PRs in quick succession, this blocks too many GitHub runners and slows down the CI.

This PR adds a `concurrency` condition to the workflow, which means it's only run once at a time. If we merge a PR, the CI is started. If we don't merge anything until the CI is completed, everything just works as usual. If we merge another PR before the CI has completed, the previous CI run is cancelled before the second run starts.

I think this will not often make a difference, but if it does, I don't think it hurts.