### PR TITLE
fix(docs): use relative path for quick_start button-link

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -129,7 +129,7 @@ Getting started
 
       For Spack, EasyBuild, and containerized setups, refer to our comprehensive deployment guide.
 
-      .. button-link:: /quick_start.html
+      .. button-link:: quick_start.html
          :color: primary
          :class: sd-btn-primary sd-btn-block mt-3
 


### PR DESCRIPTION
## Description

The "View full installation guide" button-link on the landing page used `/quick_start.html` (root-relative), which 404s on ReadTheDocs where the site is served under `/en/latest/`. Changed to `quick_start.html` (relative) so Sphinx resolves it correctly.

## Verification

- `https://heat.readthedocs.io/quick_start.html` → 404
- `https://heat.readthedocs.io/en/latest/quick_start.html` → 200

## Changes

- `doc/source/index.rst:132`: Changed button-link from `/quick_start.html` to `quick_start.html`

## Related Issues

Resolves #2501