### PR TITLE
Remove special cases for old dependencies

### DIFF
--- a/heat/cluster/spectral.py
+++ b/heat/cluster/spectral.py
@@ -159,7 +159,6 @@ class Spectral(ht.ClusteringMixin, ht.BaseEstimator):
             )
             V, T = ht.lanczos(L, self.lanczos_n_iter, v0)
 
-            # if int(torch.__version__.split(".")[1]) >= 9:
             try:
                 # 4. Calculate and Sort Eigenvalues and Eigenvectors of tridiagonal matrix T
                 eval, evec = torch.linalg.eig(T.larray)

--- a/heat/core/rounding.py
+++ b/heat/core/rounding.py
@@ -407,12 +407,9 @@ def sign(x: DNDarray, out: Optional[DNDarray] = None) -> DNDarray:
         data = out.larray
     else:
         data = torch.clone(x.larray)
-    # NOTE remove when min version >= 1.9
-    if "1.8" in torch.__version__:  # pragma: no cover
-        pos = data != 0
-    else:
-        indices = torch.nonzero(data)
-        pos = torch.split(indices, 1, 1)
+
+    indices = torch.nonzero(data)
+    pos = torch.split(indices, 1, 1)
     data[pos] = x.larray[pos] / torch.sqrt(torch.square(x.larray[pos]))
 
     if out is not None:

