### PR TITLE
add astype function

### DIFF
--- a/heat/array_api/test/skips.txt
+++ b/heat/array_api/test/skips.txt
@@ -1,6 +1,5 @@
 # fails sometimes
 array_api_tests/test_creation_functions.py::test_asarray_scalars
-array_api_tests/test_data_type_functions.py::test_can_cast
 array_api_tests/test_linalg.py::test_matmul
 array_api_tests/test_manipulation_functions.py::test_concat
 array_api_tests/test_manipulation_functions.py::test_expand_dims

--- a/heat/array_api/test/skips.txt
+++ b/heat/array_api/test/skips.txt
@@ -1,6 +1,5 @@
 # fails sometimes
 array_api_tests/test_creation_functions.py::test_asarray_scalars
-array_api_tests/test_data_type_functions.py::test_astype
 array_api_tests/test_data_type_functions.py::test_can_cast
 array_api_tests/test_linalg.py::test_matmul
 array_api_tests/test_manipulation_functions.py::test_concat

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -558,11 +558,13 @@ class DNDarray:
         )
         if copy:
             return DNDarray(
-                casted_array, self.shape, dtype, self.split, self.device, self.comm, self.balanced
+                casted_array, self.shape, dtype, self.split, device, self.comm, self.balanced
             )
 
         self.__array = casted_array
         self.__dtype = dtype
+        self.__device = device
+
 
         return self
 

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -520,7 +520,7 @@ class DNDarray:
 
         return heat
 
-    def astype(self, dtype, copy=True) -> DNDarray:
+    def astype(self, dtype, copy=True, device: Device = None) -> DNDarray:
         """
         Returns a casted version of this array.
         Casted array is a new array of the same shape but with given type of this array. If copy is ``True``, the
@@ -533,9 +533,11 @@ class DNDarray:
         copy : bool, optional
             By default the operation returns a copy of this array. If copy is set to ``False`` the cast is performed
             in-place and this array is returned
-
+        device: ht.Device, optional
+            The device on which to place the array. If ``None``, keep device. Default: None.
         """
         dtype = canonical_heat_type(dtype)
+        device = self.__device if device is None else devices.sanitize_device(device)
         if self.__array.is_mps:
             if dtype == types.float64:
                 # print warning
@@ -551,7 +553,9 @@ class DNDarray:
                     ResourceWarning,
                 )
                 dtype = types.complex64
