### PR TITLE
make arange() follow array api standard

### DIFF
--- a/heat/array_api/_creation_functions.py
+++ b/heat/array_api/_creation_functions.py
@@ -37,7 +37,7 @@ def arange(
         ``stop >= start``. Default: ``1``.
     dtype : Optional[Dtype]
         Output array data type. If ``dtype`` is ``None``, the output array data
-        type is inferred from ``start``, ``stop`` and ``step``.
+        type is inferred from ``start``, ``stop`` and ``step``. Default: ``None``
     device : Optional[Device]
         Device on which to place the created array. Default: ``None``.
     """

--- a/heat/array_api/test/xfails.txt
+++ b/heat/array_api/test/xfails.txt
@@ -5,7 +5,6 @@ array_api_tests/test_array_object.py::test_getitem_masking
 array_api_tests/test_array_object.py::test_setitem_masking
 array_api_tests/test_array_object.py::test_getitem_arrays_and_ints_1[None]
 array_api_tests/test_array_object.py::test_getitem_arrays_and_ints_2[None]
-array_api_tests/test_creation_functions.py::test_arange
 array_api_tests/test_creation_functions.py::test_asarray_arrays
 array_api_tests/test_creation_functions.py::test_empty
 array_api_tests/test_creation_functions.py::test_empty_like

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -97,11 +97,10 @@ def arange(
     >>> ht.arange(3, 7, 2)
     DNDarray([3, 5], dtype=ht.int32, device=cpu:0, split=None)
     """
-    # invariance
     if not isinstance(start, (int, float)):
         raise TypeError(f"'start' must be int or float. Got {type(start)}")
 
-    # set start, stop if
+    # set start and stop if no stop is specified
     if stop is None:
         start, stop = 0, start
 

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -41,11 +41,15 @@ __all__ = [
 
 
 def arange(
-    *args: Union[int, float],
-    dtype: Optional[Type[datatype]] = None,
-    split: Optional[int] = None,
-    device: Optional[Union[str, Device]] = None,
-    comm: Optional[Communication] = None,
+    start: int | float,
+    /,
+    stop: int | float | None = None,
+    step: int | float = 1,
+    *,
+    dtype: datatype | None = None,
+    split: int | None = None,
+    device: str | Device | None = None,
+    comm: Communication | None = None,
 ) -> DNDarray:
     """
     Return evenly spaced values within a given interval.
@@ -61,12 +65,13 @@ def arange(
 
     Parameters
     ----------
-    *args : int or float, optional
-        Positional arguments defining the interval. Can be:
-        - A single argument: interpreted as `stop`, with `start=0` and `step=1`.
-        - Two arguments: interpreted as `start` and `stop`, with `step=1`.
-        - Three arguments: interpreted as `start`, `stop`, and `step`.
-        The function raises a `TypeError` if more than three arguments are provided.
+    start : int or float
+        if ``stop`` is specified, the start of the interval (inclusive); otherwise, the end of the interval (exclusive).
+        If ``stop`` is not specified, the default starting value is ``0``.
+    stop : int or float, optional
+        the end of the interval. Default: None.
+    step : int or float, optional
+        the distance between two adjacent elements (``out[i+1] - out[i]``). Default: ``1``.
     dtype : datatype, optional
         The type of the output array.  If `dtype` is not given, it is automatically inferred from the other input
         arguments.
@@ -92,42 +97,43 @@ def arange(
     >>> ht.arange(3, 7, 2)
     DNDarray([3, 5], dtype=ht.int32, device=cpu:0, split=None)
     """
-    num_of_param = len(args)
+    # invariance
+    if not isinstance(start, (int, float)):
+        raise TypeError(f"'start' must be int or float. Got {type(start)}")
 
-    # check if all positional arguments are integers
-    all_ints = all([isinstance(_, int) for _ in args])
+    # set start, stop if
+    if stop is None:
+        start, stop = 0, start
 
-    # set start, stop, step, num according to *args
-    if num_of_param == 1:
-        if dtype is None:
-            # use int32 as default instead of int64 used in numpy
-            dtype = types.int32 if all_ints else types.float32
-        start = 0
-        stop = int(np.ceil(args[0]))
-        step = 1
-        num = stop
-    elif num_of_param == 2:
-        if dtype is None:
-            dtype = types.int32 if all_ints else types.float32
-        start = args[0]
-        stop = args[1]
-        step = 1
-        num = int(np.ceil(stop - start))
-    elif num_of_param == 3:
-        if dtype is None:
-            dtype = types.int32 if all_ints else types.float32
-        start = args[0]
-        stop = args[1]
-        step = args[2]
-        num = int(np.ceil((stop - start) / step))
-    else:
-        raise TypeError(
-            f"function takes minimum one and at most 3 positional arguments ({num_of_param} given)"
-        )
+    if not isinstance(stop, (int, float)):
+        raise TypeError(f"'stop' must be int or float. Got {type(stop)}")
+
+    if not isinstance(step, (int, float)):
+        raise TypeError(f"'step' must be int or float. Got {type(step)}")
+
+    if step == 0:
+        raise ValueError("'step' cannot be 0.")
 
     # sanitize device and comm
     device = devices.sanitize_device(device)
     comm = sanitize_comm(comm)
+
+    if dtype is None:
+        dtype = types.float32 if float in (type(start), type(stop), type(step)) else types.int64
+
+    dtype = types.canonical_heat_type(dtype)
+
+    num = int(np.ceil((stop - start) / step))
+    if np.sign(num) < 1:
+        return DNDarray(
+            torch.tensor([], dtype=dtype.torch_type(), device=device.torch_device),
+            gshape=(0,),
+            dtype=dtype,
+            split=split,
+            device=device,
+            comm=comm,
+            balanced=True,
+        )
 
     gshape = (num,)
     split = sanitize_axis(gshape, split)
@@ -137,12 +143,10 @@ def arange(
     # compose the local tensor
     start += offset * step
     stop = start + lshape[0] * step
-    htype = types.canonical_heat_type(dtype)
-    if types.issubdtype(htype, types.floating):
-        data = torch.arange(start, stop, step, dtype=htype.torch_type(), device=device.torch_device)
-    else:
-        data = torch.arange(start, stop, step, device=device.torch_device)
-        data = data.type(htype.torch_type())
+
+    data = torch.arange(start, stop, step, dtype=dtype.torch_type(), device=device.torch_device)
+    htype = types.canonical_heat_type(data.dtype)
+
     return DNDarray(
         data, gshape=gshape, dtype=htype, split=split, device=device, comm=comm, balanced=balanced
     )

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -143,7 +143,7 @@ def arange(
     # compose the local tensor
     start += offset * step
     stop = start + lshape[0] * step
-        
+
     if types.issubdtype(dtype, types.floating):
         data = torch.arange(start, stop, step, dtype=dtype.torch_type(), device=device.torch_device)
     else:

--- a/heat/core/factories.py
+++ b/heat/core/factories.py
@@ -143,12 +143,15 @@ def arange(
     # compose the local tensor
     start += offset * step
     stop = start + lshape[0] * step
-
-    data = torch.arange(start, stop, step, dtype=dtype.torch_type(), device=device.torch_device)
-    htype = types.canonical_heat_type(data.dtype)
+        
+    if types.issubdtype(dtype, types.floating):
+        data = torch.arange(start, stop, step, dtype=dtype.torch_type(), device=device.torch_device)
+    else:
+        data = torch.arange(start, stop, step, device=device.torch_device)
+        data = data.type(dtype.torch_type())
 
     return DNDarray(
-        data, gshape=gshape, dtype=htype, split=split, device=device, comm=comm, balanced=balanced
+        data, gshape=gshape, dtype=dtype, split=split, device=device, comm=comm, balanced=balanced
     )
 
 

--- a/tests/core/linalg/test_basics.py
+++ b/tests/core/linalg/test_basics.py
@@ -1807,10 +1807,10 @@ class TestLinalgBasics(TestCase):
 
     def test_transpose(self):
         # vector transpose, not distributed
-        vector = ht.arange(10, dtype=ht.int32)
+        vector = ht.arange(10)
         vector_t = vector.T
         self.assertIsInstance(vector_t, ht.DNDarray)
-        self.assertEqual(vector_t.dtype, ht.int32)
+        self.assertEqual(vector_t.dtype, ht.int64)
         self.assertEqual(vector_t.split, None)
         self.assertEqual(vector_t.shape, (10,))
 

--- a/tests/core/linalg/test_basics.py
+++ b/tests/core/linalg/test_basics.py
@@ -1807,7 +1807,7 @@ class TestLinalgBasics(TestCase):
 
     def test_transpose(self):
         # vector transpose, not distributed
-        vector = ht.arange(10)
+        vector = ht.arange(10, dtype=ht.int32)
         vector_t = vector.T
         self.assertIsInstance(vector_t, ht.DNDarray)
         self.assertEqual(vector_t.dtype, ht.int32)
@@ -1833,7 +1833,7 @@ class TestLinalgBasics(TestCase):
         self.assertEqual(array_4d_t.larray.shape, (5, 2, 4, 3))
 
         # vector transpose, distributed
-        vector_split = ht.arange(10, split=0)
+        vector_split = ht.arange(10, dtype=ht.int32, split=0)
         vector_split_t = vector_split.T
         self.assertIsInstance(vector_split_t, ht.DNDarray)
         self.assertEqual(vector_split_t.dtype, ht.int32)

--- a/tests/core/test_dndarray.py
+++ b/tests/core/test_dndarray.py
@@ -335,7 +335,7 @@ class TestDNDarray(TestCase):
 
     def test_array(self):
         # undistributed case
-        x = ht.arange(6 * 7 * 8).reshape((6, 7, 8))
+        x = ht.arange(6 * 7 * 8, dtype=ht.int32).reshape((6, 7, 8))
         x_np = np.arange(6 * 7 * 8, dtype=np.int32).reshape((6, 7, 8))
 
         self.assertTrue((x.__array__() == x_np).all())

--- a/tests/core/test_factories.py
+++ b/tests/core/test_factories.py
@@ -12,8 +12,8 @@ class TestFactories(TestCase):
         self.assertIsInstance(one_arg_arange_int, ht.DNDarray)
         self.assertEqual(one_arg_arange_int.shape, (10,))
         self.assertLessEqual(one_arg_arange_int.lshape[0], 10)
-        self.assertEqual(one_arg_arange_int.dtype, ht.int32)
-        self.assertEqual(one_arg_arange_int.larray.dtype, torch.int32)
+        self.assertEqual(one_arg_arange_int.dtype, ht.int64)
+        self.assertEqual(one_arg_arange_int.larray.dtype, torch.int64)
         self.assertEqual(one_arg_arange_int.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(one_arg_arange_int.sum(), 45)
@@ -34,8 +34,8 @@ class TestFactories(TestCase):
         self.assertIsInstance(two_arg_arange_int, ht.DNDarray)
         self.assertEqual(two_arg_arange_int.shape, (10,))
         self.assertLessEqual(two_arg_arange_int.lshape[0], 10)
-        self.assertEqual(two_arg_arange_int.dtype, ht.int32)
-        self.assertEqual(two_arg_arange_int.larray.dtype, torch.int32)
+        self.assertEqual(two_arg_arange_int.dtype, ht.int64)
+        self.assertEqual(two_arg_arange_int.larray.dtype, torch.int64)
         self.assertEqual(two_arg_arange_int.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(two_arg_arange_int.sum(), 45)
@@ -56,8 +56,8 @@ class TestFactories(TestCase):
         self.assertIsInstance(three_arg_arange_int, ht.DNDarray)
         self.assertEqual(three_arg_arange_int.shape, (5,))
         self.assertLessEqual(three_arg_arange_int.lshape[0], 5)
-        self.assertEqual(three_arg_arange_int.dtype, ht.int32)
-        self.assertEqual(three_arg_arange_int.larray.dtype, torch.int32)
+        self.assertEqual(three_arg_arange_int.dtype, ht.int64)
+        self.assertEqual(three_arg_arange_int.larray.dtype, torch.int64)
         self.assertEqual(three_arg_arange_int.split, None)
         # make an in direct check for the sequence, compare against the gaussian sum
         self.assertEqual(three_arg_arange_int.sum(), 20)
@@ -85,7 +85,7 @@ class TestFactories(TestCase):
         self.assertEqual(three_arg_arange_dtype_float32.sum(axis=0, keepdims=True), 20.0)
 
         # testing setting dtype to int16
-        three_arg_arange_dtype_short = ht.arange(0, 10, 2.0, dtype=torch.int16)
+        three_arg_arange_dtype_short = ht.arange(0, 10, 2.0, dtype=ht.int16)
         self.assertIsInstance(three_arg_arange_dtype_short, ht.DNDarray)
         self.assertEqual(three_arg_arange_dtype_short.shape, (5,))
         self.assertLessEqual(three_arg_arange_dtype_short.lshape[0], 5)
@@ -97,7 +97,7 @@ class TestFactories(TestCase):
 
         # testing setting dtype to float64
         if not self.is_mps:
-            three_arg_arange_dtype_float64 = ht.arange(0, 10, 2, dtype=torch.float64)
+            three_arg_arange_dtype_float64 = ht.arange(0, 10, 2, dtype=ht.float64)
             self.assertIsInstance(three_arg_arange_dtype_float64, ht.DNDarray)
             self.assertEqual(three_arg_arange_dtype_float64.shape, (5,))
             self.assertLessEqual(three_arg_arange_dtype_float64.lshape[0], 5)
@@ -110,6 +110,15 @@ class TestFactories(TestCase):
             check_precision = ht.arange(16777217.0, 16777218, 1, dtype=ht.float64)
             self.assertEqual(check_precision.sum(), 16777217)
 
+        # empty array
+        empty_array = ht.arange(5, 0, 1, dtype=ht.int32)
+        self.assertIsInstance(empty_array, ht.DNDarray)
+        self.assertEqual(empty_array.shape, (0,))
+        self.assertEqual(empty_array.dtype, ht.int32)
+        self.assertEqual(empty_array.larray.dtype, torch.int32)
+        self.assertEqual(empty_array.split, None)
+        self.assertTrue(ht.equal(empty_array, ht.array([], dtype=ht.int32)))
+
         # exceptions
         with self.assertRaises(ValueError):
             ht.arange(-5, 3, split=1)
@@ -117,6 +126,12 @@ class TestFactories(TestCase):
             ht.arange()
         with self.assertRaises(TypeError):
             ht.arange(1, 2, 3, 4)
+        with self.assertRaises(ValueError):
+            ht.arange(5, step=0)
+        with self.assertRaises(TypeError):
+            ht.arange("A")
+        with self.assertRaises(TypeError):
+            ht.arange(0, "A")
 
     def test_array(self):
         # basic array function, unsplit data

--- a/tests/core/test_printing.py
+++ b/tests/core/test_printing.py
@@ -134,7 +134,7 @@ class TestPrinting(TestCase):
             self.assertEqual(comparison, __str)
 
     def test_unbalanced(self):
-        dndarray = ht.arange(2 * 3 * 4, split=0).reshape((2, 3, 4))
+        dndarray = ht.arange(2 * 3 * 4, dtype=ht.int32, split=0).reshape((2, 3, 4))
         if dndarray.comm.size == 2:
             comparison = (
                 "DNDarray([[ 0,  1,  2,  3],\n"
@@ -146,7 +146,7 @@ class TestPrinting(TestCase):
                 self.assertEqual(comparison, __str)
 
     def test_unsplit_below_threshold(self):
-        dndarray = ht.arange(2 * 3 * 4).reshape((2, 3, 4))
+        dndarray = ht.arange(2 * 3 * 4, dtype=ht.int32).reshape((2, 3, 4))
         comparison = (
             "DNDarray([[[ 0,  1,  2,  3],\n"
             "           [ 4,  5,  6,  7],\n"
@@ -162,7 +162,7 @@ class TestPrinting(TestCase):
             self.assertEqual(comparison, __str)
 
     def test_unsplit_above_threshold(self):
-        dndarray = ht.arange(12 * 13 * 14).reshape((12, 13, 14))
+        dndarray = ht.arange(12 * 13 * 14, dtype=ht.int32).reshape((12, 13, 14))
         comparison = (
             "DNDarray([[[   0,    1,    2,  ...,   11,   12,   13],\n"
             "           [  14,   15,   16,  ...,   25,   26,   27],\n"
@@ -332,7 +332,7 @@ class TestPrinting(TestCase):
 
     def test_split_1_above_threshold(self):
         ht.set_printoptions(edgeitems=2)
-        dndarray = ht.arange(10 * 11 * 12).reshape((10, 11, 12)).resplit_(1)
+        dndarray = ht.arange(10 * 11 * 12, dtype=ht.int32).reshape((10, 11, 12)).resplit_(1)
         comparison = (
             "DNDarray([[[   0,    1,  ...,   10,   11],\n"
             "           [  12,   13,  ...,   22,   23],\n"
@@ -399,7 +399,7 @@ class TestPrinting(TestCase):
 
     def test_split_2_above_threshold(self):
         ht.set_printoptions(threshold=1)
-        dndarray = ht.arange(3 * 10 * 12).reshape((3, 10, 12)).resplit_(2)
+        dndarray = ht.arange(3 * 10 * 12, dtype=ht.int32).reshape((3, 10, 12)).resplit_(2)
         comparison = (
             "DNDarray([[[  0,   1,   2,  ...,   9,  10,  11],\n"
             "           [ 12,  13,  14,  ...,  21,  22,  23],\n"


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR makes the arange closer to the specification array api. The default type inferred for int is now ht.int64 (was ht.int32 before)

Issue/s resolved: #2479 

## Changes proposed:
- signature following array api standard
- create empty array when `stop >= start`

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

array api

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