--- a/heat/core/vmap.py
+++ b/heat/core/vmap.py
@@ -54,9 +54,6 @@ def vmap(
     Please note that the options 'same' and 'different' for `randomness` will result in behaviour different from the one known by PyTorch as (at least currently)
     no actions are taken to synchronize randomness across the MPI processes.
     """
-    # check PyTorch version, return error if not 2.0.0 or higher
-    if torch.__version__ < "2.0.0":
-        raise RuntimeError("The function `heat.vmap` requires PyTorch 2.0.0 or higher.")
     # rough check of input argument types
     if not callable(func):
         raise TypeError("The input function `func` must be callable.")

--- a/heat/sparse/factories.py
+++ b/heat/sparse/factories.py
@@ -196,10 +196,6 @@ def __sparse_matrix(
     ValueError
         If the split or is_split axis is not supported for the type.
     """
-    # version check
-    if int(torch.__version__.split(".")[0]) <= 1 and int(torch.__version__.split(".")[1]) < 10:
-        raise RuntimeError(f"ht.sparse requires torch >= 1.10. Found version {torch.__version__}.")
-
     # sanitize the data type
     if dtype is not None:
         dtype = types.canonical_heat_type(dtype)

--- a/tests/core/test_dndarray.py
+++ b/tests/core/test_dndarray.py
@@ -6,8 +6,6 @@ import heat as ht
 from pathlib import Path
 from heat.testing.basic_test import TestCase
 
-pytorch_major_version = int(torch.__version__.split(".")[0])
-
 
 class TestDNDarray(TestCase):
     @classmethod
@@ -1747,12 +1745,9 @@ class TestDNDarray(TestCase):
         heat_int16 = ht.array(torch_int16)
         numpy_int16 = torch_int16.cpu().numpy()
         self.assertEqual(heat_int16.stride(), torch_int16.stride())
-        if pytorch_major_version >= 2:
-            self.assertTrue(
-                (np.asarray(heat_int16.strides) * 2 == np.asarray(numpy_int16.strides)).all()
-            )
-        else:
-            self.assertEqual(heat_int16.strides, numpy_int16.strides)
+        self.assertTrue(
+            (np.asarray(heat_int16.strides) * 2 == np.asarray(numpy_int16.strides)).all()
+        )
 
         # Local, float32, row-major memory layout
         torch_float32 = torch.arange(
@@ -1761,12 +1756,9 @@ class TestDNDarray(TestCase):
         heat_float32 = ht.array(torch_float32)
         numpy_float32 = torch_float32.cpu().numpy()
         self.assertEqual(heat_float32.stride(), torch_float32.stride())
-        if pytorch_major_version >= 2:
-            self.assertTrue(
-                (np.asarray(heat_float32.strides) * 4 == np.asarray(numpy_float32.strides)).all()
-            )
-        else:
-            self.assertEqual(heat_float32.strides, numpy_float32.strides)
+        self.assertTrue(
+            (np.asarray(heat_float32.strides) * 4 == np.asarray(numpy_float32.strides)).all()
+        )
 
         # Local, float64, column-major memory layout
         if not self.is_mps:
@@ -1776,15 +1768,12 @@ class TestDNDarray(TestCase):
             heat_float64_F = ht.array(torch_float64, order="F")
             numpy_float64_F = np.array(torch_float64.cpu().numpy(), order="F")
             self.assertNotEqual(heat_float64_F.stride(), torch_float64.stride())
-            if pytorch_major_version >= 2:
-                self.assertTrue(
-                    (
-                        np.asarray(heat_float64_F.strides) * 8
-                        == np.asarray(numpy_float64_F.strides)
-                    ).all()
-                )
-            else:
-                self.assertEqual(heat_float64_F.strides, numpy_float64_F.strides)
+            self.assertTrue(
+                (
+                    np.asarray(heat_float64_F.strides) * 8
+                    == np.asarray(numpy_float64_F.strides)
+                ).all()
+            )
 
         # Distributed, int16, row-major memory layout
         size = ht.communication.MPI_WORLD.size
@@ -1799,15 +1788,12 @@ class TestDNDarray(TestCase):
         numpy_int16_split_strides = (
             tuple(np.array(numpy_int16.strides[:split]) / size) + numpy_int16.strides[split:]
         )
-        if pytorch_major_version >= 2:
-            self.assertTrue(
-                (
-                    np.asarray(heat_int16_split.strides) * 2
-                    == np.asarray(numpy_int16_split_strides)
-                ).all()
-            )
-        else:
-            self.assertEqual(heat_int16_split.strides, numpy_int16_split_strides)
+        self.assertTrue(
+            (
+                np.asarray(heat_int16_split.strides) * 2
+                == np.asarray(numpy_int16_split_strides)
+            ).all()
+        )
 
         # Distributed, float32, row-major memory layout
         split = -1
@@ -1819,15 +1805,12 @@ class TestDNDarray(TestCase):
         numpy_float32_split_strides = (
             tuple(np.array(numpy_float32.strides[:split]) / size) + numpy_float32.strides[split:]
         )
-        if pytorch_major_version >= 2:
-            self.assertTrue(
-                (
-                    np.asarray(heat_float32_split.strides) * 4
-                    == np.asarray(numpy_float32_split_strides)
-                ).all()
-            )
-        else:
-            self.assertEqual(heat_float32_split.strides, numpy_float32_split_strides)
+        self.assertTrue(
+            (
+                np.asarray(heat_float32_split.strides) * 4
+                == np.asarray(numpy_float32_split_strides)
+            ).all()
+        )
 
         # Distributed, float64, column-major memory layout
         if not self.is_mps:
@@ -1840,15 +1823,12 @@ class TestDNDarray(TestCase):
             numpy_float64_F_split_strides = numpy_float64_F.strides[: split + 1] + tuple(
                 np.array(numpy_float64_F.strides[split + 1 :]) / size
             )
-            if pytorch_major_version >= 2:
-                self.assertTrue(
-                    (
-                        np.asarray(heat_float64_F_split.strides) * 8
-                        == np.asarray(numpy_float64_F_split_strides)
-                    ).all()
-                )
-            else:
-                self.assertEqual(heat_float64_F_split.strides, numpy_float64_F_split_strides)
+            self.assertTrue(
+                (
+                    np.asarray(heat_float64_F_split.strides) * 8
+                    == np.asarray(numpy_float64_F_split_strides)
+                ).all()
+            )
 
     def test_tolist(self):
         a = ht.zeros([ht.MPI_WORLD.size, ht.MPI_WORLD.size, ht.MPI_WORLD.size], dtype=ht.int32)
@@ -1889,30 +1869,20 @@ class TestDNDarray(TestCase):
         scalar_array = ht.array(1)
         scalar_proxy = scalar_array.__torch_proxy__()
         self.assertTrue(scalar_proxy.ndim == 0)
-        if pytorch_major_version >= 2:
-            scalar_proxy_nbytes = (
-                scalar_proxy.untyped_storage().size()
-                * scalar_proxy.untyped_storage().element_size()
-            )
-        else:
-            scalar_proxy_nbytes = (
-                scalar_proxy.storage().size() * scalar_proxy.storage().element_size()
-            )
+        scalar_proxy_nbytes = (
+            scalar_proxy.untyped_storage().size()
+            * scalar_proxy.untyped_storage().element_size()
+        )
         self.assertTrue(scalar_proxy_nbytes == 1)
 
         dndarray = ht.zeros((4, 7, 6), split=1)
         dndarray_proxy = dndarray.__torch_proxy__()
         self.assertTrue(dndarray_proxy.ndim == dndarray.ndim)
         self.assertTrue(tuple(dndarray_proxy.shape) == dndarray.gshape)
-        if pytorch_major_version >= 2:
-            dndarray_proxy_nbytes = (
-                dndarray_proxy.untyped_storage().size()
-                * dndarray_proxy.untyped_storage().element_size()
-            )
-        else:
-            dndarray_proxy_nbytes = (
-                dndarray_proxy.storage().size() * dndarray_proxy.storage().element_size()
-            )
+        dndarray_proxy_nbytes = (
+            dndarray_proxy.untyped_storage().size()
+            * dndarray_proxy.untyped_storage().element_size()
+        )
         self.assertTrue(dndarray_proxy_nbytes == 1)
 
     def test_torch_function(self):

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -2717,31 +2717,22 @@ class TestManipulations(TestCase):
         # test local row_stack, 2-D arrays
         a = np.arange(10, dtype=np.float32).reshape(2, 5)
         b = np.arange(15, dtype=np.float32).reshape(3, 5)
-        if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
-            np_rstack = np.vstack((a, b))
-        else:
-            np_rstack = np.row_stack((a, b))
+        np_rstack = np.vstack((a, b))
         ht_a = ht.array(a)
         ht_b = ht.array(b)
         ht_rstack = ht.row_stack((ht_a, ht_b))
         self.assertTrue((np_rstack == ht_rstack.numpy()).all())
 
         # 2-D and 1-D arrays
-        c = np.arange(5, dtype=np.float32)
-        if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
-            np_rstack = np.vstack((a, b, c))
-        else:
-            np_rstack = np.row_stack((a, b, c))
+        c = np.arange(5, dtype=np.float32):
+        np_rstack = np.vstack((a, b, c))
         ht_c = ht.array(c)
         ht_rstack = ht.row_stack((ht_a, ht_b, ht_c))
         self.assertTrue((np_rstack == ht_rstack.numpy()).all())
 
         # 2-D and 1-D arrays, distributed
         c = np.arange(5, dtype=np.float32)
-        if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
-            np_rstack = np.vstack((a, b, c))
-        else:
-            np_rstack = np.row_stack((a, b, c))
+        np_rstack = np.vstack((a, b, c))
         ht_a = ht.array(a, split=0)
         ht_b = ht.array(b, split=0)
         ht_c = ht.array(c, split=0)
@@ -2752,10 +2743,7 @@ class TestManipulations(TestCase):
         # 1-D arrays, distributed, different dtypes
         d = np.arange(10).astype(np.float32)
         e = np.arange(10)
-        if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
-            np_rstack = np.vstack((d, e))
-        else:
-            np_rstack = np.row_stack((d, e))
+        np_rstack = np.vstack((d, e))
         ht_d = ht.array(d, split=0)
         ht_e = ht.array(e, split=0)
         ht_rstack = ht.row_stack((ht_d, ht_e))

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -2724,7 +2724,7 @@ class TestManipulations(TestCase):
         self.assertTrue((np_rstack == ht_rstack.numpy()).all())
 
         # 2-D and 1-D arrays
-        c = np.arange(5, dtype=np.float32):
+        c = np.arange(5, dtype=np.float32)
         np_rstack = np.vstack((a, b, c))
         ht_c = ht.array(c)
         ht_rstack = ht.row_stack((ht_a, ht_b, ht_c))

--- a/tests/core/test_vmap.py
+++ b/tests/core/test_vmap.py
@@ -6,135 +6,122 @@ from heat.testing.basic_test import TestCase
 
 
 class TestVmap(TestCase):
-    if torch.__version__ < "2.0.0":
+    def test_vmap(self):
+        # two inputs (both split), two outputs, including keyword arguments that are not vmapped
+        # inputs split along different axes, output split along same axis (one of them different to input split)
+        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=1)
+        out_dims = 0  # test with out_dims as int (tuple below)
 
-        def test_vmap(self):
-            out_dims = (0, 0)
+        def func(x0, x1, k=2, scale=1e-2):
+            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
 
-            def func(x0, x1, k=2, scale=1e-2):
-                return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+        vfunc = ht.vmap(func, out_dims)
+        y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
 
-            with self.assertRaises(RuntimeError):
-                vfunc = ht.vmap(func, out_dims)  # noqa: F841
+        # compare with torch
+        x0_torch = x0.resplit(None).larray
+        x1_torch = x1.resplit(None).larray
+        vfunc_torch = torch.vmap(func, (0, 1), (0, 0))
+        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
 
-    else:
+        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
 
-        def test_vmap(self):
-            # two inputs (both split), two outputs, including keyword arguments that are not vmapped
-            # inputs split along different axes, output split along same axis (one of them different to input split)
-            x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
-            x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=1)
-            out_dims = 0  # test with out_dims as int (tuple below)
+        # two inputs (only one of them split), two outputs, including keyword arguments that are not vmapped
+        # output split along different axis, one output has different data type than input
+        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+        x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=None)
+        out_dims = (0, 1)
 
