### PR TITLE
skip large resplit test on GHActions

### DIFF
--- a/tests/core/test_manipulations.py
+++ b/tests/core/test_manipulations.py
@@ -1,9 +1,12 @@
+import os
 import numpy as np
 import unittest
 import torch
 
 import heat as ht
 from heat.testing.basic_test import TestCase
+
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 class TestManipulations(TestCase):
     def test_broadcast_arrays(self):
@@ -3245,7 +3248,8 @@ class TestManipulations(TestCase):
                             del a
                             del resplit_a
 
-    @unittest.skipIf(ht.MPI_WORLD.size != 2, "Test requires exactly 2 MPI processes")
+    # This test runs ~1h on Github Actions
+    @unittest.skipIf(IN_GITHUB_ACTIONS or ht.MPI_WORLD.size != 2, "Test requires exactly 2 MPI processes")
     def test_resplit_large_count_limit(self):
         if not self.is_mps:
             # Test resplit with large dimensions


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR skips a test on GitHub Actions that runs roughly an hour there.

Issue/s resolved: #2469 

## Changes proposed:

- skip test_resplit_large_count_limit on GitHub Actions

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

CI

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
