### PR TITLE
Fix test assertions in test_statistics

### DIFF
--- a/tests/core/test_statistics.py
+++ b/tests/core/test_statistics.py
@@ -255,7 +255,7 @@ class TestStatistics(TestCase):
         self.assertEqual(avg_volume.dtype, ht.types.canonical_heat_type(dtype))
         self.assertEqual(avg_volume.larray.dtype, dtype)
         self.assertEqual(avg_volume.split, None)
-        self.assertAlmostEqual(avg_volume.numpy().all(), np_avg_volume.all())
+        self.assertTrue(ht.allclose(avg_volume, ht.array(np_avg_volume, dtype=avg_volume.dtype)))
         avg_volume_with_cumwgt = ht.average(
             random_volume, weights=random_weights, axis=1, returned=True
         )
@@ -270,14 +270,14 @@ class TestStatistics(TestCase):
             torch.randn((3, 3, 3), dtype=dtype, device=self.device.torch_device), is_split=1
         )
         avg_volume = ht.average(random_volume, weights=random_weights_3d, axis=1)
-        np_avg_volume = np.average(random_volume.numpy(), weights=random_weights.numpy(), axis=1)
+        np_avg_volume = np.average(random_volume.numpy(), weights=random_weights_3d.numpy(), axis=1)
         self.assertIsInstance(avg_volume, ht.DNDarray)
         self.assertEqual(avg_volume.shape, (3, 3))
         self.assertEqual(avg_volume.lshape, (3, 3))
         self.assertEqual(avg_volume.dtype, ht.types.canonical_heat_type(dtype))
         self.assertEqual(avg_volume.larray.dtype, dtype)
         self.assertEqual(avg_volume.split, None)
-        self.assertAlmostEqual(avg_volume.numpy().all(), np_avg_volume.all())
+        self.assertTrue(ht.allclose(avg_volume, ht.array(np_avg_volume, dtype=avg_volume.dtype)))
         avg_volume_with_cumwgt = ht.average(
             random_volume, weights=random_weights, axis=1, returned=True
         )
@@ -1224,8 +1224,8 @@ class TestStatistics(TestCase):
         p_ht = ht.percentile(x_ht, q, axis=axis, interpolation="lower", keepdims=True)
         out = ht.empty(p_np.shape, dtype=out_dtype, split=None, device=x_ht.device)
         ht.percentile(x_ht, q, axis=axis, out=out, interpolation="lower", keepdims=True)
-        self.assertEqual(p_ht.numpy()[5].all(), p_np[5].all())
-        self.assertEqual(out.numpy()[2].all(), p_np[2].all())
+        self.assertTrue(ht.allclose(p_ht, ht.array(p_np, dtype=p_ht.dtype)))
+        self.assertTrue(ht.allclose(out, ht.array(p_np, dtype=out.dtype)))
         self.assertTrue(p_ht.shape == p_np.shape)
         axis = None
         try:
@@ -1256,7 +1256,7 @@ class TestStatistics(TestCase):
         x_sc = ht.array(4.5)
         p_ht = ht.percentile(x_sc, q=q)
         p_np = np.percentile(4.5, q=q)
-        self.assertEqual(p_ht.numpy().all(), p_np.all())
+        self.assertTrue(ht.allclose(p_ht, ht.array(p_np, dtype=p_ht.dtype)))
 
         # test tuple axis and out buffer
         q = (20, 50, 80)


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

Issue/s resolved: #

## Changes proposed:

-
-
-
-

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
