### PR TITLE
Refactor `unique_inverse`

### DIFF
--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -3643,16 +3643,7 @@ DNDarray.unique: Callable[[DNDarray, bool, bool, int], Tuple[DNDarray, torch.ten
 DNDarray.unique.__doc__ = unique.__doc__
 
 
-class UniqueInverseResult(NamedTuple):
-    """
-    Internal object for return type of ``unique_inverse``.
-    """
-
-    values: DNDarray
-    inverse_indices: DNDarray
-
-
-def unique_inverse(x: DNDarray, /) -> UniqueInverseResult:
+def unique_inverse(x: DNDarray, /) -> Tuple[DNDarray, DNDarray]:
     """
     Returns the unique elements of an input array ``x`` and the indices from the
     set of unique elements that reconstruct ``x``.
@@ -3680,7 +3671,9 @@ def unique_inverse(x: DNDarray, /) -> UniqueInverseResult:
           [0, 2]])
     """
     result = unique(x, return_inverse=True)
-    return UniqueInverseResult(*result)
+    return NamedTuple("UniqueInverseResult", [("values", DNDarray), ("inverse_indices", DNDarray)])(
+        *result
+    )
 
 
 def unfold(a: DNDarray, axis: int, size: int, step: int = 1):

--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -3740,7 +3740,9 @@ class TestManipulations(TestCase):
             self.assertEqual(unique_ht.inverse_indices.dtype, ht.int64)
             self.assertEqual(unique_ht.values.device, array.device)
             self.assertTrue(np.allclose(np.sort(unique_ht.values.numpy()), np.sort(unique_np.values)))
+            self.assertTrue(np.allclose(np.sort(unique_ht[0].numpy()), np.sort(unique_np[0])))
             self.assertTrue(np.allclose(np.sort(unique_ht.inverse_indices.numpy()), np.sort(unique_np.inverse_indices)))
+            self.assertTrue(np.allclose(np.sort(unique_ht[1].numpy()), np.sort(unique_np[1])))
 
     def test_vsplit(self):
         # for further testing, see test_split


### PR DESCRIPTION
Puts definition of `UniqueInverseResult` into the `unique_inverse` function.