-            def func(x0, x1, k=2, scale=1e-2):
-                return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, scale * x0 @ x1
+        def func(x0, x1, k=2, scale=1e-2):
+            return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, (scale * x0 @ x1).int()
 
-            vfunc = ht.vmap(func, out_dims)
+        vfunc = ht.vmap(func, out_dims)
+        y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
+
+        # compare with torch
+        x0_torch = x0.resplit(None).larray
+        x1_torch = x1.resplit(None).larray
+        vfunc_torch = torch.vmap(func, (0, None), (0, 1))
+        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
+
+        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+        self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+
+        # catch wrong number of output dimensions
+        with self.assertRaises(ValueError):
+            vfunc = ht.vmap(func, (0, 1, 2))
             y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
 
-            # compare with torch
-            x0_torch = x0.resplit(None).larray
-            x1_torch = x1.resplit(None).larray
-            vfunc_torch = torch.vmap(func, (0, 1), (0, 0))
-            y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
+        # one output only
+        def func(x0, m=1, scale=2):
+            return (x0 - m) ** scale
 
-            self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
-            self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
+        vfunc = ht.vmap(func, out_dims=(0,))
 
-            # two inputs (only one of them split), two outputs, including keyword arguments that are not vmapped
-            # output split along different axis, one output has different data type than input
-            x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
-            x1 = ht.random.randn(10, 5 * ht.MPI_WORLD.size, split=None)
-            out_dims = (0, 1)
+        x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
+        y0 = vfunc(x0, m=2, scale=3)[0]
 
