### PR TITLE
[BUG] Missing `packaging` dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dependencies = [
     "torch~=2.4,<2.13.1",
     "torchvision~=0.19",
     "scipy~=1.14",
+    "packging>=26.3"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "torch~=2.4,<2.13.1",
     "torchvision~=0.19",
     "scipy~=1.14",
-    "packging>=26.3"
+    "packaging>=25.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [ ]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

The `packaging` package got added for some version checks, but it was never explicitly added to the dependencies. Most of the CI passed because it is a `zarr` dependency. 

Issue/s resolved: #2493 

## Changes proposed:

- Adding `packaging` to the dependency list. 
-
-
-

## Type of change
- Bug fix (non-breaking change which fixes an issue)