-        casted_array = self.__array.type(dtype.torch_type())
+        casted_array = self.__array.to(
+            device=device.torch_device, dtype=dtype.torch_type(), copy=copy
+        )
         if copy:
             return DNDarray(
                 casted_array, self.shape, dtype, self.split, self.device, self.comm, self.balanced

--- a/heat/core/dndarray.py
+++ b/heat/core/dndarray.py
@@ -565,7 +565,6 @@ class DNDarray:
         self.__dtype = dtype
         self.__device = device
 
-
         return self
 
     def balance_(self) -> None:

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -820,6 +820,7 @@ def heat_type_of(
 def can_cast(
     from_: Union[str, Type[datatype], Any],
     to: Union[str, Type[datatype], Any],
+    /,
     casting: str = "intuitive",
 ) -> bool:
     """

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -45,6 +45,7 @@ __all__ = [
     "float64",
     "double",
     "flexible",
+    "astype",
     "can_cast",
     "canonical_heat_type",
     "heat_type_is_exact",
@@ -635,6 +636,47 @@ def __get_all_heat_types():
 
     type_related_classes = all_subclasses(datatype)
     return [me for me in type_related_classes if len(me.__subclasses__()) == 0]
+
+
+def astype(
+    x: dndarray.DNDarray,
+    dtype: datatype,
+    /,
+    *,
+    copy: bool = True,
+    device: devices.Device | None = None,
+):
+    """
+    Copies an array to a specified data type irrespective of Type Promotion Rules.
+
+    Parameters
+    ----------
+    x : Array
+        Array to cast.
+    dtype : Dtype
+        Desired data type.
+    copy : bool
+        If ``True``, a newly allocated array is returned. If ``False`` and the
+        specified ``dtype`` matches the data type of the input array, the
+        input array is returned; otherwise, a newly allocated is returned.
+        Default: ``True``.
+    device : ht.Device, optional
+        The device on which to place the returned array. If ``None``, infers device from ``x``. Default: None.
+
+    Examples
+    --------
+    >>> import heat as ht
+    >>> arr = ht.array([1, 2, 3])
+    >>> arr
+    DNDarray(MPI-rank: 0, Shape: (3,), Split: None, Local Shape: (3,), Device: cpu:0, Dtype: int64, Data:
+         [1, 2, 3])
+    >>> ht.astype(arr, ht.float64)
+    DNDarray(MPI-rank: 0, Shape: (3,), Split: None, Local Shape: (3,), Device: cpu:0, Dtype: float64, Data:
+         [1., 2., 3.])
+    """
+    sanitation.sanitize_in(x)
+
+    return x.astype(dtype, copy)
 
 
 def canonical_heat_type(a_type: Union[str, Type[datatype], Any]) -> Type[datatype]:

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -647,7 +647,7 @@ def astype(
     device: devices.Device | None = None,
 ):
     """
-    Copies an array to a specified data type irrespective of Type Promotion Rules.
+    Copies an array to a specified data type irrespective of type promotion rules.
 
     Parameters
     ----------

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -676,7 +676,7 @@ def astype(
     """
     sanitation.sanitize_in(x)
 
-    return x.astype(dtype, copy)
+    return x.astype(dtype, copy=copy, device=device)
 
 
 def canonical_heat_type(a_type: Union[str, Type[datatype], Any]) -> Type[datatype]:

--- a/tests/core/test_dndarray.py
+++ b/tests/core/test_dndarray.py
@@ -432,27 +432,6 @@ class TestDNDarray(TestCase):
         with self.assertRaises(TypeError):
             x.larray = "[1, 2, 3]"
 
-    def test_astype(self):
-        data = ht.float32([[1, 2, 3], [4, 5, 6]])
-
-        # check starting invariant
-        self.assertEqual(data.dtype, ht.float32)
-
-        # check the copy case for uint8
-        as_uint8 = data.astype(ht.uint8)
-        self.assertIsInstance(as_uint8, ht.DNDarray)
-        self.assertEqual(as_uint8.dtype, ht.uint8)
-        self.assertEqual(as_uint8.larray.dtype, torch.uint8)
-        self.assertIsNot(as_uint8, data)
-
-        # check the copy case for float64
-        if not self.is_mps:
-            as_float64 = data.astype(ht.float64, copy=False)
-            self.assertIsInstance(as_float64, ht.DNDarray)
-            self.assertEqual(as_float64.dtype, ht.float64)
-            self.assertEqual(as_float64.larray.dtype, torch.float64)
-            self.assertIs(as_float64, data)
-
     def test_balance_and_lshape_map(self):
         data = ht.zeros((70, 20), split=0)
         data = data[:50]

--- a/tests/core/test_dndarray.py
+++ b/tests/core/test_dndarray.py
@@ -455,7 +455,7 @@ class TestDNDarray(TestCase):
             self.assertIs(as_float64, data)
 
         # check device case for complex
-        as_complex64 = ht.astype(data, ht.complex64, device=ht.cpu)
+        as_complex64 = data.astype(ht.complex64, device=ht.cpu)
         array_type_check(as_complex64, ht.complex64)
         self.assertEqual(as_complex64.device, ht.cpu)
 

--- a/tests/core/test_dndarray.py
+++ b/tests/core/test_dndarray.py
@@ -432,6 +432,33 @@ class TestDNDarray(TestCase):
         with self.assertRaises(TypeError):
             x.larray = "[1, 2, 3]"
 
+    def test_astype(self):
+        def array_type_check(array, dtype):
+            self.assertIsInstance(array, ht.DNDarray)
+            self.assertEqual(array.dtype, dtype)
+            self.assertEqual(array.larray.dtype, dtype.torch_type())
+
+        data = ht.float32([[1, 2, 3], [4, 5, 6]])
+
+        # check starting invariant
+        self.assertEqual(data.dtype, ht.float32)
+
+        # check the copy case for uint8
+        as_uint8 = data.astype(ht.uint8)
+        array_type_check(as_uint8, ht.uint8)
+        self.assertIsNot(as_uint8, data)
+
+        # check the copy case for float64
+        if not self.is_mps:
+            as_float64 = data.astype(ht.float64, copy=False)
+            array_type_check(as_float64, ht.float64)
+            self.assertIs(as_float64, data)
+
+        # check device case for complex
+        as_complex64 = ht.astype(data, ht.complex64, device=ht.cpu)
+        array_type_check(as_complex64, ht.complex64)
+        self.assertEqual(as_complex64.device, ht.cpu)
+
     def test_balance_and_lshape_map(self):
         data = ht.zeros((70, 20), split=0)
         data = data[:50]

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -192,6 +192,41 @@ class TestTypes(TestCase):
 
 
 class TestTypeConversion(TestCase):
+    def test_astype(self):
+        def array_type_check(array, dtype):
+            self.assertIsInstance(array, ht.DNDarray)
+            self.assertEqual(array.dtype, dtype)
+            self.assertEqual(array.larray.dtype, dtype.torch_type())
+
+
+        data = ht.float32([[1, 2, 3], [4, 5, 6]])
+
+        # check starting invariant
+        self.assertEqual(data.dtype, ht.float32)
+
+        # check the copy case for uint8
+        as_uint8_f = ht.astype(data, ht.uint8)
+        array_type_check(as_uint8_f, ht.uint8)
+        self.assertIsNot(as_uint8_f, data)
+
+        # DNDarray method
+        as_uint8 = data.astype(ht.uint8)
+        array_type_check(as_uint8, ht.uint8)
+        self.assertIsNot(as_uint8, data)
+
+        self.assertTrue(ht.equal(as_uint8, as_uint8_f))
+
+        # check the copy case for float64
+        if not self.is_mps:
+            as_float64 = data.astype(ht.float64, copy=False)
+            array_type_check(as_float64, ht.float64)
+            self.assertIs(as_float64, data)
+
+        # check device case for complex
+        as_complex64 = ht.astype(data, ht.complex64, device=ht.cpu)
+        array_type_check(as_complex64, ht.complex64)
+        self.assertEqual(as_complex64.device, ht.cpu)
+
     def test_can_cast(self):
         zeros_array = np.zeros((3,), dtype=np.int16)
 

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -193,39 +193,26 @@ class TestTypes(TestCase):
 
 class TestTypeConversion(TestCase):
     def test_astype(self):
-        def array_type_check(array, dtype):
-            self.assertIsInstance(array, ht.DNDarray)
-            self.assertEqual(array.dtype, dtype)
-            self.assertEqual(array.larray.dtype, dtype.torch_type())
-
-
+        # check the call to DNDarray.astype
         data = ht.float32([[1, 2, 3], [4, 5, 6]])
 
         # check starting invariant
         self.assertEqual(data.dtype, ht.float32)
 
-        # check the copy case for uint8
-        as_uint8_f = ht.astype(data, ht.uint8)
-        array_type_check(as_uint8_f, ht.uint8)
-        self.assertIsNot(as_uint8_f, data)
+        # check the copy case for int16
+        as_int16_f = ht.astype(data, ht.int16)
+        self.assertIsInstance(as_int16_f, ht.DNDarray)
+        self.assertIsNot(as_int16_f, data)
 
         # DNDarray method
-        as_uint8 = data.astype(ht.uint8)
-        array_type_check(as_uint8, ht.uint8)
-        self.assertIsNot(as_uint8, data)
+        as_int16 = data.astype(ht.int16)
 
-        self.assertTrue(ht.equal(as_uint8, as_uint8_f))
+        self.assertTrue(ht.equal(as_int16_f, as_int16))
+        self.assertEqual(as_int16_f.dtype, as_int16.dtype)
+        self.assertEqual(as_int16_f.device, as_int16.device)
 
-        # check the copy case for float64
-        if not self.is_mps:
-            as_float64 = data.astype(ht.float64, copy=False)
-            array_type_check(as_float64, ht.float64)
-            self.assertIs(as_float64, data)
-
-        # check device case for complex
-        as_complex64 = ht.astype(data, ht.complex64, device=ht.cpu)
-        array_type_check(as_complex64, ht.complex64)
-        self.assertEqual(as_complex64.device, ht.cpu)
+        with self.assertRaises(TypeError):
+            ht.astype("A", ht.int32)
 
     def test_can_cast(self):
         zeros_array = np.zeros((3,), dtype=np.int16)


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR adds ht.astype for array api compatibility.

Issue/s resolved: #2472 

## Changes proposed:

- add `ht.astype`
- move `test_astype` from `test_dndarray` to `test_types.py`

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

array api

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no