-            def func(x0, x1, k=2, scale=1e-2):
-                return torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2, (scale * x0 @ x1).int()
+        x0_torch = x0.resplit(None).larray
+        vfunc_torch = torch.vmap(func, (0,), (0,))
+        y0_torch = vfunc_torch(x0_torch, m=2, scale=3)
 
-            vfunc = ht.vmap(func, out_dims)
-            y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
+        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
 
-            # compare with torch
-            x0_torch = x0.resplit(None).larray
-            x1_torch = x1.resplit(None).larray
-            vfunc_torch = torch.vmap(func, (0, None), (0, 1))
-            y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=2.2)
+    def test_vmap_with_chunks(self):
+        x1_splits = [None, 1]
+        chunk_sizes = list(range(1, 5))
+        dtypes = [ht.float32, ht.float64]
+        for x1_split in x1_splits:
+            for cs in chunk_sizes:
+                for dtype in dtypes:
+                    with self.subTest(x1_split=x1_split, chunk_size=cs, dtype=dtype):
+                        # same as before but now with prescribed chunk sizes for the vmap
+                        x0 = ht.random.randn(
+                            5 * ht.MPI_WORLD.size, 10, 10, split=0, dtype=dtype
+                        )
+                        x1 = ht.random.randn(
+                            10, 5 * ht.MPI_WORLD.size, split=x1_split, dtype=dtype
+                        )
+                        out_dims = (0, 0)
 
