### PR TITLE
Increase atol in silhouette test

### DIFF
--- a/tests/cluster/test_metrics.py
+++ b/tests/cluster/test_metrics.py
@@ -150,7 +150,7 @@ class TestSilhouette(TestCase):
 
                                 if n_s == n_points:
                                     score_all = silhouette_score(data, labels, metric=metric)
-                                    assert np.isclose(score1, score_all)
+                                    assert np.isclose(score1, score_all, atol=1e-6)
                                 else:
                                     assert not np.isclose(score1, score3)
 


### PR DESCRIPTION
an assertion fails on two processes

## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Decreases the atol of a specific assertion with np.isclose in `test_silhouette_random_sampling`. It only fails exactly on two processes.

Issue/s resolved: #2462 

## Changes proposed:

- Increase atol to 1e-6

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

bug fix

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
