### PR TITLE
Fix REUSE linter in pr_update

### DIFF
--- a/.github/workflows/pr_update.yml
+++ b/.github/workflows/pr_update.yml
@@ -108,6 +108,10 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
The REUSE linter, as added in #2522 was actually checking out the base of the PR rather than the head. So it was useless.. This PR changes that.