-            self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
-            self.assertTrue(torch.allclose(y1.resplit(None).larray, y1_torch))
-
-            # catch wrong number of output dimensions
-            with self.assertRaises(ValueError):
-                vfunc = ht.vmap(func, (0, 1, 2))
-                y0, y1 = vfunc(x0, x1, k=2, scale=2.2)
-
-            # one output only
-            def func(x0, m=1, scale=2):
-                return (x0 - m) ** scale
-
-            vfunc = ht.vmap(func, out_dims=(0,))
-
-            x0 = ht.random.randn(5 * ht.MPI_WORLD.size, 10, 10, split=0)
-            y0 = vfunc(x0, m=2, scale=3)[0]
-
-            x0_torch = x0.resplit(None).larray
-            vfunc_torch = torch.vmap(func, (0,), (0,))
-            y0_torch = vfunc_torch(x0_torch, m=2, scale=3)
-
-            self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
-
-        def test_vmap_with_chunks(self):
-            x1_splits = [None, 1]
-            chunk_sizes = list(range(1, 5))
-            dtypes = [ht.float32, ht.float64]
-            for x1_split in x1_splits:
-                for cs in chunk_sizes:
-                    for dtype in dtypes:
-                        with self.subTest(x1_split=x1_split, chunk_size=cs, dtype=dtype):
-                            # same as before but now with prescribed chunk sizes for the vmap
-                            x0 = ht.random.randn(
-                                5 * ht.MPI_WORLD.size, 10, 10, split=0, dtype=dtype
-                            )
-                            x1 = ht.random.randn(
-                                10, 5 * ht.MPI_WORLD.size, split=x1_split, dtype=dtype
-                            )
-                            out_dims = (0, 0)
-
-                            def func(x0, x1, k=2, scale=1e-2):
-                                return (
-                                    torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2,
-                                    scale * x0 @ x1,
-                                )
-
-                            vfunc = ht.vmap(func, out_dims, chunk_size=cs)
-                            y0, y1 = vfunc(x0, x1, k=2, scale=-2.2)
-
-                            # compare with torch
-                            x0_torch = x0.resplit(None).larray
-                            x1_torch = x1.resplit(None).larray
-                            vfunc_torch = torch.vmap(func, (0, x1_split), out_dims)
-                            y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=-2.2)
-
-                            self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
-                            tol = 1e-12 if dtype == ht.float64 else 1e-4
-                            self.assertTrue(
-                                torch.allclose(y1.resplit(None).larray, y1_torch, atol=tol)
+                        def func(x0, x1, k=2, scale=1e-2):
+                            return (
+                                torch.topk(torch.linalg.svdvals(x0), k)[0] ** 2,
+                                scale * x0 @ x1,
                             )
 
-        def test_vmap_catch_errors(self):
-            # not a callable
-            with self.assertRaises(TypeError):
-                ht.vmap(1)
-            # invalid randomness
-            with self.assertRaises(ValueError):
-                ht.vmap(lambda x: x, randomness="random")
-            # invalid chunk_size
-            with self.assertRaises(TypeError):
-                ht.vmap(lambda x: x, chunk_size="1")
-            with self.assertRaises(ValueError):
-                ht.vmap(lambda x: x, chunk_size=0)
-            # not all inputs are DNDarrays
-            with self.assertRaises(TypeError):
-                ht.vmap(lambda x: x, out_dims=0)(ht.ones(10), 2)
-            # number of output DNDarrays does not match number of split dimensions
-            with self.assertRaises(ValueError):
-                ht.vmap(lambda x: x, out_dims=(0, 1))(ht.ones(10))
+                        vfunc = ht.vmap(func, out_dims, chunk_size=cs)
+                        y0, y1 = vfunc(x0, x1, k=2, scale=-2.2)
+
+                        # compare with torch
+                        x0_torch = x0.resplit(None).larray
+                        x1_torch = x1.resplit(None).larray
+                        vfunc_torch = torch.vmap(func, (0, x1_split), out_dims)
+                        y0_torch, y1_torch = vfunc_torch(x0_torch, x1_torch, k=2, scale=-2.2)
+
+                        self.assertTrue(torch.allclose(y0.resplit(None).larray, y0_torch))
+                        tol = 1e-12 if dtype == ht.float64 else 1e-4
+                        self.assertTrue(
+                            torch.allclose(y1.resplit(None).larray, y1_torch, atol=tol)
+                        )
+
+    def test_vmap_catch_errors(self):
+        # not a callable
+        with self.assertRaises(TypeError):
+            ht.vmap(1)
+        # invalid randomness
+        with self.assertRaises(ValueError):
+            ht.vmap(lambda x: x, randomness="random")
+        # invalid chunk_size
+        with self.assertRaises(TypeError):
+            ht.vmap(lambda x: x, chunk_size="1")
+        with self.assertRaises(ValueError):
+            ht.vmap(lambda x: x, chunk_size=0)
+        # not all inputs are DNDarrays
+        with self.assertRaises(TypeError):
+            ht.vmap(lambda x: x, out_dims=0)(ht.ones(10), 2)
+        # number of output DNDarrays does not match number of split dimensions
+        with self.assertRaises(ValueError):
+            ht.vmap(lambda x: x, out_dims=(0, 1))(ht.ones(10))

--- a/tests/sparse/test_dcscmatrix.py
+++ b/tests/sparse/test_dcscmatrix.py
@@ -268,10 +268,6 @@ class TestDCSC_matrix(TestCase):
                 ).all()
             )
 
-    @unittest.skipIf(
-        int(torch.__version__.split(".")[0]) <= 1,
-        f"ht.sparse requires torch >= 2.0. Found version {torch.__version__}.",
-    )
     def test_astype(self):
         heat_sparse_csc = ht.sparse.sparse_csc_matrix(self.ref_torch_sparse_csc)
 


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Removes some if statements with older pytorch and numpy versions.

Issue/s resolved: #2447 

## Changes proposed:

- remove if statements pytorch < 2.4 in src and tests
- remove if statements numpy < 2.0 in tests

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

maintenance 

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
