### PR TITLE
change broadcast arrays return type

### DIFF
--- a/heat/array_api/test/xfails.txt
+++ b/heat/array_api/test/xfails.txt
@@ -5,7 +5,6 @@ array_api_tests/test_array_object.py::test_getitem_masking
 array_api_tests/test_array_object.py::test_setitem_masking
 array_api_tests/test_array_object.py::test_getitem_arrays_and_ints_1[None]
 array_api_tests/test_array_object.py::test_getitem_arrays_and_ints_2[None]
-array_api_tests/test_array_object.py::test_scalar_casting[__float__(float64)]
 array_api_tests/test_creation_functions.py::test_arange
 array_api_tests/test_creation_functions.py::test_asarray_arrays
 array_api_tests/test_creation_functions.py::test_empty
@@ -18,9 +17,9 @@ array_api_tests/test_creation_functions.py::test_meshgrid
 array_api_tests/test_creation_functions.py::test_ones
 array_api_tests/test_creation_functions.py::test_ones_like
 array_api_tests/test_creation_functions.py::test_tril
+array_api_tests/test_creation_functions.py::test_triu
 array_api_tests/test_creation_functions.py::test_zeros
 array_api_tests/test_creation_functions.py::test_zeros_like
-array_api_tests/test_data_type_functions.py::test_broadcast_arrays
 array_api_tests/test_data_type_functions.py::test_broadcast_to
 array_api_tests/test_data_type_functions.py::test_isdtype
 array_api_tests/test_has_names.py::test_has_names[linalg-cholesky]

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -150,7 +150,7 @@ DNDarray.balance = lambda self, copy=False: balance(self, copy)
 DNDarray.balance.__doc__ = balance.__doc__
 
 
-def broadcast_arrays(*arrays: DNDarray) -> List[DNDarray]:
+def broadcast_arrays(*arrays: DNDarray) -> tuple[DNDarray]:
     """
     Broadcasts one or more arrays against one another. Returns the broadcasted arrays, distributed along the split dimension of the first array in the list. If the first array is not distributed, the output will not be distributed.
 
@@ -216,19 +216,18 @@ def broadcast_arrays(*arrays: DNDarray) -> List[DNDarray]:
     # broadcast the local torch tensors: this is a view of the original data
     broadcasted = torch.broadcast_tensors(*t_arrays)
 
-    out = []
-    for i in range(len(broadcasted)):
-        out.append(
-            DNDarray(
-                broadcasted[i],
-                gshape=output_shape,
-                dtype=arrays[i].dtype,
-                split=output_split,
-                device=arrays[i].device,
-                comm=output_comm,
-                balanced=output_balanced,
-            )
+    out = (
+        DNDarray(
+            broadcasted[i],
+            gshape=output_shape,
+            dtype=arrays[i].dtype,
+            split=output_split,
+            device=arrays[i].device,
+            comm=output_comm,
+            balanced=output_balanced,
         )
+        for i in range(len(broadcasted))
+    )
 
     return out
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -150,7 +150,7 @@ DNDarray.balance = lambda self, copy=False: balance(self, copy)
 DNDarray.balance.__doc__ = balance.__doc__
 
 
-def broadcast_arrays(*arrays: DNDarray) -> tuple[DNDarray]:
+def broadcast_arrays(*arrays: DNDarray) -> tuple[DNDarray, ...]:
     """
     Broadcasts one or more arrays against one another. Returns the broadcasted arrays, distributed along the split dimension of the first array in the list. If the first array is not distributed, the output will not be distributed.
 

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -216,7 +216,7 @@ def broadcast_arrays(*arrays: DNDarray) -> tuple[DNDarray]:
     # broadcast the local torch tensors: this is a view of the original data
     broadcasted = torch.broadcast_tensors(*t_arrays)
 
-    out = (
+    out = tuple(
         DNDarray(
             broadcasted[i],
             gshape=output_shape,


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Changes the return value to type tuple as defined in the latest array api specification

Issue/s resolved: #2466 

## Changes proposed:

- create a tuple instead of a list as the return value

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

array api

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
