### PR TITLE
add isdtype function

### DIFF
--- a/heat/array_api/test/xfails.txt
+++ b/heat/array_api/test/xfails.txt
@@ -20,8 +20,6 @@ array_api_tests/test_creation_functions.py::test_tril
 array_api_tests/test_creation_functions.py::test_triu
 array_api_tests/test_creation_functions.py::test_zeros
 array_api_tests/test_creation_functions.py::test_zeros_like
-array_api_tests/test_data_type_functions.py::test_broadcast_to
-array_api_tests/test_data_type_functions.py::test_isdtype
 array_api_tests/test_has_names.py::test_has_names[linalg-cholesky]
 array_api_tests/test_has_names.py::test_has_names[linalg-cross]
 array_api_tests/test_has_names.py::test_has_names[linalg-det]

--- a/heat/core/manipulations.py
+++ b/heat/core/manipulations.py
@@ -232,7 +232,7 @@ def broadcast_arrays(*arrays: DNDarray) -> tuple[DNDarray, ...]:
     return out
 
 
-def broadcast_to(x: DNDarray, shape: Tuple[int, ...]) -> DNDarray:
+def broadcast_to(x: DNDarray, /, shape: tuple[int, ...]) -> DNDarray:
     """
     Broadcasts an array to a specified shape. Returns a view of ``x`` if ``x`` is not distributed, otherwise it returns a broadcasted, distributed, load-balanced copy of ``x``.
 

--- a/heat/core/types.py
+++ b/heat/core/types.py
@@ -52,6 +52,7 @@ __all__ = [
     "heat_type_is_realfloating",
     "heat_type_is_complexfloating",
     "iscomplex",
+    "isdtype",
     "isreal",
     "issubdtype",
     "heat_type_of",
@@ -860,6 +861,58 @@ def iscomplex(x: dndarray.DNDarray) -> dndarray.DNDarray:
         return x.imag != 0
     else:
         return factories.zeros(x.shape, bool, split=x.split, device=x.device, comm=x.comm)
+
+
+def isdtype(dtype: datatype, kind: datatype | str | tuple[datatype | str, ...]) -> bool:
+    """
+    Returns a boolean indicating whether a provided dtype is of a specified data type “kind”.
+
+    Parameters
+    ----------
+    dtype : datatype
+        the input dtype.
+    kind : str or dtype or Tuple[str, dtype], ...]
+        data type kind.
+    """
+    dtype = canonical_heat_type(dtype)
+
+    input_kinds = kind if isinstance(kind, tuple) else (kind,)
+
+    processed_kinds = set()
+
+    for kind in input_kinds:
+        match kind:
+            case "bool":
+                processed_kinds.add(bool)
+            case "signed integer":
+                processed_kinds.update((int8, int16, int32, int64))
+            case "unsigned integer":
+                processed_kinds.add(uint8)
+            case "integral":
+                processed_kinds.update((int8, int16, int32, int64, uint8))
+            case "real floating":
+                processed_kinds.update((float16, float32, float64))
+            case "complex floating":
+                processed_kinds.update((complex64, complex128))
+            case "numeric":
+                processed_kinds.update(
+                    (
+                        int8,
+                        int16,
+                        int32,
+                        int64,
+                        uint8,
+                        float16,
+                        float32,
+                        float64,
+                        complex64,
+                        complex128,
+                    )
+                )
+            case _:
+                processed_kinds.add(canonical_heat_type(kind))
+
+    return dtype in processed_kinds
 
 
 def isreal(x: dndarray.DNDarray) -> dndarray.DNDarray:

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -278,6 +278,38 @@ class TestTypeConversion(TestCase):
         with self.assertRaises(TypeError):
             ht.core.types.heat_type_of(object)
 
+    def test_isdtype(self):
+        dtype = ht.bool
+        self.assertTrue(ht.isdtype(dtype, ht.bool))
+        self.assertFalse(ht.isdtype(dtype, ht.uint8))
+        self.assertTrue(ht.isdtype(dtype, "bool"))
+        self.assertFalse(ht.isdtype(dtype, ("signed integer", "unsigned integer")))
+        self.assertFalse(ht.isdtype(dtype, "integral"))
+        self.assertFalse(ht.isdtype(dtype, ("real floating", "complex floating")))
+        self.assertFalse(ht.isdtype(dtype, "numeric"))
+
+        dtype = ht.int64
+        self.assertTrue(ht.isdtype(dtype, ht.int64))
+        self.assertTrue(ht.isdtype(dtype, "signed integer"))
+        self.assertFalse(ht.isdtype(dtype, "unsigned integer"))
+        self.assertTrue(ht.isdtype(dtype, "integral"))
+        self.assertFalse(ht.isdtype(dtype, ("bool", "real floating", "complex floating")))
+        self.assertTrue(ht.isdtype(dtype, "numeric"))
+
+        dtype = ht.float32
+        self.assertTrue(ht.isdtype(dtype, ht.float32))
+        self.assertFalse(ht.isdtype(dtype, ("bool", "signed integer", "unsigned integer", "integral")))
+        self.assertTrue(ht.isdtype(dtype, "real floating"))
+        self.assertFalse(ht.isdtype(dtype, "complex floating"))
+        self.assertTrue(ht.isdtype(dtype, "numeric"))
+
+        with self.assertRaises(TypeError):
+            ht.isdtype("typo", ht.complex64)
+
+        with self.assertRaises(TypeError):
+            ht.isdtype(ht.uint8, "int")
+
+
     def test_issubdtype(self):
         # First level
         self.assertTrue(ht.issubdtype(ht.bool, ht.datatype))


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR adds ht.isdtype

Issue/s resolved: #2477

## Changes proposed:

- as isdtype()
- update signature broadcast_to()
- remove isdtype and broadcast_to from `xskips.txt`
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

New feature

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
no
