### PR TITLE
add unique_inverse

### DIFF
--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -3643,16 +3643,7 @@ DNDarray.unique: Callable[[DNDarray, bool, bool, int], Tuple[DNDarray, torch.ten
 DNDarray.unique.__doc__ = unique.__doc__
 
 
-class UniqueInverseResult(NamedTuple):
-    """
-    Internal object for return type of ``unique_inverse``.
-    """
-
-    values: DNDarray
-    inverse_indices: DNDarray
-
-
-def unique_inverse(x: DNDarray, /) -> UniqueInverseResult:
+def unique_inverse(x: DNDarray, /) -> Tuple[DNDarray, DNDarray]:
     """
     Returns the unique elements of an input array ``x`` and the indices from the
     set of unique elements that reconstruct ``x``.
@@ -3680,7 +3671,9 @@ def unique_inverse(x: DNDarray, /) -> UniqueInverseResult:
           [0, 2]])
     """
     result = unique(x, return_inverse=True)
-    return UniqueInverseResult(*result)
+    return NamedTuple("UniqueInverseResult", [("values", DNDarray), ("inverse_indices", DNDarray)])(
+        *result
+    )
 
 
 def unfold(a: DNDarray, axis: int, size: int, step: int = 1):

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 import warnings
 
-from typing import Any, Iterable, Type, List, Callable, Union, Tuple, Sequence, Optional
+from typing import Any, Iterable, Type, List, Callable, Union, Tuple, Sequence, Optional, NamedTuple
 
 from .communication import MPI, Communication
 from .dndarray import DNDarray
@@ -61,6 +61,7 @@ __all__ = [
     "topk",
     "unfold",
     "unique",
+    "unique_inverse",
     "vsplit",
     "vstack",
 ]
@@ -3640,6 +3641,46 @@ DNDarray.unique: Callable[[DNDarray, bool, bool, int], Tuple[DNDarray, torch.ten
     )
 )
 DNDarray.unique.__doc__ = unique.__doc__
+
+
+class UniqueInverseResult(NamedTuple):
+    """
+    Internal object for return type of ``unique_inverse``.
+    """
+
+    values: DNDarray
+    inverse_indices: DNDarray
+
+
+def unique_inverse(x: DNDarray, /) -> UniqueInverseResult:
+    """
+    Returns the unique elements of an input array ``x`` and the indices from the
+    set of unique elements that reconstruct ``x``.
+
+    Parameters
+    ----------
+    x : Array
+        Input array. If ``x`` has more than one dimension, the function flattens ``x``
+        and returns the unique elements of the flattened array.
+
+    See Also
+    --------
+    :func:`unique`
+
+    Examples
+    --------
+    >>> x = ht.array([[3, 2], [1, 3]])
+    >>> uniq = ht.unique_inverse(x)
+    >>> uniq.values
+    DNDarray(MPI-rank: 0, Shape: (3,), Split: None, Local Shape: (3,), Device: cpu:0, Dtype: int64, Data:
+         [1, 2, 3])
+    >>> uniq.inverse_indices
+    DNDarray(MPI-rank: 0, Shape: (2, 2), Split: None, Local Shape: (2, 2), Device: cpu:0, Dtype: int64, Data:
+         [[2, 1],
+          [0, 2]])
+    """
+    result = unique(x, return_inverse=True)
+    return UniqueInverseResult(*result)
 
 
 def unfold(a: DNDarray, axis: int, size: int, step: int = 1):

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3740,7 +3740,9 @@ class TestManipulations(TestCase):
             self.assertEqual(unique_ht.inverse_indices.dtype, ht.int64)
             self.assertEqual(unique_ht.values.device, array.device)
             self.assertTrue(np.allclose(np.sort(unique_ht.values.numpy()), np.sort(unique_np.values)))
+            self.assertTrue(np.allclose(np.sort(unique_ht[0].numpy()), np.sort(unique_np[0])))
             self.assertTrue(np.allclose(np.sort(unique_ht.inverse_indices.numpy()), np.sort(unique_np.inverse_indices)))
+            self.assertTrue(np.allclose(np.sort(unique_ht[1].numpy()), np.sort(unique_np[1])))
 
     def test_vsplit(self):
         # for further testing, see test_split

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3731,6 +3731,17 @@ class TestManipulations(TestCase):
             (inv == ht.array(exp_inv.to(dtype=inv.larray.dtype), split=inv.split)).all()
         )
 
+    def test_unique_inverse(self):
+        for array in [ht.array([1, 1, 2]), ht.array([[1., 1], [2, 3]], split=0)]:
+            unique_ht = ht.unique_inverse(array)
+            unique_np = np.unique_inverse(array.numpy())
+
+            self.assertEqual(unique_ht.values.dtype, array.dtype)
+            self.assertEqual(unique_ht.inverse_indices.dtype, ht.int64)
+            self.assertEqual(unique_ht.values.device, array.device)
+            self.assertTrue(np.allclose(np.sort(unique_ht.values.numpy()), np.sort(unique_np.values)))
+            self.assertTrue(np.allclose(np.sort(unique_ht.inverse_indices.numpy()), np.sort(unique_np.inverse_indices)))
+
     def test_vsplit(self):
         # for further testing, see test_split
         data_ht = ht.arange(24).reshape((4, 3, 2))


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Moves unique_inverse to main namespace

Issue/s resolved: #2450 

## Changes proposed:

- add unique_inverse
- add NamedTuple UniqueInverseResult 

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

array api

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
