### PR TITLE
add alias bitwise_inverse

### DIFF
--- a/.github/actions/trigger_codebase_tests/action.yml
+++ b/.github/actions/trigger_codebase_tests/action.yml
@@ -33,4 +33,5 @@ runs:
           -F "variables[BRANCH]=$BRANCH" \
           -F "variables[PR]=$PR_NUMBER" \
           -F "variables[SHA]=${{ inputs.sha }}" \
+          -F "variables[TORCH_PACKAGES]='torch==1.13.0 torchvision==0.28.0'" \
           https://codebase.helmholtz.cloud/api/v4/projects/20697/trigger/pipeline

--- a/.github/actions/trigger_codebase_tests/action.yml
+++ b/.github/actions/trigger_codebase_tests/action.yml
@@ -33,5 +33,5 @@ runs:
           -F "variables[BRANCH]=$BRANCH" \
           -F "variables[PR]=$PR_NUMBER" \
           -F "variables[SHA]=${{ inputs.sha }}" \
-          -F "variables[TORCH_PACKAGES]=torch==1.13.0 torchvision==0.28.0" \
+          -F "variables[TORCH_PACKAGES]=torch==2.13.0 torchvision==0.28.0" \
           https://codebase.helmholtz.cloud/api/v4/projects/20697/trigger/pipeline

--- a/.github/actions/trigger_codebase_tests/action.yml
+++ b/.github/actions/trigger_codebase_tests/action.yml
@@ -33,5 +33,5 @@ runs:
           -F "variables[BRANCH]=$BRANCH" \
           -F "variables[PR]=$PR_NUMBER" \
           -F "variables[SHA]=${{ inputs.sha }}" \
-          -F "variables[TORCH_PACKAGES]='torch==1.13.0 torchvision==0.28.0'" \
+          -F "variables[TORCH_PACKAGES]=torch==1.13.0 torchvision==0.28.0" \
           https://codebase.helmholtz.cloud/api/v4/projects/20697/trigger/pipeline

--- a/heat/core/arithmetics.py
+++ b/heat/core/arithmetics.py
@@ -32,6 +32,7 @@ __all__ = [
     "add",
     "bitwise_and",
     "bitwise_not",
+    "bitwise_invert",
     "bitwise_or",
     "bitwise_xor",
     "copysign",
@@ -1791,7 +1792,7 @@ DNDarray.__invert__ = lambda self: invert(self)
 DNDarray.__invert__.__doc__ = invert.__doc__
 
 # alias for invert
-bitwise_not = invert
+bitwise_not = bitwise_invert = invert
 """Alias for :py:func:`invert`"""
 
 


### PR DESCRIPTION
## Due Diligence
<!--- Please address the following points before setting your PR "ready for review".
--->
- General:
    - [x]  **title** of the PR is suitable to appear in the [Release Notes](https://github.com/helmholtz-analytics/heat/releases/latest)
- Implementation:
    - [ ] unit tests: all split configurations tested
    - [ ] unit tests: multiple dtypes tested
    - [ ] **NEW** unit tests: MPS tested (1 MPI process, 1 GPU)
    - [ ] benchmarks: created for new functionality
    - [ ] benchmarks: performance improved or maintained
    - [ ] documentation updated where needed

## Description

<!--- Include a summary of the change/s.
Please also include relevant motivation and context. List any dependencies that are required for this change.
--->

This PR adds `bitwise_inverse` as another alias for Array API. It also introduces a previously unused variable for the CI that allows to set the pytorch version.

Issue/s resolved: #2511 

## Changes proposed:

- add bitwise_inverse

## Type of change
<!--
i.e.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
--->

## Memory requirements
<!--- Compare memory requirements to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

This can be done using https://github.com/pythonprofilers/memory_profiler for CPU memory measurements,
GPU measurements can be done with https://pytorch.org/docs/master/generated/torch.cuda.max_memory_allocated.html.
These tools only profile the memory used by each process, not the entire function.
--->

## Performance
<!--- Compare performance to previous implementation / relevant torch operations if applicable:
- in distributed and non-distributed mode
- with `split=None` and `split not None`

Python has an embedded profiler: https://docs.python.org/3.9/library/profile.html
Again, this will only profile the performance on each process. Printing the results with many processes
may be illegible. It may be easiest to save the output of each to a file.
--->

#### Does this change modify the behaviour of other functions? If so, which?
yes / no
