### PR TITLE
Raise error if GPU is selected for test via environment variable but no GPU is found

### DIFF
--- a/heat/testing/basic_test.py
+++ b/heat/testing/basic_test.py
@@ -67,7 +67,7 @@ class TestCase(unittest.TestCase):
                 is_mps = True
             else:
                 raise RuntimeError(
-                    f'Device {envar} from environment variable "HEAT_TEST_USE_DEVICE" not found! Neither CUDA, nor MPS is available'
+                    f'Device {envar} from environment variable "HEAT_TEST_USE_DEVICE" not found! Neither CUDA, ROCm, nor MPS is available'
                 )
         else:
             raise RuntimeError(

--- a/heat/testing/basic_test.py
+++ b/heat/testing/basic_test.py
@@ -47,12 +47,13 @@ class TestCase(unittest.TestCase):
         if envar == "cpu":
             ht.use_device("cpu")
             ht_device = ht.cpu
-            other_device = ht.cpu
             if torch.cuda.is_available():
                 torch.cuda.set_device(torch.device(ht.gpu.torch_device))
                 other_device = ht.gpu
             elif torch.backends.mps.is_built() and torch.backends.mps.is_available():
                 other_device = ht.gpu
+            else:
+                other_device = ht.cpu
         elif envar == "gpu":
             if torch.cuda.is_available():
                 ht.use_device("gpu")
@@ -64,6 +65,10 @@ class TestCase(unittest.TestCase):
                 ht_device = ht.gpu
                 other_device = ht.cpu
                 is_mps = True
+            else:
+                raise RuntimeError(
+                    f'Device {envar} from environment variable "HEAT_TEST_USE_DEVICE" not found! Neither CUDA, nor MPS is available'
+                )
         else:
             raise RuntimeError(
                 f"Value '{envar}' of environment variable 'HEAT_TEST_USE_DEVICE' is unsupported"


### PR DESCRIPTION
In [this CI run on codebase](https://codebase.helmholtz.cloud/helmholtz-analytics/Cx/-/jobs/3390027), the AMD tests are failing because local variable `ht_device` is not found in [this line](https://github.com/helmholtz-analytics/heat/blob/9dfe62185474b2878d188d3beb6c2277dc535c1a/heat/testing/basic_test.py#L72) in the setup of the basic test class.
I think the problem is probably that the AMD runners no longer have GPUs. This PR doesn't fix that problem, but it raises an error if GPU is selected for the tests via `HEAT_TEST_USE_DEVICE=GPU pytest ...` but no GPU is found.