### PR TITLE
add unique_values

### DIFF
--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -61,6 +61,7 @@ __all__ = [
     "topk",
     "unfold",
     "unique",
+    "unique_values",
     "vsplit",
     "vstack",
 ]
@@ -3640,6 +3641,19 @@ DNDarray.unique: Callable[[DNDarray, bool, bool, int], Tuple[DNDarray, torch.ten
     )
 )
 DNDarray.unique.__doc__ = unique.__doc__
+
+
+def unique_values(x: DNDarray, /) -> DNDarray:
+    """
+    Returns the unique elements of an input array ``x``.
+
+    Parameters
+    ----------
+    x : DNDarray
+        Input array. If ``x`` has more than one dimension, the function flattens ``x``
+        and returns the unique elements of the flattened array.
+    """
+    return unique(x)
 
 
 def unfold(a: DNDarray, axis: int, size: int, step: int = 1):

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3731,6 +3731,11 @@ class TestManipulations(TestCase):
             (inv == ht.array(exp_inv.to(dtype=inv.larray.dtype), split=inv.split)).all()
         )
 
+    def test_unique_values(self):
+        # unique_values calls unique internally
+        array = ht.array([1, 1, 2])
+        self.assertTrue(ht.equal(ht.unique_values(array), ht.unique(array)))
+
     def test_vsplit(self):
         # for further testing, see test_split
         data_ht = ht.arange(24).reshape((4, 3, 2))

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3732,9 +3732,25 @@ class TestManipulations(TestCase):
         )
 
     def test_unique_values(self):
-        # unique_values calls unique internally
-        array = ht.array([1, 1, 2])
-        self.assertTrue(ht.equal(ht.unique_values(array), ht.unique(array)))
+        # 1D array
+        array_ht = ht.array([1, 1, 2])
+        array_np = np.array([1, 1, 2])
+
+        unique_ht = ht.unique_values(array_ht)
+        unique_np = np.unique_values(array_np)
+
+        self.assertEqual(unique_ht.dtype, array_ht.dtype)
+        self.assertTrue(np.all(np.equal(ht.sort(array_ht).numpy(), np.sort(array_np))))
+
+        # 2D array
+        array_ht = ht.array([[1., 1], [2, 3]], split=0)
+        array_np = np.array([[1., 1], [2, 3]])
+
+        unique_ht = ht.unique_values(array_ht)
+        unique_np = np.unique_values(array_np)
+
+        self.assertEqual(unique_ht.dtype, array_ht.dtype)
+        self.assertTrue(np.all(np.equal(ht.sort(array_ht).numpy(), np.sort(array_np))))
 
     def test_vsplit(self):
         # for further testing, see test_split

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3738,7 +3738,7 @@ class TestManipulations(TestCase):
 
             self.assertEqual(unique_ht.dtype, array.dtype)
             self.assertEqual(unique_ht.device, array.device)
-            self.assertTrue(np.allclose(unique_ht.numpy(), unique_np))
+            self.assertTrue(np.allclose(np.sort(unique_ht.numpy()), np.sort(unique_np)))
 
     def test_vsplit(self):
         # for further testing, see test_split

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3732,25 +3732,13 @@ class TestManipulations(TestCase):
         )
 
     def test_unique_values(self):
-        # 1D array
-        array_ht = ht.array([1, 1, 2])
-        array_np = np.array([1, 1, 2])
-
-        unique_ht = ht.unique_values(array_ht)
-        unique_np = np.unique_values(array_np)
-
-        self.assertEqual(unique_ht.dtype, array_ht.dtype)
-        self.assertTrue(np.all(np.equal(ht.sort(array_ht).numpy(), np.sort(array_np))))
-
-        # 2D array
-        array_ht = ht.array([[1., 1], [2, 3]], split=0)
-        array_np = np.array([[1., 1], [2, 3]])
-
-        unique_ht = ht.unique_values(array_ht)
-        unique_np = np.unique_values(array_np)
-
-        self.assertEqual(unique_ht.dtype, array_ht.dtype)
-        self.assertTrue(np.all(np.equal(ht.sort(array_ht).numpy(), np.sort(array_np))))
+        for array in [ht.array([1, 1, 2]), ht.array([[1., 1], [2, 3]], split=0)]:
+            unique_ht = ht.unique_values(array)
+            unique_np = np.unique_values(array.numpy())
+            
+            self.assertEqual(unique_ht.dtype, array.dtype)
+            self.assertEqual(unique_ht.device, array.device)
+            self.assertTrue(np.allclose(unique_ht.numpy(), unique_np))
 
     def test_vsplit(self):
         # for further testing, see test_split

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3735,7 +3735,7 @@ class TestManipulations(TestCase):
         for array in [ht.array([1, 1, 2]), ht.array([[1., 1], [2, 3]], split=0)]:
             unique_ht = ht.unique_values(array)
             unique_np = np.unique_values(array.numpy())
-            
+
             self.assertEqual(unique_ht.dtype, array.dtype)
             self.assertEqual(unique_ht.device, array.device)
             self.assertTrue(np.allclose(unique_ht.numpy(), unique_np))


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR moves unique_values to the main namespace. Also adds a very simple test as it solely calls unique with default arguments.

Issue/s resolved: #2451 

## Changes proposed:

- unique_values

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

array api

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
